### PR TITLE
fix: Add WSL troubleshooting and reset command for database auth issues

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -32,6 +32,7 @@ if "%1"=="start" goto start
 if "%1"=="stop" goto stop
 if "%1"=="logs" goto logs
 if "%1"=="status" goto status
+if "%1"=="reset" goto reset
 goto usage
 
 :banner
@@ -203,12 +204,40 @@ docker compose ps
 echo.
 goto :eof
 
+:reset
+call :banner
+echo %RED%WARNING: This will delete ALL data including:%NC%
+echo    - Database (all users, controls, frameworks, etc.)
+echo    - Redis cache
+echo    - Uploaded files
+echo    - Configuration in .env
+echo.
+set /p CONFIRM="Are you sure you want to reset everything? (y/N) "
+if /i "%CONFIRM%"=="y" (
+    echo %YELLOW%Stopping all services and removing volumes...%NC%
+    docker compose down -v
+    
+    if exist ".env" (
+        echo %YELLOW%Removing .env file...%NC%
+        del /f .env
+    )
+    
+    echo %GREEN%Reset complete%NC%
+    echo.
+    echo Run start.bat to start fresh with new credentials.
+    echo.
+) else (
+    echo %YELLOW%Reset cancelled%NC%
+)
+goto :eof
+
 :usage
-echo Usage: start.bat [start^|stop^|logs^|status]
+echo Usage: start.bat [start^|stop^|logs^|status^|reset]
 echo.
 echo Commands:
 echo   start   Start all services (default)
 echo   stop    Stop all services
 echo   logs    View service logs
 echo   status  Check service status
+echo   reset   Delete all data and start fresh (fixes auth issues)
 exit /b 1

--- a/start.sh
+++ b/start.sh
@@ -198,6 +198,34 @@ show_status() {
     echo ""
 }
 
+reset_all() {
+    print_banner
+    echo -e "${RED}⚠️  WARNING: This will delete ALL data including:${NC}"
+    echo "   - Database (all users, controls, frameworks, etc.)"
+    echo "   - Redis cache"
+    echo "   - Uploaded files"
+    echo "   - Configuration in .env"
+    echo ""
+    read -p "Are you sure you want to reset everything? (y/N) " -n 1 -r
+    echo ""
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        echo -e "${YELLOW}Stopping all services and removing volumes...${NC}"
+        docker compose down -v
+        
+        if [ -f ".env" ]; then
+            echo -e "${YELLOW}Removing .env file...${NC}"
+            rm -f .env
+        fi
+        
+        echo -e "${GREEN}✓ Reset complete${NC}"
+        echo ""
+        echo "Run ./start.sh to start fresh with new credentials."
+        echo ""
+    else
+        echo -e "${YELLOW}Reset cancelled${NC}"
+    fi
+}
+
 # Main
 case "${1:-start}" in
     start)
@@ -212,14 +240,18 @@ case "${1:-start}" in
     status)
         show_status
         ;;
+    reset)
+        reset_all
+        ;;
     *)
-        echo "Usage: ./start.sh [start|stop|logs|status]"
+        echo "Usage: ./start.sh [start|stop|logs|status|reset]"
         echo ""
         echo "Commands:"
         echo "  start   Start all services (default)"
         echo "  stop    Stop all services"
         echo "  logs    View service logs"
         echo "  status  Check service status"
+        echo "  reset   Delete all data and start fresh (fixes auth issues)"
         exit 1
         ;;
 esac


### PR DESCRIPTION
## Summary
- Add WSL-specific troubleshooting section to `GETTING_STARTED.md` explaining PostgreSQL authentication failures and how to fix them
- Add `reset` command to `start.sh` and `start.bat` that removes all Docker volumes and the `.env` file for a completely fresh start
- Update command reference documentation to include the new reset option

## Problem
Users on WSL (and other platforms) encounter container crashes with errors like:
- `FATAL: password authentication failed for user "grc"` or `"GRC"`
- `failed to start server in dev mode`
- Keycloak or other services can't connect to PostgreSQL

This happens when the PostgreSQL data volume was initialized with different credentials than what's in the current `.env` file (e.g., when `.env` was deleted and regenerated with new random passwords).

## Solution
1. **Documentation**: Added clear troubleshooting steps explaining the root cause and fix
2. **Tooling**: Added a `reset` command that automates the fix:
   ```bash
   ./start.sh reset   # Linux/macOS/WSL
   start.bat reset    # Windows
   ```

## Test plan
- [ ] Verify `./start.sh reset` prompts for confirmation and removes volumes + .env
- [ ] Verify `start.bat reset` works on Windows
- [ ] Verify documentation renders correctly in GETTING_STARTED.md
- [ ] Test the full reset → start flow creates working containers