### PR TITLE
fix: Bundle recharts with d3 dependencies to prevent initialization errors

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -61,6 +61,29 @@ export default defineConfig(({ mode }) => {
               return 'vendor-http';
             }
             
+            // Recharts and ALL its dependencies must stay together to avoid
+            // "Cannot access 'N' before initialization" errors caused by
+            // circular dependencies between recharts, d3-*, and react-smooth.
+            // This includes all d3 modules that recharts depends on.
+            if (
+              id.includes('recharts') ||
+              id.includes('d3-interpolate') ||
+              id.includes('d3-color') ||
+              id.includes('d3-path') ||
+              id.includes('d3-shape') ||
+              id.includes('d3-scale') ||
+              id.includes('d3-array') ||
+              id.includes('d3-format') ||
+              id.includes('d3-time') ||
+              id.includes('d3-time-format') ||
+              id.includes('react-smooth') ||
+              id.includes('react-is') ||
+              id.includes('victory-vendor') ||
+              id.includes('internmap')
+            ) {
+              return 'vendor-charts';
+            }
+            
             // Everything else stays in the main vendor bundle to avoid
             // circular dependency issues that cause "Cannot access 'X' before initialization"
             return 'vendor';


### PR DESCRIPTION
## Summary

Fixes the "Cannot access 'N' before initialization" error that causes localhost:3000 to spin indefinitely and never load.

**Closes #10**

## Root Cause

The error occurred because Vite's code-splitting was separating recharts from its d3-* dependencies into different chunks. When these chunks loaded, the circular dependencies between:
- `recharts`
- `d3-interpolate`
- `d3-color`
- `d3-shape`
- `react-smooth`
- `react-is`

...caused incorrect module initialization order, resulting in the ReferenceError.

## Solution

Explicitly group recharts and ALL its d3 dependencies into a single `vendor-charts` chunk in `vite.config.ts`. This ensures they initialize together in the correct order.

### Before
- Recharts was in the main `vendor` chunk
- D3 dependencies were split into separate async chunks
- Dynamic `import('recharts')` created inconsistent chunk boundaries

### After
- Recharts + all d3-* + react-smooth + react-is bundled in `vendor-charts` (445KB)
- Consistent initialization order guaranteed
- Dynamic imports still work, but load the complete chart bundle

## Testing

- [x] `npm run build` completes successfully
- [x] No TypeScript errors
- [x] Chart components render correctly in development
- [ ] Verify fix resolves issue for @DevSecOpsX-Tek and @xcolt45

## Files Changed

- `frontend/vite.config.ts` - Updated `manualChunks` to group chart dependencies