### PR TITLE
Fix Docker setup instructions and GitHub URLs

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -57,7 +57,7 @@ Lightweight deployment for:
 **Quick Start**:
 ```bash
 # Clone repository
-git clone https://github.com/your-org/gigachad-grc.git
+git clone https://github.com/grcengineering/gigachad-grc.git
 cd gigachad-grc
 
 # Configure environment
@@ -271,7 +271,7 @@ Run smoke tests and monitor logs for errors.
 
 ### Support Channels
 - **Email**: support@example.com
-- **GitHub Issues**: github.com/your-org/gigachad-grc/issues
+- **GitHub Issues**: github.com/grcengineering/gigachad-grc/issues
 - **Community Slack**: gigachad-grc.slack.com
 
 ### Professional Services

--- a/README.md
+++ b/README.md
@@ -833,7 +833,7 @@ Infrastructure Layer:
 ### The Easy Way (Recommended)
 
 ```bash
-git clone https://github.com/your-org/gigachad-grc.git
+git clone https://github.com/grcengineering/gigachad-grc.git
 cd gigachad-grc
 ./init.sh demo
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You only need **one thing**: [**Docker Desktop**](https://www.docker.com/product
 |----------|----------------|
 | **macOS** | [Download for Mac](https://www.docker.com/products/docker-desktop/) (Apple Silicon or Intel) |
 | **Windows** | [Download for Windows](https://www.docker.com/products/docker-desktop/) (requires WSL 2) |
-| **Linux** | `curl -fsSL https://get.docker.com | sh` |
+| **Linux** | `curl -fsSL https://get.docker.com \| sh` |
 
 > **No Node.js, npm, or other development tools required!**
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -60,7 +60,7 @@ ENCRYPTION_KEY=your-32-byte-hex-key
 
 1. Clone and configure:
 ```bash
-git clone https://github.com/your-org/gigachad-grc.git
+git clone https://github.com/grcengineering/gigachad-grc.git
 cd gigachad-grc
 cp env.example .env
 ```

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -61,7 +61,7 @@
 
 ```bash
 # Clone repository
-git clone https://github.com/your-org/gigachad-grc.git
+git clone https://github.com/grcengineering/gigachad-grc.git
 cd gigachad-grc
 
 # Copy environment file

--- a/docs/PRODUCTION_DEPLOYMENT.md
+++ b/docs/PRODUCTION_DEPLOYMENT.md
@@ -795,7 +795,7 @@ For issues or questions:
 
 1. Check the [troubleshooting section](#troubleshooting)
 2. Review logs: `docker compose logs -f`
-3. Check [GitHub Issues](https://github.com/your-org/gigachad-grc/issues)
+3. Check [GitHub Issues](https://github.com/grcengineering/gigachad-grc/issues)
 4. Contact: support@yourcompany.com
 
 ---

--- a/frontend/src/pages/DeveloperDocs.tsx
+++ b/frontend/src/pages/DeveloperDocs.tsx
@@ -526,7 +526,7 @@ function DeploymentDocs() {
         <h3 className="text-xl font-bold text-surface-100 mb-4">Quick Start with Docker Compose</h3>
         <CodeBlock 
           code={`# Clone the repository
-git clone https://github.com/your-org/gigachad-grc.git
+git clone https://github.com/grcengineering/gigachad-grc.git
 cd gigachad-grc
 
 # Copy environment template
@@ -640,7 +640,7 @@ function DevelopmentDocs() {
         <h3 className="text-xl font-bold text-surface-100 mb-4">Quick Start</h3>
         <CodeBlock 
           code={`# Clone the repository
-git clone https://github.com/your-org/gigachad-grc.git
+git clone https://github.com/grcengineering/gigachad-grc.git
 cd gigachad-grc
 
 # Install dependencies

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -324,7 +324,7 @@ terraform destroy
 
 For issues or questions:
 - **Documentation**: docs/
-- **GitHub Issues**: https://github.com/your-org/gigachad-grc/issues
+- **GitHub Issues**: https://github.com/grcengineering/gigachad-grc/issues
 - **Email**: support@your-domain.com
 
 ## License


### PR DESCRIPTION
This PR fixes to a couple of small problems I had/noticed while trying to spin up GigaChad GRC:

1. In the main `README.md`, the command for installing Docker on Linux wasn't rendered correctly because it includes a pipe (`|`), and was placed within a Markdown table, which itself is constructed using pipes. I've added an escape for the pipe that should be rendered.
2. In the main `README.md` and in several other places across the repo, the URL for the repo was given as `https://github.com/YOUR-ORG/gigachad-grc`, which will not clone or link correctly. All these instances have been found and corrected.