### PR TITLE
fix: Add reports permissions to dev auth guard

### DIFF
--- a/services/controls/src/auth/dev-auth.guard.ts
+++ b/services/controls/src/auth/dev-auth.guard.ts
@@ -83,6 +83,8 @@ export class DevAuthGuard implements CanActivate {
         'bcdr:delete',
         'permissions:read',
         'permissions:write',
+        'reports:read',
+        'reports:export',
       ],
       // Optional display name for audit/logging
       name: 'John Doe',


### PR DESCRIPTION
## Summary
Fixes #33 - Admin user cannot download exports in demo mode (after dev login)

## Problem
When using dev login and trying to download reports from the dashboard, users received:
```
ForbiddenException: No permission found for reports:export
```

The dev auth guard mock user was missing the `reports:read` and `reports:export` permissions.

## Solution
Added the missing permissions to the dev auth guard:
```typescript
'reports:read',
'reports:export',
```

## Test plan
- [x] Verify report download works after dev login
- [x] Controls service rebuilds successfully
- [x] No linter errors