### PR TITLE
fix: Correct API method mismatches and nginx routing for audit modules

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -258,8 +258,93 @@ server {
         proxy_read_timeout 60s;
     }
 
-    location /api/audit/ {
-        proxy_pass http://audit_service/api/audit/;
+    # Audit sub-modules - strip /api/audit prefix for backend routes
+    location /api/audit/templates {
+        proxy_pass http://audit_service/templates;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+
+    location /api/audit/workpapers {
+        proxy_pass http://audit_service/workpapers;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+
+    location /api/audit/test-procedures {
+        proxy_pass http://audit_service/test-procedures;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+
+    location /api/audit/remediation {
+        proxy_pass http://audit_service/remediation;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+
+    location /api/audit/planning {
+        proxy_pass http://audit_service/planning;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+
+    location /api/audit/reports {
+        proxy_pass http://audit_service/reports;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+
+    location /api/audit/analytics {
+        proxy_pass http://audit_service/analytics;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+
+    location /api/audit/audit-ai {
+        proxy_pass http://audit_service/audit-ai;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -872,7 +872,7 @@ export const auditsApi = {
   create: (data: CreateAuditData): Promise<AxiosResponse<Audit>> => 
     api.post('/api/audits', data),
   update: (id: string, data: UpdateAuditData): Promise<AxiosResponse<Audit>> => 
-    api.put(`/api/audits/${id}`, data),
+    api.patch(`/api/audits/${id}`, data),
   delete: (id: string): Promise<AxiosResponse<void>> => 
     api.delete(`/api/audits/${id}`),
 };
@@ -884,7 +884,7 @@ export const auditRequestsApi = {
   create: (data: { auditId: string; title: string; description?: string; assigneeId?: string; dueDate?: string }) => 
     api.post('/api/audit-requests', data),
   update: (id: string, data: { title?: string; description?: string; status?: string; assigneeId?: string; dueDate?: string }) => 
-    api.put(`/api/audit-requests/${id}`, data),
+    api.patch(`/api/audit-requests/${id}`, data),
   delete: (id: string) => api.delete(`/api/audit-requests/${id}`),
 };
 
@@ -1028,7 +1028,7 @@ export const vendorsApi = {
   create: (data: CreateVendorData): Promise<AxiosResponse<Vendor>> => 
     api.post('/api/vendors', data),
   update: (id: string, data: UpdateVendorData): Promise<AxiosResponse<Vendor>> => 
-    api.put(`/api/vendors/${id}`, data),
+    api.patch(`/api/vendors/${id}`, data),
   delete: (id: string): Promise<AxiosResponse<void>> => 
     api.delete(`/api/vendors/${id}`),
   // Review scheduling endpoints
@@ -1257,7 +1257,7 @@ export const contractsApi = {
   create: (data: CreateContractData): Promise<AxiosResponse<Contract>> => 
     api.post('/api/contracts', data),
   update: (id: string, data: UpdateContractData): Promise<AxiosResponse<Contract>> => 
-    api.put(`/api/contracts/${id}`, data),
+    api.patch(`/api/contracts/${id}`, data),
   delete: (id: string): Promise<AxiosResponse<void>> => 
     api.delete(`/api/contracts/${id}`),
 };


### PR DESCRIPTION
## Summary

- Fix HTTP method mismatches where frontend used PUT but backend expects PATCH for vendors, contracts, audits, and audit-requests endpoints
- Add nginx location blocks for audit sub-modules that were returning 404 errors

## Changes

### API Method Fixes (frontend/src/lib/api.ts)

| Endpoint | Before | After |
|----------|--------|-------|
| `/api/vendors/:id` | PUT | PATCH |
| `/api/contracts/:id` | PUT | PATCH |
| `/api/audits/:id` | PUT | PATCH |
| `/api/audit-requests/:id` | PUT | PATCH |

### Nginx Routing Fixes (frontend/nginx.conf)

Added location blocks to properly route audit sub-modules by stripping the `/api/audit` prefix:

- `/api/audit/templates` → `/templates`
- `/api/audit/workpapers` → `/workpapers`
- `/api/audit/test-procedures` → `/test-procedures`
- `/api/audit/remediation` → `/remediation`
- `/api/audit/planning` → `/planning`
- `/api/audit/reports` → `/reports`
- `/api/audit/analytics` → `/analytics`
- `/api/audit/audit-ai` → `/audit-ai`

## Test plan

- [ ] Verify vendor updates save correctly
- [ ] Verify contract updates save correctly
- [ ] Verify audit updates save correctly
- [ ] Verify audit request updates save correctly
- [ ] Verify audit templates page loads data
- [ ] Verify audit workpapers page loads data
- [ ] Verify audit test procedures page loads data
- [ ] Verify audit remediation page loads data
- [ ] Verify audit planning page loads data