### PR TITLE
fix(auth): Auto-sync dev user on first request

### DIFF
--- a/services/frameworks/src/auth/dev-auth.guard.ts
+++ b/services/frameworks/src/auth/dev-auth.guard.ts
@@ -1,8 +1,6 @@
-import {
-  Injectable,
-  CanActivate,
-  ExecutionContext,
-} from '@nestjs/common';
+import { Injectable, CanActivate, ExecutionContext, Logger } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { DEV_USER, ensureDevUserExists } from '@gigachad-grc/shared';
 
 /**
  * Development auth guard that bypasses JWT validation
@@ -10,27 +8,41 @@ import {
  *
  * WARNING: Only use in development mode
  * CRITICAL: This guard will throw an error in production
+ *
+ * AUTO-SYNC: Automatically ensures the mock user and organization
+ * exist in the database to prevent foreign key constraint errors.
  */
 @Injectable()
 export class DevAuthGuard implements CanActivate {
-  canActivate(context: ExecutionContext): boolean {
+  private readonly logger = new Logger(DevAuthGuard.name);
+  private devUserSynced = false;
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
     // SECURITY: Prevent usage in production
     const nodeEnv = process.env.NODE_ENV || 'development';
     if (nodeEnv === 'production') {
       throw new Error(
         'SECURITY ERROR: DevAuthGuard is configured but NODE_ENV is set to production. ' +
-        'This is a critical security vulnerability. Please use proper JWT authentication in production.',
+          'This is a critical security vulnerability. Please use proper JWT authentication in production.'
       );
     }
 
     const request = context.switchToHttp().getRequest();
-    
-    // Mock user context for development - uses actual user from database
+
+    // Auto-sync: Ensure mock user and organization exist in database
+    if (!this.devUserSynced) {
+      await ensureDevUserExists(this.prisma, this.logger);
+      this.devUserSynced = true;
+    }
+
+    // Mock user context for development
     request.user = {
-      userId: '8f88a42b-e799-455c-b68a-308d7d2e9aa4', // John Doe from seeded users
-      keycloakId: 'john-doe-keycloak-id',
-      email: 'john.doe@example.com',
-      organizationId: '8924f0c1-7bb1-4be8-84ee-ad8725c712bf', // Default org UUID
+      userId: DEV_USER.userId,
+      keycloakId: DEV_USER.keycloakId,
+      email: DEV_USER.email,
+      organizationId: DEV_USER.organizationId,
       role: 'admin',
       permissions: [
         'controls:read',
@@ -56,4 +68,3 @@ export class DevAuthGuard implements CanActivate {
     return true;
   }
 }
-

--- a/services/shared/src/auth/dev-user-sync.ts
+++ b/services/shared/src/auth/dev-user-sync.ts
@@ -1,0 +1,80 @@
+import { DEV_USER } from './dev-user.constants';
+
+/**
+ * Minimal logger interface for dev user sync.
+ */
+interface LoggerLike {
+  log: (message: string) => void;
+  warn: (message: string) => void;
+}
+
+/**
+ * Ensures the mock development user and organization exist in the database.
+ *
+ * Uses the upsert pattern to handle race conditions gracefully - if multiple
+ * services start simultaneously, the first one creates the records and
+ * subsequent calls become no-ops.
+ *
+ * @param prisma - Prisma client instance with organization and user models
+ * @param logger - Logger instance for debug output
+ *
+ * @remarks
+ * This function should be called once per guard instance on first request.
+ * It's safe to call multiple times due to the upsert semantics.
+ *
+ * @example
+ * ```typescript
+ * if (!this.devUserSynced) {
+ *   await ensureDevUserExists(this.prisma, this.logger);
+ *   this.devUserSynced = true;
+ * }
+ * ```
+ */
+export async function ensureDevUserExists(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  prisma: { organization: any; user: any },
+  logger: LoggerLike,
+): Promise<void> {
+  try {
+    // Upsert organization - creates if not exists, no-op if exists
+    await prisma.organization.upsert({
+      where: { id: DEV_USER.organizationId },
+      update: {}, // No updates needed - just ensure it exists
+      create: {
+        id: DEV_USER.organizationId,
+        name: 'Development Organization',
+        slug: 'dev-org',
+        description: 'Auto-created organization for development',
+        status: 'active',
+        settings: {
+          timezone: 'UTC',
+          dateFormat: 'YYYY-MM-DD',
+        },
+      },
+    });
+
+    // Upsert user - creates if not exists, no-op if exists
+    await prisma.user.upsert({
+      where: { id: DEV_USER.userId },
+      update: {}, // No updates needed - just ensure it exists
+      create: {
+        id: DEV_USER.userId,
+        keycloakId: DEV_USER.keycloakId,
+        email: DEV_USER.email,
+        firstName: DEV_USER.firstName,
+        lastName: DEV_USER.lastName,
+        displayName: DEV_USER.displayName,
+        organizationId: DEV_USER.organizationId,
+        role: 'admin',
+        status: 'active',
+      },
+    });
+
+    logger.log('Dev user sync complete');
+  } catch (error) {
+    // Log but don't throw - the dev user might already exist via another path
+    logger.warn(
+      `Dev user sync warning: ${error instanceof Error ? error.message : 'Unknown error'}`,
+    );
+  }
+}

--- a/services/shared/src/auth/dev-user.constants.ts
+++ b/services/shared/src/auth/dev-user.constants.ts
@@ -1,0 +1,22 @@
+/**
+ * Centralized mock user constants for development authentication.
+ *
+ * These values must remain consistent across all services to prevent
+ * foreign key constraint errors when creating records in development.
+ *
+ * @remarks
+ * - The userId and organizationId are UUIDs that will be auto-created
+ *   in the database on first API request via the DevAuthGuard.
+ * - Only used when NODE_ENV !== 'production'
+ */
+export const DEV_USER = {
+  userId: '8f88a42b-e799-455c-b68a-308d7d2e9aa4',
+  organizationId: '8924f0c1-7bb1-4be8-84ee-ad8725c712bf',
+  keycloakId: 'john-doe-keycloak-id',
+  email: 'john.doe@example.com',
+  firstName: 'John',
+  lastName: 'Doe',
+  displayName: 'John Doe',
+} as const;
+
+export type DevUser = typeof DEV_USER;

--- a/services/shared/src/auth/index.ts
+++ b/services/shared/src/auth/index.ts
@@ -2,6 +2,5 @@ export * from './jwt.guard';
 export * from './roles.decorator';
 export * from './user.decorator';
 export * from './keycloak.service';
-
-
-
+export * from './dev-user.constants';
+export * from './dev-user-sync';

--- a/services/tprm/src/auth/dev-auth.guard.ts
+++ b/services/tprm/src/auth/dev-auth.guard.ts
@@ -1,8 +1,6 @@
-import {
-  Injectable,
-  CanActivate,
-  ExecutionContext,
-} from '@nestjs/common';
+import { Injectable, CanActivate, ExecutionContext, Logger } from '@nestjs/common';
+import { PrismaService } from '../common/prisma.service';
+import { DEV_USER, ensureDevUserExists } from '@gigachad-grc/shared';
 
 /**
  * Development auth guard that bypasses JWT validation
@@ -10,27 +8,40 @@ import {
  *
  * WARNING: Only use in development mode
  * CRITICAL: This guard will throw an error in production
+ *
+ * AUTO-SYNC: Automatically ensures the mock user and organization
+ * exist in the database to prevent foreign key constraint errors.
  */
 @Injectable()
 export class DevAuthGuard implements CanActivate {
-  canActivate(context: ExecutionContext): boolean {
+  private readonly logger = new Logger(DevAuthGuard.name);
+  private devUserSynced = false;
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
     // SECURITY: Prevent usage in production
     const nodeEnv = process.env.NODE_ENV || 'development';
     if (nodeEnv === 'production') {
       throw new Error(
         'SECURITY ERROR: DevAuthGuard is configured but NODE_ENV is set to production. ' +
-        'This is a critical security vulnerability. Please use proper JWT authentication in production.',
+          'This is a critical security vulnerability. Please use proper JWT authentication in production.'
       );
     }
 
     const request = context.switchToHttp().getRequest();
 
-    // Mock user context for development - uses actual user from database
+    // Auto-sync: Ensure mock user and organization exist in database
+    if (!this.devUserSynced) {
+      await ensureDevUserExists(this.prisma, this.logger);
+      this.devUserSynced = true;
+    }
+
     request.user = {
-      userId: '8f88a42b-e799-455c-b68a-308d7d2e9aa4', // John Doe from seeded users
-      keycloakId: 'john-doe-keycloak-id',
-      email: 'john.doe@example.com',
-      organizationId: '8924f0c1-7bb1-4be8-84ee-ad8725c712bf', // Default org UUID
+      userId: DEV_USER.userId,
+      keycloakId: DEV_USER.keycloakId,
+      email: DEV_USER.email,
+      organizationId: DEV_USER.organizationId,
       role: 'admin',
       permissions: [
         'vendors:read',

--- a/services/trust/src/auth/dev-auth.guard.ts
+++ b/services/trust/src/auth/dev-auth.guard.ts
@@ -1,8 +1,6 @@
-import {
-  Injectable,
-  CanActivate,
-  ExecutionContext,
-} from '@nestjs/common';
+import { Injectable, CanActivate, ExecutionContext, Logger } from '@nestjs/common';
+import { PrismaService } from '../common/prisma.service';
+import { DEV_USER, ensureDevUserExists } from '@gigachad-grc/shared';
 
 /**
  * Development auth guard that bypasses JWT validation
@@ -10,27 +8,40 @@ import {
  *
  * WARNING: Only use in development mode
  * CRITICAL: This guard will throw an error in production
+ *
+ * AUTO-SYNC: Automatically ensures the mock user and organization
+ * exist in the database to prevent foreign key constraint errors.
  */
 @Injectable()
 export class DevAuthGuard implements CanActivate {
-  canActivate(context: ExecutionContext): boolean {
+  private readonly logger = new Logger(DevAuthGuard.name);
+  private devUserSynced = false;
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
     // SECURITY: Prevent usage in production
     const nodeEnv = process.env.NODE_ENV || 'development';
     if (nodeEnv === 'production') {
       throw new Error(
         'SECURITY ERROR: DevAuthGuard is configured but NODE_ENV is set to production. ' +
-        'This is a critical security vulnerability. Please use proper JWT authentication in production.',
+          'This is a critical security vulnerability. Please use proper JWT authentication in production.'
       );
     }
 
     const request = context.switchToHttp().getRequest();
 
-    // Mock user context for development - uses actual user from database
+    // Auto-sync: Ensure mock user and organization exist in database
+    if (!this.devUserSynced) {
+      await ensureDevUserExists(this.prisma, this.logger);
+      this.devUserSynced = true;
+    }
+
     request.user = {
-      userId: '8f88a42b-e799-455c-b68a-308d7d2e9aa4', // John Doe from seeded users
-      keycloakId: 'john-doe-keycloak-id',
-      email: 'john.doe@example.com',
-      organizationId: '8924f0c1-7bb1-4be8-84ee-ad8725c712bf', // Default org UUID
+      userId: DEV_USER.userId,
+      keycloakId: DEV_USER.keycloakId,
+      email: DEV_USER.email,
+      organizationId: DEV_USER.organizationId,
       role: 'admin',
       permissions: [
         'questionnaires:read',


### PR DESCRIPTION
Fixes the "Invalid reference to related record" error that occurs when creating records in development without loading demo data.

The `DevAuthGuard` uses hardcoded mock user and organization IDs that don't exist in the database. I decided to add an auto-sync mechanism that creates the mock organization and user on first API request if they don't exist. This eliminates the foreign key constraint violation without requiring manual demo data loading.

For this reason, new developers can now start using the application immediately after running `./start.sh`.

Fixes #73

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Chore / Maintenance (tooling, dependencies, etc.)

## Pre-Submission Checklist

- [x] I have rebased on the latest `main` branch
- [ ] I have run `npm run lint` with no errors *(blocked by typescript-eslint version regression on main)*
- [x] I have run `npm run format`
- [x] I have run `npm run test` and all tests pass *(176 pass; 3 files fail due to pre-existing exceljs issue)*
- [x] I have tested my changes manually in the browser
- [x] I have performed a self-review of my code
- [x] I have updated documentation as needed *(N/A - internal dev-only guard)*
- [x] My changes generate no new warnings or errors

## Implementation Details

Modified all 6 DevAuthGuard implementations:
- `services/controls/src/auth/dev-auth.guard.ts`
- `services/frameworks/src/auth/dev-auth.guard.ts`
- `services/policies/src/auth/dev-auth.guard.ts`
- `services/audit/src/auth/dev-auth.guard.ts`
- `services/trust/src/auth/dev-auth.guard.ts`
- `services/tprm/src/auth/dev-auth.guard.ts`

Each guard now:
1. Injects `PrismaService`
2. Calls `ensureDevUserExists()` on first request
3. Creates the organization and user if missing
4. Caches sync status to avoid repeated database calls

**Production Safety**: This code only runs when `NODE_ENV !== 'production'`. The guard throws an error if accidentally configured in production environments.
