### PR TITLE
fix: Add null check for courseStats in SecurityTrainingDashboard

### DIFF
--- a/frontend/src/pages/SecurityTrainingDashboard.tsx
+++ b/frontend/src/pages/SecurityTrainingDashboard.tsx
@@ -282,7 +282,7 @@ export default function SecurityTrainingDashboard() {
           <h2 className="text-lg font-semibold text-foreground mb-4">Course Completion Rates</h2>
           {isLoading ? (
             <SkeletonTable rows={4} />
-          ) : stats.courseStats.length === 0 ? (
+          ) : !stats.courseStats?.length ? (
             <div className="text-center py-8 text-surface-400">
               <AcademicCapIcon className="w-10 h-10 mx-auto mb-2 opacity-50" />
               <p>No course data available</p>
@@ -290,7 +290,7 @@ export default function SecurityTrainingDashboard() {
             </div>
           ) : (
             <div className="space-y-4">
-              {stats.courseStats.slice(0, 5).map((course) => (
+              {(stats.courseStats || []).slice(0, 5).map((course) => (
                 <div key={course.courseId}>
                   <div className="flex items-center justify-between mb-1">
                     <span className="text-surface-300 text-sm">{course.courseName}</span>


### PR DESCRIPTION
## Summary
Fixes #34 - Visiting People > Security Training leads to undefined error on frontend

## Problem
The Security Training Dashboard page crashed with:
```
can't access property "length", t.courseStats is undefined
```

This occurred when the training API returned data in an unexpected format where `courseStats` was undefined.

## Solution
Added optional chaining (`?.`) to safely handle cases where `courseStats` is undefined:

```tsx
// Before (crashed when courseStats was undefined)
stats.courseStats.length === 0

// After (safely handles undefined)
!stats.courseStats?.length
```

Also added a fallback empty array when mapping over courseStats.

## Test plan
- [x] Verify Security Training page loads without error after dev login
- [x] Verify page displays "No course data available" when courseStats is empty/undefined
- [x] No linter errors