### PR TITLE
fix(controls): Add missing exceljs and pdfkit dependencies

### DIFF
--- a/services/controls/package.json
+++ b/services/controls/package.json
@@ -37,8 +37,10 @@
     "class-validator": "^0.14.0",
     "compression": "^1.7.4",
     "date-fns": "^4.1.0",
+    "exceljs": "^4.4.0",
     "helmet": "^7.1.0",
     "nodemailer": "^7.0.11",
+    "pdfkit": "^0.16.0",
     "prom-client": "^15.1.3",
     "reflect-metadata": "^0.1.14",
     "rxjs": "^7.8.1"
@@ -52,6 +54,7 @@
     "@types/jest": "^29.5.11",
     "@types/multer": "^2.0.0",
     "@types/node": "^20.10.0",
+    "@types/pdfkit": "^0.13.9",
     "@typescript-eslint/eslint-plugin": "^6.14.0",
     "@typescript-eslint/parser": "^8.50.0",
     "eslint": "^8.56.0",


### PR DESCRIPTION
## Description

Adds missing `exceljs` and `pdfkit` dependencies to the controls service.

The exports service imports these packages for Excel and PDF generation, but they were never added to `package.json`. This causes Docker builds to fail because TypeScript cannot resolve the modules. The issue was introduced in PR #55 (commit `2ab32ab`).

Fixes #62

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Chore / Maintenance (tooling, dependencies, etc.)

## Pre-Submission Checklist

- [x] I have rebased on the latest `main` branch
- [x] I have run `npm run lint` with no errors (pre-existing issues only, no new ones)
- [x] I have run `npm run format`
- [x] I have run `npm run test` and all tests pass (pre-existing failures only, no new ones)
- [x] I have tested my changes manually in the browser
- [x] I have performed a self-review of my code
- [x] I have updated documentation as needed (N/A for this fix)
- [x] My changes generate no new warnings or errors