### PR TITLE
fix(frontend): add missing nginx route for framework catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Fixed Framework Library returning 404 in Docker deployment - added missing `/api/frameworks/catalog` nginx route to proxy to controls service (port 3001) instead of frameworks service (port 3002)
 - Fixed TypeScript compilation errors in retention service (incorrect field names for Prisma schema)
 - Fixed AWS connector dynamic imports to use runtime `require()` for optional SDK packages
 - Fixed Azure evidence collector dynamic imports

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -356,9 +356,10 @@ server {
     }
 
     # -----------------------------------------
-    # Audit Logs (Controls Service) - System Audit Trail
-    # Frontend calls /api/audit-logs OR /api/audit, backend is at /api/audit
+    # Controls Service (3001) - WITH /api prefix
     # -----------------------------------------
+
+    # Audit Logs - System Audit Trail - Frontend calls /api/audit-logs OR /api/audit, backend is at /api/audit
     location /api/audit-logs {
         proxy_pass http://controls_service/api/audit;
         proxy_http_version 1.1;
@@ -384,11 +385,22 @@ server {
         proxy_read_timeout 60s;
     }
 
-    # -----------------------------------------
-    # Controls Service (3001) - Default for /api/*
+    # Framework Catalog - Built-in Frameworks - Handled by controls service rather than frameworks service
+    location /api/frameworks/catalog {
+        proxy_pass http://controls_service/api/frameworks/catalog;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+
+    # Default for /api/*
     # This handles: /api/controls, /api/evidence, /api/users,
     # /api/notifications, /api/bcdr, /api/assets, etc.
-    # -----------------------------------------
     location /api/ {
         proxy_pass http://controls_service/api/;
         proxy_http_version 1.1;


### PR DESCRIPTION
### Description
Fixes #48

This PR resolves the 404 error in the Framework Library by adding a specific route for `/api/frameworks/catalog` in `nginx.conf`.

**Changes:**
- Added `location /api/frameworks/catalog` block to `nginx.conf`.
- Configured it to proxy to `controls_service` (port 3001) instead of allowing it to fall through to the `frameworks_service`.
- Moved the routing rule to the "Controls Service" section and updated the comments in that section for consistency with the other sections.

### Verification
**Manual Verification:**
1. Rebuilt frontend container.
2. Verified API response via curl (returns 200 OK).
3. Verified UI displays all 14 frameworks.

**Automated Tests:**
- **Unit Tests:** Ran `npm test` in frontend directory.
  - Result: `All 224 tests passed`.

**Note on Linting:**
- Ran `npm run lint` which resulted in pre-existing issues but no new issues introduced with this change.

### Checklist
- [x] Code follows project coding standards
- [x] CHANGELOG.md updated
- [x] Tested locally in Docker environment
- [x] Frontend Unit Tests passed
