### PR TITLE
fix: correct Docker instructions and GitHub URLs

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -71,7 +71,7 @@ Open Terminal and run:
 
 ```bash
 # Download the project
-git clone https://github.com/YOUR_ORG/gigachad-grc.git
+git clone https://github.com/grcengineering/gigachad-grc.git
 
 # Go into the folder
 cd gigachad-grc
@@ -86,7 +86,7 @@ Open Command Prompt or PowerShell and run:
 
 ```cmd
 # Download the project
-git clone https://github.com/YOUR_ORG/gigachad-grc.git
+git clone https://github.com/grcengineering/gigachad-grc.git
 
 # Go into the folder
 cd gigachad-grc
@@ -300,8 +300,8 @@ docker rmi $(docker images 'gigachad-grc-*' -q) 2>/dev/null
 
 ### Community Support
 
-- [GitHub Issues](https://github.com/YOUR_ORG/gigachad-grc/issues) - Report bugs
-- [Discussions](https://github.com/YOUR_ORG/gigachad-grc/discussions) - Ask questions
+- [GitHub Issues](https://github.com/grcengineering/gigachad-grc/issues) - Report bugs
+- [Discussions](https://github.com/grcengineering/gigachad-grc/discussions) - Ask questions
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Node.js 20+](https://img.shields.io/badge/Node.js-20%2B-green.svg)](https://nodejs.org/)
 [![Docker](https://img.shields.io/badge/Docker-Ready-blue.svg)](https://www.docker.com/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-[![Open in Gitpod](https://img.shields.io/badge/Gitpod-Try%20Demo-orange.svg)](https://gitpod.io/#https://github.com/YOUR_ORG/gigachad-grc)
+[![Open in Gitpod](https://img.shields.io/badge/Gitpod-Try%20Demo-orange.svg)](https://gitpod.io/#https://github.com/grcengineering/gigachad-grc)
 
 A comprehensive, modular, containerized Governance, Risk, and Compliance (GRC) platform built with modern technologies. Manage your entire security program from compliance tracking to risk management, third-party assessments, and external audits.
 
@@ -23,14 +23,14 @@ You only need **one thing**: [**Docker Desktop**](https://www.docker.com/product
 |----------|----------------|
 | **macOS** | [Download for Mac](https://www.docker.com/products/docker-desktop/) (Apple Silicon or Intel) |
 | **Windows** | [Download for Windows](https://www.docker.com/products/docker-desktop/) (requires WSL 2) |
-| **Linux** | `curl -fsSL https://get.docker.com | sh` |
+| **Linux** | `curl -fsSL https://get.docker.com \| sh` |
 
 > **No Node.js, npm, or other development tools required!**
 
 ### Start in 3 Commands
 
 ```bash
-git clone https://github.com/YOUR_ORG/gigachad-grc.git
+git clone https://github.com/grcengineering/gigachad-grc.git
 cd gigachad-grc
 ./start.sh
 ```
@@ -71,7 +71,7 @@ make help         # See all Makefile commands
 
 **Try in your browser** (no installation):
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/YOUR_ORG/gigachad-grc)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/grcengineering/gigachad-grc)
 
 ➡️ See the **[Demo & Sandbox Guide](docs/DEMO.md)** for detailed walkthrough with sample data.
 

--- a/RELEASE_NOTES_v1.0.0.md
+++ b/RELEASE_NOTES_v1.0.0.md
@@ -84,7 +84,7 @@ See `docs/SECURITY_DEEP_DIVE_AUDIT.md` for the full security audit report.
 
 ```bash
 # Clone the repository
-git clone https://github.com/YOUR_ORG/gigachad-grc.git
+git clone https://github.com/grcengineering/gigachad-grc.git
 cd gigachad-grc
 
 # Start the demo
@@ -171,8 +171,8 @@ Thank you to everyone who contributed to this release!
 
 ## 📣 Feedback
 
-- **Issues:** [GitHub Issues](https://github.com/YOUR_ORG/gigachad-grc/issues)
-- **Discussions:** [GitHub Discussions](https://github.com/YOUR_ORG/gigachad-grc/discussions)
+- **Issues:** [GitHub Issues](https://github.com/grcengineering/gigachad-grc/issues)
+- **Discussions:** [GitHub Discussions](https://github.com/grcengineering/gigachad-grc/discussions)
 - **Security:** See [SECURITY.md](docs/SECURITY_MODEL.md) for reporting vulnerabilities
 
 ---

--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -84,7 +84,7 @@ The fastest way to see GigaChad GRC in action on your local machine.
 ### Step 1: Clone the Repository
 
 ```bash
-git clone https://github.com/YOUR_ORG/gigachad-grc.git
+git clone https://github.com/grcengineering/gigachad-grc.git
 cd gigachad-grc
 ```
 
@@ -156,7 +156,7 @@ Try GigaChad GRC instantly in your browser—no installation required.
 
 Click this button or the badge in the README:
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/YOUR_ORG/gigachad-grc)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/grcengineering/gigachad-grc)
 
 ### Step 2: Wait for Environment
 
@@ -232,7 +232,7 @@ For users who want more control over the setup process.
 
 ```bash
 # Clone repository
-git clone https://github.com/YOUR_ORG/gigachad-grc.git
+git clone https://github.com/grcengineering/gigachad-grc.git
 cd gigachad-grc
 
 # Install root dependencies

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -7,7 +7,7 @@ Get up and running with GigaChad GRC in **one command**.
 ## 🚀 Just Want to Try It?
 
 ```bash
-git clone https://github.com/YOUR_ORG/gigachad-grc.git
+git clone https://github.com/grcengineering/gigachad-grc.git
 cd gigachad-grc
 ./init.sh demo
 ```
@@ -16,7 +16,7 @@ That's it! The script handles everything: environment setup, Docker containers, 
 
 **Or try it in your browser** (no install required):
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/YOUR_ORG/gigachad-grc)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/grcengineering/gigachad-grc)
 
 ---
 

--- a/docs/help/getting-started/demo-data.md
+++ b/docs/help/getting-started/demo-data.md
@@ -297,7 +297,7 @@ If you've forked GigaChad GRC, follow these steps for a clean demo data experien
 
 ```bash
 # 1. Clone the repository
-git clone https://github.com/YOUR_ORG/gigachad-grc.git
+git clone https://github.com/grcengineering/gigachad-grc.git
 cd gigachad-grc
 
 # 2. Start infrastructure first


### PR DESCRIPTION
## Summary

- Escape pipe character (`|` → `\|`) in README.md Docker install command to fix markdown table rendering
- Replace all `YOUR_ORG` placeholder URLs with `grcengineering` across documentation

## Files Changed (6)

| File | Changes |
|------|---------|
| `README.md` | Pipe escape + 3 URL fixes |
| `GETTING_STARTED.md` | 4 URL fixes |
| `RELEASE_NOTES_v1.0.0.md` | 3 URL fixes |
| `docs/DEMO.md` | 3 URL fixes |
| `docs/QUICK_START.md` | 2 URL fixes |
| `docs/help/getting-started/demo-data.md` | 1 URL fix |

Closes #6

## Test Plan

- [x] Verify README.md table renders correctly with escaped pipe
- [x] Verify all git clone URLs point to valid repository