### PR TITLE
fix(security): comprehensive audit - SSRF, IDOR, auth, secrets, mass assignment

### DIFF
--- a/deploy/db-migrate.sh
+++ b/deploy/db-migrate.sh
@@ -36,7 +36,7 @@ DB_HOST=${POSTGRES_HOST:-postgres}
 DB_PORT=${POSTGRES_PORT:-5432}
 DB_NAME=${POSTGRES_DB:-gigachad_grc}
 DB_USER=${POSTGRES_USER:-grc}
-DB_PASS=${POSTGRES_PASSWORD:-grc_secret}
+DB_PASS=${POSTGRES_PASSWORD:?POSTGRES_PASSWORD environment variable is required}
 BACKUP_DIR=${BACKUP_DIR:-./backups}
 
 # =============================================================================

--- a/deploy/monitoring/docker-compose.monitoring.yml
+++ b/deploy/monitoring/docker-compose.monitoring.yml
@@ -28,12 +28,13 @@ services:
     networks:
       - grc-network
     ports:
-      - "9090:9090"
+      - '9090:9090'
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:9090/-/healthy"]
+      test:
+        ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:9090/-/healthy']
       interval: 30s
       timeout: 10s
       retries: 3
@@ -45,9 +46,10 @@ services:
     image: grafana/grafana:10.2.0
     container_name: grc-grafana
     environment:
-      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
-      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
-      GF_USERS_ALLOW_SIGN_UP: "false"
+      # SECURITY: Credentials must be explicitly set - no defaults allowed
+      GF_SECURITY_ADMIN_USER: '${GRAFANA_ADMIN_USER:?GRAFANA_ADMIN_USER is required}'
+      GF_SECURITY_ADMIN_PASSWORD: '${GRAFANA_ADMIN_PASSWORD:?GRAFANA_ADMIN_PASSWORD is required}'
+      GF_USERS_ALLOW_SIGN_UP: 'false'
       GF_SERVER_ROOT_URL: ${GRAFANA_ROOT_URL:-http://localhost:3030}
       GF_INSTALL_PLUGINS: grafana-clock-panel,grafana-piechart-panel
     volumes:
@@ -56,14 +58,15 @@ services:
     networks:
       - grc-network
     ports:
-      - "3030:3000"
+      - '3030:3000'
     depends_on:
       - prometheus
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/api/health"]
+      test:
+        ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:3000/api/health']
       interval: 30s
       timeout: 10s
       retries: 3
@@ -81,7 +84,7 @@ services:
     networks:
       - grc-network
     ports:
-      - "3100:3100"
+      - '3100:3100'
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true
@@ -121,7 +124,7 @@ services:
     networks:
       - grc-network
     ports:
-      - "8081:8080"
+      - '8081:8080'
     restart: unless-stopped
 
   # =============================================================================
@@ -142,7 +145,7 @@ services:
     networks:
       - grc-network
     ports:
-      - "9100:9100"
+      - '9100:9100'
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true
@@ -162,7 +165,7 @@ services:
     networks:
       - grc-network
     ports:
-      - "9093:9093"
+      - '9093:9093'
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true
@@ -180,8 +183,3 @@ volumes:
 networks:
   grc-network:
     external: true
-
-
-
-
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -186,19 +186,19 @@ services:
     environment:
       NODE_ENV: ${NODE_ENV:-development}
       PORT: 3001
-      DATABASE_URL: postgresql://${POSTGRES_USER:-grc}:${POSTGRES_PASSWORD:-grc_secret}@postgres:5432/${POSTGRES_DB:-gigachad_grc}
-      REDIS_URL: redis://:${REDIS_PASSWORD:-redis_secret}@redis:6379
+      DATABASE_URL: postgresql://${POSTGRES_USER:?POSTGRES_USER is required}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/${POSTGRES_DB:-gigachad_grc}
+      REDIS_URL: redis://:${REDIS_PASSWORD:?REDIS_PASSWORD is required}@redis:6379
       S3_ENDPOINT: rustfs
       S3_PORT: 9000
       S3_USE_SSL: ${MINIO_USE_SSL:-true}
-      S3_ACCESS_KEY: ${MINIO_ROOT_USER:-rustfsadmin}
-      S3_SECRET_KEY: ${MINIO_ROOT_PASSWORD:-rustfsadmin}
+      S3_ACCESS_KEY: ${MINIO_ROOT_USER:?MINIO_ROOT_USER is required}
+      S3_SECRET_KEY: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required}
       # Legacy MinIO env vars (for backwards compatibility)
       MINIO_ENDPOINT: rustfs
       MINIO_PORT: 9000
       MINIO_USE_SSL: ${MINIO_USE_SSL:-true}
-      MINIO_ACCESS_KEY: ${MINIO_ROOT_USER:-rustfsadmin}
-      MINIO_SECRET_KEY: ${MINIO_ROOT_PASSWORD:-rustfsadmin}
+      MINIO_ACCESS_KEY: ${MINIO_ROOT_USER:?MINIO_ROOT_USER is required}
+      MINIO_SECRET_KEY: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required}
       KEYCLOAK_URL: http://keycloak:8080
       KEYCLOAK_REALM: ${KEYCLOAK_REALM:-gigachad-grc}
       # Security secrets
@@ -259,18 +259,18 @@ services:
     environment:
       NODE_ENV: ${NODE_ENV:-development}
       PORT: 3002
-      DATABASE_URL: postgresql://${POSTGRES_USER:-grc}:${POSTGRES_PASSWORD:-grc_secret}@postgres:5432/${POSTGRES_DB:-gigachad_grc}
-      REDIS_URL: redis://:${REDIS_PASSWORD:-redis_secret}@redis:6379
+      DATABASE_URL: postgresql://${POSTGRES_USER:?POSTGRES_USER is required}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/${POSTGRES_DB:-gigachad_grc}
+      REDIS_URL: redis://:${REDIS_PASSWORD:?REDIS_PASSWORD is required}@redis:6379
       S3_ENDPOINT: rustfs
       S3_PORT: 9000
       S3_USE_SSL: ${MINIO_USE_SSL:-true}
-      S3_ACCESS_KEY: ${MINIO_ROOT_USER:-rustfsadmin}
-      S3_SECRET_KEY: ${MINIO_ROOT_PASSWORD:-rustfsadmin}
+      S3_ACCESS_KEY: ${MINIO_ROOT_USER:?MINIO_ROOT_USER is required}
+      S3_SECRET_KEY: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required}
       MINIO_ENDPOINT: rustfs
       MINIO_PORT: 9000
       MINIO_USE_SSL: ${MINIO_USE_SSL:-true}
-      MINIO_ACCESS_KEY: ${MINIO_ROOT_USER:-rustfsadmin}
-      MINIO_SECRET_KEY: ${MINIO_ROOT_PASSWORD:-rustfsadmin}
+      MINIO_ACCESS_KEY: ${MINIO_ROOT_USER:?MINIO_ROOT_USER is required}
+      MINIO_SECRET_KEY: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required}
       KEYCLOAK_URL: http://keycloak:8080
       KEYCLOAK_REALM: ${KEYCLOAK_REALM:-gigachad-grc}
     ports:
@@ -303,18 +303,18 @@ services:
     environment:
       NODE_ENV: ${NODE_ENV:-development}
       PORT: 3004
-      DATABASE_URL: postgresql://${POSTGRES_USER:-grc}:${POSTGRES_PASSWORD:-grc_secret}@postgres:5432/${POSTGRES_DB:-gigachad_grc}
-      REDIS_URL: redis://:${REDIS_PASSWORD:-redis_secret}@redis:6379
+      DATABASE_URL: postgresql://${POSTGRES_USER:?POSTGRES_USER is required}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/${POSTGRES_DB:-gigachad_grc}
+      REDIS_URL: redis://:${REDIS_PASSWORD:?REDIS_PASSWORD is required}@redis:6379
       S3_ENDPOINT: rustfs
       S3_PORT: 9000
       S3_USE_SSL: ${MINIO_USE_SSL:-true}
-      S3_ACCESS_KEY: ${MINIO_ROOT_USER:-rustfsadmin}
-      S3_SECRET_KEY: ${MINIO_ROOT_PASSWORD:-rustfsadmin}
+      S3_ACCESS_KEY: ${MINIO_ROOT_USER:?MINIO_ROOT_USER is required}
+      S3_SECRET_KEY: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required}
       MINIO_ENDPOINT: rustfs
       MINIO_PORT: 9000
       MINIO_USE_SSL: ${MINIO_USE_SSL:-true}
-      MINIO_ACCESS_KEY: ${MINIO_ROOT_USER:-rustfsadmin}
-      MINIO_SECRET_KEY: ${MINIO_ROOT_PASSWORD:-rustfsadmin}
+      MINIO_ACCESS_KEY: ${MINIO_ROOT_USER:?MINIO_ROOT_USER is required}
+      MINIO_SECRET_KEY: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required}
       KEYCLOAK_URL: http://keycloak:8080
       KEYCLOAK_REALM: ${KEYCLOAK_REALM:-gigachad-grc}
     ports:
@@ -349,18 +349,18 @@ services:
     environment:
       NODE_ENV: ${NODE_ENV:-development}
       PORT: 3005
-      DATABASE_URL: postgresql://${POSTGRES_USER:-grc}:${POSTGRES_PASSWORD:-grc_secret}@postgres:5432/${POSTGRES_DB:-gigachad_grc}
-      REDIS_URL: redis://:${REDIS_PASSWORD:-redis_secret}@redis:6379
+      DATABASE_URL: postgresql://${POSTGRES_USER:?POSTGRES_USER is required}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/${POSTGRES_DB:-gigachad_grc}
+      REDIS_URL: redis://:${REDIS_PASSWORD:?REDIS_PASSWORD is required}@redis:6379
       S3_ENDPOINT: rustfs
       S3_PORT: 9000
       S3_USE_SSL: ${MINIO_USE_SSL:-true}
-      S3_ACCESS_KEY: ${MINIO_ROOT_USER:-rustfsadmin}
-      S3_SECRET_KEY: ${MINIO_ROOT_PASSWORD:-rustfsadmin}
+      S3_ACCESS_KEY: ${MINIO_ROOT_USER:?MINIO_ROOT_USER is required}
+      S3_SECRET_KEY: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required}
       MINIO_ENDPOINT: rustfs
       MINIO_PORT: 9000
       MINIO_USE_SSL: ${MINIO_USE_SSL:-true}
-      MINIO_ACCESS_KEY: ${MINIO_ROOT_USER:-rustfsadmin}
-      MINIO_SECRET_KEY: ${MINIO_ROOT_PASSWORD:-rustfsadmin}
+      MINIO_ACCESS_KEY: ${MINIO_ROOT_USER:?MINIO_ROOT_USER is required}
+      MINIO_SECRET_KEY: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required}
       KEYCLOAK_URL: http://keycloak:8080
       KEYCLOAK_REALM: ${KEYCLOAK_REALM:-gigachad-grc}
     ports:
@@ -396,18 +396,18 @@ services:
     environment:
       NODE_ENV: ${NODE_ENV:-development}
       PORT: 3006
-      DATABASE_URL: postgresql://${POSTGRES_USER:-grc}:${POSTGRES_PASSWORD:-grc_secret}@postgres:5432/${POSTGRES_DB:-gigachad_grc}
-      REDIS_URL: redis://:${REDIS_PASSWORD:-redis_secret}@redis:6379
+      DATABASE_URL: postgresql://${POSTGRES_USER:?POSTGRES_USER is required}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/${POSTGRES_DB:-gigachad_grc}
+      REDIS_URL: redis://:${REDIS_PASSWORD:?REDIS_PASSWORD is required}@redis:6379
       S3_ENDPOINT: rustfs
       S3_PORT: 9000
       S3_USE_SSL: ${MINIO_USE_SSL:-true}
-      S3_ACCESS_KEY: ${MINIO_ROOT_USER:-rustfsadmin}
-      S3_SECRET_KEY: ${MINIO_ROOT_PASSWORD:-rustfsadmin}
+      S3_ACCESS_KEY: ${MINIO_ROOT_USER:?MINIO_ROOT_USER is required}
+      S3_SECRET_KEY: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required}
       MINIO_ENDPOINT: rustfs
       MINIO_PORT: 9000
       MINIO_USE_SSL: ${MINIO_USE_SSL:-true}
-      MINIO_ACCESS_KEY: ${MINIO_ROOT_USER:-rustfsadmin}
-      MINIO_SECRET_KEY: ${MINIO_ROOT_PASSWORD:-rustfsadmin}
+      MINIO_ACCESS_KEY: ${MINIO_ROOT_USER:?MINIO_ROOT_USER is required}
+      MINIO_SECRET_KEY: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required}
       KEYCLOAK_URL: http://keycloak:8080
       KEYCLOAK_REALM: ${KEYCLOAK_REALM:-gigachad-grc}
     ports:
@@ -444,18 +444,18 @@ services:
     environment:
       NODE_ENV: ${NODE_ENV:-development}
       PORT: 3007
-      DATABASE_URL: postgresql://${POSTGRES_USER:-grc}:${POSTGRES_PASSWORD:-grc_secret}@postgres:5432/${POSTGRES_DB:-gigachad_grc}
-      REDIS_URL: redis://:${REDIS_PASSWORD:-redis_secret}@redis:6379
+      DATABASE_URL: postgresql://${POSTGRES_USER:?POSTGRES_USER is required}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/${POSTGRES_DB:-gigachad_grc}
+      REDIS_URL: redis://:${REDIS_PASSWORD:?REDIS_PASSWORD is required}@redis:6379
       S3_ENDPOINT: rustfs
       S3_PORT: 9000
       S3_USE_SSL: ${MINIO_USE_SSL:-true}
-      S3_ACCESS_KEY: ${MINIO_ROOT_USER:-rustfsadmin}
-      S3_SECRET_KEY: ${MINIO_ROOT_PASSWORD:-rustfsadmin}
+      S3_ACCESS_KEY: ${MINIO_ROOT_USER:?MINIO_ROOT_USER is required}
+      S3_SECRET_KEY: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required}
       MINIO_ENDPOINT: rustfs
       MINIO_PORT: 9000
       MINIO_USE_SSL: ${MINIO_USE_SSL:-true}
-      MINIO_ACCESS_KEY: ${MINIO_ROOT_USER:-rustfsadmin}
-      MINIO_SECRET_KEY: ${MINIO_ROOT_PASSWORD:-rustfsadmin}
+      MINIO_ACCESS_KEY: ${MINIO_ROOT_USER:?MINIO_ROOT_USER is required}
+      MINIO_SECRET_KEY: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required}
       KEYCLOAK_URL: http://keycloak:8080
       KEYCLOAK_REALM: ${KEYCLOAK_REALM:-gigachad-grc}
     ports:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8728,6 +8728,7 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/scripts/import-anecdotes-controls.ts
+++ b/scripts/import-anecdotes-controls.ts
@@ -8,10 +8,19 @@ import { PrismaClient } from '@prisma/client';
 import * as fs from 'fs';
 import * as _path from 'path';
 
+// SECURITY: DATABASE_URL must be explicitly set - no hardcoded credentials
+if (!process.env.DATABASE_URL) {
+  console.error('ERROR: DATABASE_URL environment variable is required');
+  console.error(
+    'Example: export DATABASE_URL="postgresql://user:password@localhost:5433/gigachad_grc"'
+  );
+  process.exit(1);
+}
+
 const prisma = new PrismaClient({
   datasources: {
     db: {
-      url: process.env.DATABASE_URL || 'postgresql://grc:grc_secret@localhost:5433/gigachad_grc',
+      url: process.env.DATABASE_URL,
     },
   },
 });
@@ -54,12 +63,17 @@ function normalizeCategory(category: string): string {
 
 // Map Anecdotes status to our status enum
 // Note: Returns string type but compatible with ControlImplementationStatus enum values
-function normalizeStatus(status: string): 'implemented' | 'in_progress' | 'not_started' | 'not_applicable' {
-  const statusMap: Record<string, 'implemented' | 'in_progress' | 'not_started' | 'not_applicable'> = {
-    'monitoring': 'implemented',
+function normalizeStatus(
+  status: string
+): 'implemented' | 'in_progress' | 'not_started' | 'not_applicable' {
+  const statusMap: Record<
+    string,
+    'implemented' | 'in_progress' | 'not_started' | 'not_applicable'
+  > = {
+    monitoring: 'implemented',
     'in progress': 'in_progress',
     'not started': 'not_started',
-    'gap': 'not_started',
+    gap: 'not_started',
   };
 
   return statusMap[status.toLowerCase().trim()] || 'not_started';
@@ -68,18 +82,18 @@ function normalizeStatus(status: string): 'implemented' | 'in_progress' | 'not_s
 // Generate a control ID from the category and name
 function generateControlId(category: string, name: string, index: number): string {
   const prefixMap: Record<string, string> = {
-    'compliance': 'COMP',
-    'human_resources': 'HR',
-    'risk_management': 'RM',
-    'vendor_management': 'VM',
-    'access_control': 'AC',
-    'physical_security': 'PHY',
-    'network_security': 'NS',
-    'incident_response': 'IR',
-    'change_management': 'CM',
-    'business_continuity': 'BC',
-    'data_protection': 'DP',
-    'other': 'OTH',
+    compliance: 'COMP',
+    human_resources: 'HR',
+    risk_management: 'RM',
+    vendor_management: 'VM',
+    access_control: 'AC',
+    physical_security: 'PHY',
+    network_security: 'NS',
+    incident_response: 'IR',
+    change_management: 'CM',
+    business_continuity: 'BC',
+    data_protection: 'DP',
+    other: 'OTH',
   };
 
   const prefix = prefixMap[category] || 'CTL';
@@ -94,7 +108,7 @@ function parseCSVLine(line: string): string[] {
 
   for (let i = 0; i < line.length; i++) {
     const char = line[i];
-    
+
     if (char === '"') {
       if (inQuotes && line[i + 1] === '"') {
         current += '"';
@@ -109,19 +123,19 @@ function parseCSVLine(line: string): string[] {
       current += char;
     }
   }
-  
+
   result.push(current.trim());
   return result;
 }
 
 // Parse the Anecdotes CSV format
 function parseAnecdotesCSV(csvContent: string): AnecdotesControl[] {
-  const lines = csvContent.split('\n').filter(line => line.trim());
+  const lines = csvContent.split('\n').filter((line) => line.trim());
   if (lines.length < 2) {
     throw new Error('CSV must have a header row and at least one data row');
   }
 
-  const headers = parseCSVLine(lines[0]).map(h => h.toLowerCase());
+  const headers = parseCSVLine(lines[0]).map((h) => h.toLowerCase());
   const controls: AnecdotesControl[] = [];
 
   for (let i = 1; i < lines.length; i++) {
@@ -212,32 +226,42 @@ async function ensureSOC2Requirements(frameworkId: string): Promise<Map<string, 
   const criteria = [
     // Common Criteria (Security)
     { ref: 'CC1', title: 'Control Environment', level: 0, isCategory: true },
-    { ref: 'CC1.1', title: 'COSO Principle 1 - Integrity and Ethical Values', level: 1, parent: 'CC1' },
+    {
+      ref: 'CC1.1',
+      title: 'COSO Principle 1 - Integrity and Ethical Values',
+      level: 1,
+      parent: 'CC1',
+    },
     { ref: 'CC1.2', title: 'COSO Principle 2 - Board Independence', level: 1, parent: 'CC1' },
     { ref: 'CC1.3', title: 'COSO Principle 3 - Management Structure', level: 1, parent: 'CC1' },
     { ref: 'CC1.4', title: 'COSO Principle 4 - Competent Personnel', level: 1, parent: 'CC1' },
     { ref: 'CC1.5', title: 'COSO Principle 5 - Accountability', level: 1, parent: 'CC1' },
-    
+
     { ref: 'CC2', title: 'Communication and Information', level: 0, isCategory: true },
     { ref: 'CC2.1', title: 'COSO Principle 13 - Quality Information', level: 1, parent: 'CC2' },
     { ref: 'CC2.2', title: 'COSO Principle 14 - Internal Communication', level: 1, parent: 'CC2' },
     { ref: 'CC2.3', title: 'COSO Principle 15 - External Communication', level: 1, parent: 'CC2' },
-    
+
     { ref: 'CC3', title: 'Risk Assessment', level: 0, isCategory: true },
     { ref: 'CC3.1', title: 'COSO Principle 6 - Specified Objectives', level: 1, parent: 'CC3' },
     { ref: 'CC3.2', title: 'COSO Principle 7 - Risk Identification', level: 1, parent: 'CC3' },
     { ref: 'CC3.3', title: 'COSO Principle 8 - Fraud Risk', level: 1, parent: 'CC3' },
     { ref: 'CC3.4', title: 'COSO Principle 9 - Change Assessment', level: 1, parent: 'CC3' },
-    
+
     { ref: 'CC4', title: 'Monitoring Activities', level: 0, isCategory: true },
     { ref: 'CC4.1', title: 'COSO Principle 16 - Ongoing Evaluations', level: 1, parent: 'CC4' },
-    { ref: 'CC4.2', title: 'COSO Principle 17 - Deficiency Communication', level: 1, parent: 'CC4' },
-    
+    {
+      ref: 'CC4.2',
+      title: 'COSO Principle 17 - Deficiency Communication',
+      level: 1,
+      parent: 'CC4',
+    },
+
     { ref: 'CC5', title: 'Control Activities', level: 0, isCategory: true },
     { ref: 'CC5.1', title: 'COSO Principle 10 - Risk Mitigation', level: 1, parent: 'CC5' },
     { ref: 'CC5.2', title: 'COSO Principle 11 - Technology Controls', level: 1, parent: 'CC5' },
     { ref: 'CC5.3', title: 'COSO Principle 12 - Policies and Procedures', level: 1, parent: 'CC5' },
-    
+
     { ref: 'CC6', title: 'Logical and Physical Access', level: 0, isCategory: true },
     { ref: 'CC6.1', title: 'Security Software and Infrastructure', level: 1, parent: 'CC6' },
     { ref: 'CC6.2', title: 'User Registration and Authorization', level: 1, parent: 'CC6' },
@@ -247,32 +271,32 @@ async function ensureSOC2Requirements(frameworkId: string): Promise<Map<string, 
     { ref: 'CC6.6', title: 'Boundary Protection', level: 1, parent: 'CC6' },
     { ref: 'CC6.7', title: 'Data Transmission Protection', level: 1, parent: 'CC6' },
     { ref: 'CC6.8', title: 'Malware Protection', level: 1, parent: 'CC6' },
-    
+
     { ref: 'CC7', title: 'System Operations', level: 0, isCategory: true },
     { ref: 'CC7.1', title: 'Vulnerability Management', level: 1, parent: 'CC7' },
     { ref: 'CC7.2', title: 'Security Incident Monitoring', level: 1, parent: 'CC7' },
     { ref: 'CC7.3', title: 'Security Incident Response', level: 1, parent: 'CC7' },
     { ref: 'CC7.4', title: 'Security Incident Recovery', level: 1, parent: 'CC7' },
     { ref: 'CC7.5', title: 'Incident Recovery Activities', level: 1, parent: 'CC7' },
-    
+
     { ref: 'CC8', title: 'Change Management', level: 0, isCategory: true },
     { ref: 'CC8.1', title: 'Change Authorization and Implementation', level: 1, parent: 'CC8' },
-    
+
     { ref: 'CC9', title: 'Risk Mitigation', level: 0, isCategory: true },
     { ref: 'CC9.1', title: 'Business Disruption Risk', level: 1, parent: 'CC9' },
     { ref: 'CC9.2', title: 'Vendor Risk Management', level: 1, parent: 'CC9' },
-    
+
     // Availability
     { ref: 'A1', title: 'Availability', level: 0, isCategory: true },
     { ref: 'A1.1', title: 'Capacity Management', level: 1, parent: 'A1' },
     { ref: 'A1.2', title: 'Recovery and Continuity', level: 1, parent: 'A1' },
     { ref: 'A1.3', title: 'Recovery Testing', level: 1, parent: 'A1' },
-    
+
     // Confidentiality
     { ref: 'C1', title: 'Confidentiality', level: 0, isCategory: true },
     { ref: 'C1.1', title: 'Confidential Information Identification', level: 1, parent: 'C1' },
     { ref: 'C1.2', title: 'Confidential Information Disposal', level: 1, parent: 'C1' },
-    
+
     // Processing Integrity
     { ref: 'PI1', title: 'Processing Integrity', level: 0, isCategory: true },
     { ref: 'PI1.1', title: 'Processing Accuracy', level: 1, parent: 'PI1' },
@@ -280,7 +304,7 @@ async function ensureSOC2Requirements(frameworkId: string): Promise<Map<string, 
     { ref: 'PI1.3', title: 'Processing Monitoring', level: 1, parent: 'PI1' },
     { ref: 'PI1.4', title: 'Output Validation', level: 1, parent: 'PI1' },
     { ref: 'PI1.5', title: 'Data Retention', level: 1, parent: 'PI1' },
-    
+
     // Privacy
     { ref: 'P1', title: 'Privacy Notice', level: 0, isCategory: true },
     { ref: 'P1.1', title: 'Privacy Notice Provided', level: 1, parent: 'P1' },
@@ -305,7 +329,7 @@ async function ensureSOC2Requirements(frameworkId: string): Promise<Map<string, 
   let order = 0;
 
   // First pass: create categories
-  for (const crit of criteria.filter(c => c.isCategory)) {
+  for (const crit of criteria.filter((c) => c.isCategory)) {
     const existing = await prisma.frameworkRequirement.findFirst({
       where: { frameworkId, reference: crit.ref },
     });
@@ -329,7 +353,7 @@ async function ensureSOC2Requirements(frameworkId: string): Promise<Map<string, 
   }
 
   // Second pass: create requirements under categories
-  for (const crit of criteria.filter(c => !c.isCategory)) {
+  for (const crit of criteria.filter((c) => !c.isCategory)) {
     const existing = await prisma.frameworkRequirement.findFirst({
       where: { frameworkId, reference: crit.ref },
     });
@@ -357,7 +381,12 @@ async function ensureSOC2Requirements(frameworkId: string): Promise<Map<string, 
   return refToId;
 }
 
-async function importControls(controls: AnecdotesControl[], organizationId: string, frameworkId: string, requirementMap: Map<string, string>) {
+async function importControls(
+  controls: AnecdotesControl[],
+  organizationId: string,
+  frameworkId: string,
+  requirementMap: Map<string, string>
+) {
   let created = 0;
   let updated = 0;
   let mappingsCreated = 0;
@@ -367,15 +396,15 @@ async function importControls(controls: AnecdotesControl[], organizationId: stri
     if (!ctrl.controlName) continue;
 
     const category = normalizeCategory(ctrl.category);
-    
+
     // Generate unique control ID
     controlIdCounters[category] = (controlIdCounters[category] || 0) + 1;
     const controlId = generateControlId(category, ctrl.controlName, controlIdCounters[category]);
 
     // Build guidance from requirements
     const guidance = ctrl.requirements
-      .filter(r => r.name)
-      .map(r => `• ${r.name}`)
+      .filter((r) => r.name)
+      .map((r) => `• ${r.name}`)
       .join('\n');
 
     // Check if control exists
@@ -394,7 +423,12 @@ async function importControls(controls: AnecdotesControl[], organizationId: stri
           description: ctrl.controlDescription || ctrl.controlName,
           category,
           guidance: guidance || ctrl.controlImplementation || null,
-          tags: ctrl.tags ? ctrl.tags.split(',').map(t => t.trim()).filter(Boolean) : [],
+          tags: ctrl.tags
+            ? ctrl.tags
+                .split(',')
+                .map((t) => t.trim())
+                .filter(Boolean)
+            : [],
         },
       });
       updated++;
@@ -409,7 +443,12 @@ async function importControls(controls: AnecdotesControl[], organizationId: stri
           guidance: guidance || ctrl.controlImplementation || null,
           isCustom: true,
           organizationId,
-          tags: ctrl.tags ? ctrl.tags.split(',').map(t => t.trim()).filter(Boolean) : [],
+          tags: ctrl.tags
+            ? ctrl.tags
+                .split(',')
+                .map((t) => t.trim())
+                .filter(Boolean)
+            : [],
           automationSupported: false,
         },
       });
@@ -431,8 +470,11 @@ async function importControls(controls: AnecdotesControl[], organizationId: stri
 
     // Create framework mappings from FW reference
     if (ctrl.fwReference) {
-      const refs = ctrl.fwReference.split(',').map(r => r.trim()).filter(Boolean);
-      
+      const refs = ctrl.fwReference
+        .split(',')
+        .map((r) => r.trim())
+        .filter(Boolean);
+
       for (const ref of refs) {
         const requirementId = requirementMap.get(ref);
         if (requirementId) {
@@ -466,7 +508,8 @@ async function importControls(controls: AnecdotesControl[], organizationId: stri
 }
 
 async function main() {
-  const csvPath = process.argv[2] || '/Users/chad.fryer/Downloads/SOC 2_controls_list_by_anecdotes.csv';
+  const csvPath =
+    process.argv[2] || '/Users/chad.fryer/Downloads/SOC 2_controls_list_by_anecdotes.csv';
 
   console.log('╔════════════════════════════════════════════════════════════════╗');
   console.log('║     GigaChad GRC - Anecdotes SOC 2 Controls Importer           ║');
@@ -505,11 +548,16 @@ async function main() {
     console.log('\n╔════════════════════════════════════════════════════════════════╗');
     console.log('║                      Import Complete!                          ║');
     console.log('╠════════════════════════════════════════════════════════════════╣');
-    console.log(`║  Controls Created:    ${result.created.toString().padStart(4)}                                   ║`);
-    console.log(`║  Controls Updated:    ${result.updated.toString().padStart(4)}                                   ║`);
-    console.log(`║  Mappings Created:    ${result.mappingsCreated.toString().padStart(4)}                                   ║`);
+    console.log(
+      `║  Controls Created:    ${result.created.toString().padStart(4)}                                   ║`
+    );
+    console.log(
+      `║  Controls Updated:    ${result.updated.toString().padStart(4)}                                   ║`
+    );
+    console.log(
+      `║  Mappings Created:    ${result.mappingsCreated.toString().padStart(4)}                                   ║`
+    );
     console.log('╚════════════════════════════════════════════════════════════════╝');
-
   } catch (error) {
     console.error('\n❌ Import failed:', error);
     throw error;
@@ -524,6 +572,3 @@ main()
   .finally(async () => {
     await prisma.$disconnect();
   });
-
-
-

--- a/scripts/import-anecdotes-iso27001.ts
+++ b/scripts/import-anecdotes-iso27001.ts
@@ -7,10 +7,19 @@
 import { PrismaClient } from '@prisma/client';
 import * as fs from 'fs';
 
+// SECURITY: DATABASE_URL must be explicitly set - no hardcoded credentials
+if (!process.env.DATABASE_URL) {
+  console.error('ERROR: DATABASE_URL environment variable is required');
+  console.error(
+    'Example: export DATABASE_URL="postgresql://user:password@localhost:5433/gigachad_grc"'
+  );
+  process.exit(1);
+}
+
 const prisma = new PrismaClient({
   datasources: {
     db: {
-      url: process.env.DATABASE_URL || 'postgresql://grc:grc_secret@localhost:5433/gigachad_grc',
+      url: process.env.DATABASE_URL,
     },
   },
 });
@@ -31,7 +40,7 @@ interface AnecdotesControl {
 // Map ISO 27001 categories to our category enum
 function normalizeCategory(category: string): string {
   const cat = category.toLowerCase().trim();
-  
+
   if (cat.includes('context')) return 'compliance';
   if (cat.includes('leadership')) return 'compliance';
   if (cat.includes('planning')) return 'risk_management';
@@ -43,18 +52,23 @@ function normalizeCategory(category: string): string {
   if (cat.includes('people')) return 'human_resources';
   if (cat.includes('physical')) return 'physical_security';
   if (cat.includes('technological')) return 'network_security';
-  
+
   return 'other';
 }
 
 // Map Anecdotes status to our status enum
 // Note: Returns string type but compatible with ControlImplementationStatus enum values
-function normalizeStatus(status: string): 'implemented' | 'in_progress' | 'not_started' | 'not_applicable' {
-  const statusMap: Record<string, 'implemented' | 'in_progress' | 'not_started' | 'not_applicable'> = {
-    'monitoring': 'implemented',
+function normalizeStatus(
+  status: string
+): 'implemented' | 'in_progress' | 'not_started' | 'not_applicable' {
+  const statusMap: Record<
+    string,
+    'implemented' | 'in_progress' | 'not_started' | 'not_applicable'
+  > = {
+    monitoring: 'implemented',
     'in progress': 'in_progress',
     'not started': 'not_started',
-    'gap': 'not_started',
+    gap: 'not_started',
   };
 
   return statusMap[status.toLowerCase().trim()] || 'not_started';
@@ -78,7 +92,7 @@ function parseCSVLine(line: string): string[] {
 
   for (let i = 0; i < line.length; i++) {
     const char = line[i];
-    
+
     if (char === '"') {
       if (inQuotes && line[i + 1] === '"') {
         current += '"';
@@ -93,19 +107,19 @@ function parseCSVLine(line: string): string[] {
       current += char;
     }
   }
-  
+
   result.push(current.trim());
   return result;
 }
 
 // Parse the Anecdotes CSV format
 function parseAnecdotesCSV(csvContent: string): AnecdotesControl[] {
-  const lines = csvContent.split('\n').filter(line => line.trim());
+  const lines = csvContent.split('\n').filter((line) => line.trim());
   if (lines.length < 2) {
     throw new Error('CSV must have a header row and at least one data row');
   }
 
-  const headers = parseCSVLine(lines[0]).map(h => h.toLowerCase());
+  const headers = parseCSVLine(lines[0]).map((h) => h.toLowerCase());
   const controls: AnecdotesControl[] = [];
 
   for (let i = 1; i < lines.length; i++) {
@@ -181,13 +195,16 @@ async function ensureISO27001Framework(): Promise<string> {
   return framework.id;
 }
 
-async function createISO27001Requirements(frameworkId: string, controls: AnecdotesControl[]): Promise<Map<string, string>> {
+async function createISO27001Requirements(
+  frameworkId: string,
+  controls: AnecdotesControl[]
+): Promise<Map<string, string>> {
   const refToId = new Map<string, string>();
   let order = 0;
 
   // Group controls by category to create requirement hierarchy
   const categories = new Map<string, AnecdotesControl[]>();
-  
+
   for (const ctrl of controls) {
     const cat = ctrl.category;
     if (!categories.has(cat)) {
@@ -200,7 +217,7 @@ async function createISO27001Requirements(frameworkId: string, controls: Anecdot
   for (const [categoryName, categoryControls] of categories) {
     // Create category requirement
     const catRef = categoryName.split(' ')[0].replace('.', ''); // "4. Context..." -> "4"
-    
+
     let categoryReq = await prisma.frameworkRequirement.findFirst({
       where: { frameworkId, reference: catRef },
     });
@@ -252,8 +269,8 @@ async function createISO27001Requirements(frameworkId: string, controls: Anecdot
 }
 
 async function importControls(
-  controls: AnecdotesControl[], 
-  organizationId: string, 
+  controls: AnecdotesControl[],
+  organizationId: string,
   frameworkId: string,
   requirementMap: Map<string, string>
 ) {
@@ -270,8 +287,8 @@ async function importControls(
 
     // Build guidance from requirements
     const guidance = ctrl.requirements
-      .filter(r => r.name && !r.name.toLowerCase().includes('delete'))
-      .map(r => `• ${r.name}`)
+      .filter((r) => r.name && !r.name.toLowerCase().includes('delete'))
+      .map((r) => `• ${r.name}`)
       .join('\n');
 
     // Check if control exists
@@ -290,7 +307,12 @@ async function importControls(
           description: ctrl.controlDescription || ctrl.controlName,
           category,
           guidance: guidance || null,
-          tags: ctrl.tags ? ctrl.tags.split(',').map(t => t.trim()).filter(Boolean) : [],
+          tags: ctrl.tags
+            ? ctrl.tags
+                .split(',')
+                .map((t) => t.trim())
+                .filter(Boolean)
+            : [],
         },
       });
       updated++;
@@ -304,7 +326,12 @@ async function importControls(
           guidance: guidance || null,
           isCustom: true,
           organizationId,
-          tags: ctrl.tags ? ctrl.tags.split(',').map(t => t.trim()).filter(Boolean) : [],
+          tags: ctrl.tags
+            ? ctrl.tags
+                .split(',')
+                .map((t) => t.trim())
+                .filter(Boolean)
+            : [],
           automationSupported: false,
         },
       });
@@ -357,7 +384,9 @@ async function importControls(
 }
 
 async function main() {
-  const csvPath = process.argv[2] || '/Users/chad.fryer/Downloads/ISO-IEC 27001 2022_controls_list_by_anecdotes.csv';
+  const csvPath =
+    process.argv[2] ||
+    '/Users/chad.fryer/Downloads/ISO-IEC 27001 2022_controls_list_by_anecdotes.csv';
 
   console.log('╔════════════════════════════════════════════════════════════════╗');
   console.log('║   GigaChad GRC - Anecdotes ISO 27001:2022 Controls Importer    ║');
@@ -397,11 +426,16 @@ async function main() {
     console.log('\n╔════════════════════════════════════════════════════════════════╗');
     console.log('║                      Import Complete!                          ║');
     console.log('╠════════════════════════════════════════════════════════════════╣');
-    console.log(`║  Controls Created:    ${result.created.toString().padStart(4)}                                   ║`);
-    console.log(`║  Controls Updated:    ${result.updated.toString().padStart(4)}                                   ║`);
-    console.log(`║  Mappings Created:    ${result.mappingsCreated.toString().padStart(4)}                                   ║`);
+    console.log(
+      `║  Controls Created:    ${result.created.toString().padStart(4)}                                   ║`
+    );
+    console.log(
+      `║  Controls Updated:    ${result.updated.toString().padStart(4)}                                   ║`
+    );
+    console.log(
+      `║  Mappings Created:    ${result.mappingsCreated.toString().padStart(4)}                                   ║`
+    );
     console.log('╚════════════════════════════════════════════════════════════════╝');
-
   } catch (error) {
     console.error('\n❌ Import failed:', error);
     throw error;
@@ -416,6 +450,3 @@ main()
   .finally(async () => {
     await prisma.$disconnect();
   });
-
-
-

--- a/scripts/seed-database.ts
+++ b/scripts/seed-database.ts
@@ -9,10 +9,19 @@ import { PrismaClient } from '@prisma/client';
 import * as path from 'path';
 import * as fs from 'fs';
 
+// SECURITY: DATABASE_URL must be explicitly set - no hardcoded credentials
+if (!process.env.DATABASE_URL) {
+  console.error('ERROR: DATABASE_URL environment variable is required');
+  console.error(
+    'Example: export DATABASE_URL="postgresql://user:password@localhost:5433/gigachad_grc"'
+  );
+  process.exit(1);
+}
+
 const prisma = new PrismaClient({
   datasources: {
     db: {
-      url: process.env.DATABASE_URL || 'postgresql://grc:grc_secret@localhost:5433/gigachad_grc',
+      url: process.env.DATABASE_URL,
     },
   },
 });
@@ -318,15 +327,47 @@ const DEFAULT_PERMISSION_GROUPS = {
     name: 'Administrator',
     description: 'Full access to all resources and actions',
     permissions: [
-      { resource: 'controls', actions: ['read', 'create', 'update', 'delete', 'assign', 'approve', 'export'], scope: { ownership: 'all' } },
-      { resource: 'evidence', actions: ['read', 'create', 'update', 'delete', 'assign', 'approve', 'export'], scope: { ownership: 'all' } },
-      { resource: 'policies', actions: ['read', 'create', 'update', 'delete', 'assign', 'approve', 'export'], scope: { ownership: 'all' } },
-      { resource: 'frameworks', actions: ['read', 'create', 'update', 'delete', 'assign', 'approve', 'export'], scope: { ownership: 'all' } },
-      { resource: 'integrations', actions: ['read', 'create', 'update', 'delete', 'assign', 'approve', 'export'], scope: { ownership: 'all' } },
+      {
+        resource: 'controls',
+        actions: ['read', 'create', 'update', 'delete', 'assign', 'approve', 'export'],
+        scope: { ownership: 'all' },
+      },
+      {
+        resource: 'evidence',
+        actions: ['read', 'create', 'update', 'delete', 'assign', 'approve', 'export'],
+        scope: { ownership: 'all' },
+      },
+      {
+        resource: 'policies',
+        actions: ['read', 'create', 'update', 'delete', 'assign', 'approve', 'export'],
+        scope: { ownership: 'all' },
+      },
+      {
+        resource: 'frameworks',
+        actions: ['read', 'create', 'update', 'delete', 'assign', 'approve', 'export'],
+        scope: { ownership: 'all' },
+      },
+      {
+        resource: 'integrations',
+        actions: ['read', 'create', 'update', 'delete', 'assign', 'approve', 'export'],
+        scope: { ownership: 'all' },
+      },
       { resource: 'audit_logs', actions: ['read', 'export'], scope: { ownership: 'all' } },
-      { resource: 'users', actions: ['read', 'create', 'update', 'delete', 'assign', 'approve', 'export'], scope: { ownership: 'all' } },
-      { resource: 'permissions', actions: ['read', 'create', 'update', 'delete', 'assign', 'approve', 'export'], scope: { ownership: 'all' } },
-      { resource: 'settings', actions: ['read', 'create', 'update', 'delete', 'assign', 'approve', 'export'], scope: { ownership: 'all' } },
+      {
+        resource: 'users',
+        actions: ['read', 'create', 'update', 'delete', 'assign', 'approve', 'export'],
+        scope: { ownership: 'all' },
+      },
+      {
+        resource: 'permissions',
+        actions: ['read', 'create', 'update', 'delete', 'assign', 'approve', 'export'],
+        scope: { ownership: 'all' },
+      },
+      {
+        resource: 'settings',
+        actions: ['read', 'create', 'update', 'delete', 'assign', 'approve', 'export'],
+        scope: { ownership: 'all' },
+      },
       { resource: 'dashboard', actions: ['read'], scope: { ownership: 'all' } },
     ],
   },
@@ -334,9 +375,21 @@ const DEFAULT_PERMISSION_GROUPS = {
     name: 'Compliance Manager',
     description: 'Manage controls, evidence, and policies',
     permissions: [
-      { resource: 'controls', actions: ['read', 'create', 'update', 'assign'], scope: { ownership: 'all' } },
-      { resource: 'evidence', actions: ['read', 'create', 'update', 'approve'], scope: { ownership: 'all' } },
-      { resource: 'policies', actions: ['read', 'create', 'update', 'approve'], scope: { ownership: 'all' } },
+      {
+        resource: 'controls',
+        actions: ['read', 'create', 'update', 'assign'],
+        scope: { ownership: 'all' },
+      },
+      {
+        resource: 'evidence',
+        actions: ['read', 'create', 'update', 'approve'],
+        scope: { ownership: 'all' },
+      },
+      {
+        resource: 'policies',
+        actions: ['read', 'create', 'update', 'approve'],
+        scope: { ownership: 'all' },
+      },
       { resource: 'frameworks', actions: ['read'], scope: { ownership: 'all' } },
       { resource: 'integrations', actions: ['read'], scope: { ownership: 'all' } },
       { resource: 'audit_logs', actions: ['read'], scope: { ownership: 'all' } },
@@ -360,7 +413,11 @@ const DEFAULT_PERMISSION_GROUPS = {
     description: 'Edit assigned controls and link evidence',
     permissions: [
       { resource: 'controls', actions: ['read', 'update'], scope: { ownership: 'assigned' } },
-      { resource: 'evidence', actions: ['read', 'create', 'update'], scope: { ownership: 'owned' } },
+      {
+        resource: 'evidence',
+        actions: ['read', 'create', 'update'],
+        scope: { ownership: 'owned' },
+      },
       { resource: 'policies', actions: ['read'], scope: { ownership: 'all' } },
       { resource: 'frameworks', actions: ['read'], scope: { ownership: 'all' } },
       { resource: 'dashboard', actions: ['read'], scope: { ownership: 'all' } },
@@ -441,13 +498,22 @@ async function main() {
     console.log('\n╔════════════════════════════════════════════════════════╗');
     console.log('║                    Seeding Complete!                   ║');
     console.log('╠════════════════════════════════════════════════════════╣');
-    console.log(`║  Frameworks:        ${frameworks.toString().padStart(4)}                             ║`);
-    console.log(`║  Requirements:      ${requirements.toString().padStart(4)}                             ║`);
-    console.log(`║  Controls:          ${controls.toString().padStart(4)}                             ║`);
-    console.log(`║  Mappings:          ${mappings.toString().padStart(4)}                             ║`);
-    console.log(`║  Permission Groups: ${permGroups.toString().padStart(4)}                             ║`);
+    console.log(
+      `║  Frameworks:        ${frameworks.toString().padStart(4)}                             ║`
+    );
+    console.log(
+      `║  Requirements:      ${requirements.toString().padStart(4)}                             ║`
+    );
+    console.log(
+      `║  Controls:          ${controls.toString().padStart(4)}                             ║`
+    );
+    console.log(
+      `║  Mappings:          ${mappings.toString().padStart(4)}                             ║`
+    );
+    console.log(
+      `║  Permission Groups: ${permGroups.toString().padStart(4)}                             ║`
+    );
     console.log('╚════════════════════════════════════════════════════════╝');
-
   } catch (error) {
     console.error('\n❌ Seeding failed:', error);
     throw error;
@@ -462,4 +528,3 @@ main()
   .finally(async () => {
     await prisma.$disconnect();
   });
-

--- a/services/audit/src/audits/audits.service.spec.ts
+++ b/services/audit/src/audits/audits.service.spec.ts
@@ -43,6 +43,7 @@ describe('AuditsService', () => {
 
   describe('create', () => {
     const mockCreateDto = {
+      name: 'Q1 SOC 2 Audit',
       title: 'Q1 SOC 2 Audit',
       auditType: 'soc2',
       description: 'Annual SOC 2 Type II audit',
@@ -76,7 +77,7 @@ describe('AuditsService', () => {
             auditId: 'AUD-001',
             organizationId: 'org-123',
           }),
-        }),
+        })
       );
       expect(result).toEqual(mockCreatedAudit);
     });
@@ -96,7 +97,7 @@ describe('AuditsService', () => {
           data: expect.objectContaining({
             auditId: 'CUSTOM-001',
           }),
-        }),
+        })
       );
     });
 
@@ -111,7 +112,7 @@ describe('AuditsService', () => {
           data: expect.objectContaining({
             portalAccessCode: expect.any(String),
           }),
-        }),
+        })
       );
     });
 
@@ -129,7 +130,7 @@ describe('AuditsService', () => {
           data: expect.objectContaining({
             portalAccessCode: null,
           }),
-        }),
+        })
       );
     });
   });
@@ -305,7 +306,7 @@ describe('AuditsService', () => {
             lowFindings: 4,
             actualEndDate: expect.any(Date),
           }),
-        }),
+        })
       );
     });
 
@@ -324,7 +325,7 @@ describe('AuditsService', () => {
             plannedStartDate: expect.any(Date),
             plannedEndDate: expect.any(Date),
           }),
-        }),
+        })
       );
     });
   });

--- a/services/audit/src/requests/requests.controller.ts
+++ b/services/audit/src/requests/requests.controller.ts
@@ -47,7 +47,7 @@ export class RequestsController {
     @Query('auditId') auditId?: string,
     @Query('status') status?: string,
     @Query('assignedTo') assignedTo?: string,
-    @Query('category') category?: string,
+    @Query('category') category?: string
   ) {
     const { organizationId } = req.user;
     return this.requestsService.findAll(organizationId, {
@@ -72,7 +72,7 @@ export class RequestsController {
   update(
     @Param('id') id: string,
     @Body() updateRequestDto: UpdateAuditRequestDto,
-    @Req() req: AuthenticatedRequest,
+    @Req() req: AuthenticatedRequest
   ) {
     const { organizationId } = req.user;
     return this.requestsService.update(id, organizationId, updateRequestDto);
@@ -92,7 +92,7 @@ export class RequestsController {
   addComment(
     @Param('id') requestId: string,
     @Body() body: { content: string; isInternal?: boolean },
-    @Req() req: AuthenticatedRequest,
+    @Req() req: AuthenticatedRequest
   ) {
     return this.requestsService.addComment(requestId, {
       content: body.content,
@@ -106,7 +106,9 @@ export class RequestsController {
   @Get(':id/comments')
   @ApiOperation({ summary: 'Get request comments' })
   @ApiResponse({ status: 200, description: 'Returns comments' })
-  getComments(@Param('id') requestId: string) {
-    return this.requestsService.getComments(requestId);
+  getComments(@Param('id') requestId: string, @Req() req: AuthenticatedRequest) {
+    // SECURITY: Pass organizationId to ensure tenant isolation (IDOR prevention)
+    const { organizationId } = req.user;
+    return this.requestsService.getComments(requestId, organizationId);
   }
 }

--- a/services/controls/src/collectors/dto/collector.dto.ts
+++ b/services/controls/src/collectors/dto/collector.dto.ts
@@ -1,14 +1,25 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsString, IsOptional, IsBoolean, IsIn, IsObject, IsUUID } from 'class-validator';
+import {
+  IsString,
+  IsOptional,
+  IsBoolean,
+  IsIn,
+  IsObject,
+  IsUUID,
+  IsUrl,
+  MaxLength,
+} from 'class-validator';
 
 export class CreateCollectorDto {
   @ApiProperty({ description: 'Name of the evidence collector' })
   @IsString()
+  @MaxLength(500)
   name: string;
 
   @ApiPropertyOptional({ description: 'Description of what this collector does' })
   @IsOptional()
   @IsString()
+  @MaxLength(5000)
   description?: string;
 
   @ApiProperty({ enum: ['standalone', 'integration'], description: 'Configuration mode' })
@@ -23,7 +34,7 @@ export class CreateCollectorDto {
 
   @ApiPropertyOptional({ description: 'Base URL for API calls (standalone mode)' })
   @IsOptional()
-  @IsString()
+  @IsUrl({}, { message: 'Must be a valid URL' })
   baseUrl?: string;
 
   @ApiPropertyOptional({ description: 'API endpoint path' })
@@ -52,7 +63,10 @@ export class CreateCollectorDto {
   @IsObject()
   body?: Record<string, unknown>;
 
-  @ApiPropertyOptional({ enum: ['api_key', 'oauth2', 'bearer', 'basic'], description: 'Authentication type (standalone mode)' })
+  @ApiPropertyOptional({
+    enum: ['api_key', 'oauth2', 'bearer', 'basic'],
+    description: 'Authentication type (standalone mode)',
+  })
   @IsOptional()
   @IsString()
   @IsIn(['api_key', 'oauth2', 'bearer', 'basic'])
@@ -72,7 +86,9 @@ export class CreateCollectorDto {
     dataField?: string; // JSONPath to extract main data
   };
 
-  @ApiPropertyOptional({ description: 'Template for evidence title (use {{field}} for interpolation)' })
+  @ApiPropertyOptional({
+    description: 'Template for evidence title (use {{field}} for interpolation)',
+  })
   @IsOptional()
   @IsString()
   evidenceTitle?: string;
@@ -87,7 +103,10 @@ export class CreateCollectorDto {
   @IsBoolean()
   scheduleEnabled?: boolean;
 
-  @ApiPropertyOptional({ enum: ['daily', 'weekly', 'monthly', 'custom'], description: 'Schedule frequency' })
+  @ApiPropertyOptional({
+    enum: ['daily', 'weekly', 'monthly', 'custom'],
+    description: 'Schedule frequency',
+  })
   @IsOptional()
   @IsString()
   @IsIn(['daily', 'weekly', 'monthly', 'custom'])
@@ -103,11 +122,13 @@ export class UpdateCollectorDto {
   @ApiPropertyOptional({ description: 'Name of the evidence collector' })
   @IsOptional()
   @IsString()
+  @MaxLength(500)
   name?: string;
 
   @ApiPropertyOptional({ description: 'Description of what this collector does' })
   @IsOptional()
   @IsString()
+  @MaxLength(5000)
   description?: string;
 
   @ApiPropertyOptional({ enum: ['standalone', 'integration'], description: 'Configuration mode' })
@@ -123,7 +144,7 @@ export class UpdateCollectorDto {
 
   @ApiPropertyOptional({ description: 'Base URL for API calls (standalone mode)' })
   @IsOptional()
-  @IsString()
+  @IsUrl({}, { message: 'Must be a valid URL' })
   baseUrl?: string;
 
   @ApiPropertyOptional({ description: 'API endpoint path' })
@@ -343,7 +364,7 @@ export class CollectorRunResponseDto {
 export class TestCollectorDto {
   @ApiPropertyOptional({ description: 'Override base URL for testing' })
   @IsOptional()
-  @IsString()
+  @IsUrl({}, { message: 'Must be a valid URL' })
   baseUrl?: string;
 
   @ApiPropertyOptional({ description: 'Override auth config for testing' })

--- a/services/controls/src/controls/controls.service.ts
+++ b/services/controls/src/controls/controls.service.ts
@@ -339,9 +339,16 @@ export class ControlsService {
       throw new ConflictException(`Control with ID ${dto.controlId} already exists`);
     }
 
+    // SECURITY: Explicit field mapping to prevent mass assignment vulnerabilities
     const control = await this.prisma.control.create({
       data: {
-        ...dto,
+        controlId: dto.controlId,
+        title: dto.title,
+        description: dto.description,
+        category: dto.category,
+        subcategory: dto.subcategory,
+        guidance: dto.guidance,
+        automationSupported: dto.automationSupported,
         organizationId,
         isCustom: true,
         tags: dto.tags || [],
@@ -392,10 +399,16 @@ export class ControlsService {
       throw new ConflictException('Cannot modify controls from another organization');
     }
 
+    // SECURITY: Explicit field mapping to prevent mass assignment vulnerabilities
     const updatedControl = await this.prisma.control.update({
       where: { id },
       data: {
-        ...dto,
+        title: dto.title,
+        description: dto.description,
+        category: dto.category,
+        subcategory: dto.subcategory,
+        guidance: dto.guidance,
+        automationSupported: dto.automationSupported,
         tags: dto.tags || undefined,
       },
     });

--- a/services/controls/src/controls/dto/control.dto.ts
+++ b/services/controls/src/controls/dto/control.dto.ts
@@ -44,6 +44,7 @@ export class CreateControlDto {
   @ApiProperty({ description: 'Detailed description of the control' })
   @IsString()
   @IsNotEmpty()
+  @MaxLength(5000)
   description: string;
 
   @ApiProperty({ enum: ControlCategory, example: ControlCategory.ACCESS_CONTROL })
@@ -65,6 +66,7 @@ export class CreateControlDto {
   @ApiPropertyOptional({ description: 'Implementation guidance' })
   @IsOptional()
   @IsString()
+  @MaxLength(5000)
   guidance?: string;
 
   @ApiPropertyOptional({ default: false })
@@ -83,6 +85,7 @@ export class UpdateControlDto {
   @ApiPropertyOptional()
   @IsOptional()
   @IsString()
+  @MaxLength(5000)
   description?: string;
 
   @ApiPropertyOptional({ enum: ControlCategory })
@@ -105,6 +108,7 @@ export class UpdateControlDto {
   @ApiPropertyOptional()
   @IsOptional()
   @IsString()
+  @MaxLength(5000)
   guidance?: string;
 
   @ApiPropertyOptional()
@@ -135,7 +139,7 @@ export class ControlFilterDto {
   @IsString()
   frameworkId?: string;
 
-  @ApiPropertyOptional({ 
+  @ApiPropertyOptional({
     description: 'Filter by implementation status (can be single value or array)',
     enum: ['implemented', 'in_progress', 'not_started', 'not_applicable'],
   })
@@ -188,6 +192,7 @@ export class BulkControlItemDto {
   @ApiProperty({ description: 'Detailed description of the control' })
   @IsString()
   @IsNotEmpty()
+  @MaxLength(5000)
   description: string;
 
   @ApiProperty({ enum: ControlCategory, example: ControlCategory.ACCESS_CONTROL })
@@ -209,6 +214,7 @@ export class BulkControlItemDto {
   @ApiPropertyOptional({ description: 'Implementation guidance' })
   @IsOptional()
   @IsString()
+  @MaxLength(5000)
   guidance?: string;
 
   @ApiPropertyOptional({ default: false })
@@ -218,24 +224,24 @@ export class BulkControlItemDto {
 }
 
 export class BulkUploadControlsDto {
-  @ApiProperty({ 
-    type: [BulkControlItemDto], 
-    description: 'Array of controls to import' 
+  @ApiProperty({
+    type: [BulkControlItemDto],
+    description: 'Array of controls to import',
   })
   @IsArray()
   controls: BulkControlItemDto[];
 
-  @ApiPropertyOptional({ 
-    default: false, 
-    description: 'Skip controls that already exist instead of failing' 
+  @ApiPropertyOptional({
+    default: false,
+    description: 'Skip controls that already exist instead of failing',
   })
   @IsOptional()
   @IsBoolean()
   skipExisting?: boolean;
 
-  @ApiPropertyOptional({ 
-    default: false, 
-    description: 'Update existing controls instead of skipping' 
+  @ApiPropertyOptional({
+    default: false,
+    description: 'Update existing controls instead of skipping',
   })
   @IsOptional()
   @IsBoolean()
@@ -262,4 +268,3 @@ export class BulkUploadResultDto {
     row?: number;
   }>;
 }
-

--- a/services/controls/src/custom-dashboards/dto/dashboard.dto.ts
+++ b/services/controls/src/custom-dashboards/dto/dashboard.dto.ts
@@ -8,6 +8,8 @@ import {
   IsNumber,
   ValidateNested,
   IsEnum,
+  IsUrl,
+  MaxLength,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 
@@ -171,6 +173,7 @@ export class DataQueryDto {
   @ApiPropertyOptional({ description: 'Raw SQL for advanced users' })
   @IsOptional()
   @IsString()
+  @MaxLength(10000)
   rawQuery?: string;
 }
 
@@ -233,7 +236,7 @@ export class WidgetConfigDto {
 
   @ApiPropertyOptional({ description: 'IFrame URL' })
   @IsOptional()
-  @IsString()
+  @IsUrl({}, { message: 'Must be a valid URL' })
   iframeUrl?: string;
 
   @ApiPropertyOptional({ description: 'Show legend' })
@@ -468,4 +471,3 @@ export class DataSourceDefinitionDto {
     aggregatable: boolean;
   }[];
 }
-

--- a/services/controls/src/evidence/dto/evidence.dto.ts
+++ b/services/controls/src/evidence/dto/evidence.dto.ts
@@ -51,6 +51,7 @@ export class UploadEvidenceDto {
   @ApiPropertyOptional()
   @IsOptional()
   @IsString()
+  @MaxLength(5000)
   description?: string;
 
   @ApiProperty({ enum: EvidenceType, example: EvidenceType.SCREENSHOT })
@@ -101,6 +102,7 @@ export class UpdateEvidenceDto {
   @ApiPropertyOptional()
   @IsOptional()
   @IsString()
+  @MaxLength(5000)
   description?: string;
 
   @ApiPropertyOptional({ enum: EvidenceType })
@@ -134,6 +136,7 @@ export class ReviewEvidenceDto {
   @ApiPropertyOptional()
   @IsOptional()
   @IsString()
+  @MaxLength(5000)
   notes?: string;
 }
 
@@ -146,6 +149,7 @@ export class LinkEvidenceDto {
   @ApiPropertyOptional()
   @IsOptional()
   @IsString()
+  @MaxLength(5000)
   notes?: string;
 }
 
@@ -234,6 +238,3 @@ export class EvidenceFilterDto {
   @IsOptional()
   sortOrder?: 'asc' | 'desc';
 }
-
-
-

--- a/services/controls/src/integrations/connectors/crowdstrike.connector.ts
+++ b/services/controls/src/integrations/connectors/crowdstrike.connector.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, BadRequestException } from '@nestjs/common';
+import { safeFetch, SSRFProtectionError } from '@gigachad-grc/shared';
 
 /**
  * CrowdStrike Integration Configuration
@@ -7,7 +8,7 @@ import { Injectable, Logger } from '@nestjs/common';
 export interface CrowdStrikeConfig {
   clientId: string;
   clientSecret: string;
-  baseUrl?: string;  // e.g., https://api.crowdstrike.com or https://api.us-2.crowdstrike.com
+  baseUrl?: string; // e.g., https://api.crowdstrike.com or https://api.us-2.crowdstrike.com
 }
 
 /**
@@ -180,9 +181,17 @@ export class CrowdStrikeConnector {
 
       // Test by getting sensor info
       const baseUrl = config.baseUrl || this.DEFAULT_BASE_URL;
-      const response = await fetch(`${baseUrl}/sensors/queries/sensors/v1?limit=1`, {
-        headers: this.buildHeaders(token),
-      });
+      let response: Response;
+      try {
+        response = await safeFetch(`${baseUrl}/sensors/queries/sensors/v1?limit=1`, {
+          headers: this.buildHeaders(token),
+        });
+      } catch (error) {
+        if (error instanceof SSRFProtectionError) {
+          throw new BadRequestException(`SSRF protection blocked: ${error.message}`);
+        }
+        throw error;
+      }
 
       if (!response.ok) {
         return { success: false, message: `API error: ${response.status}` };
@@ -197,6 +206,9 @@ export class CrowdStrikeConnector {
       };
     } catch (error: any) {
       this.logger.error('CrowdStrike connection test failed', error);
+      if (error instanceof BadRequestException) {
+        throw error;
+      }
       return { success: false, message: error.message || 'Connection failed' };
     }
   }
@@ -217,54 +229,61 @@ export class CrowdStrikeConnector {
 
     // Collect data in parallel
     const [devices, detections, vulnerabilities] = await Promise.all([
-      this.getDevices(baseUrl, token).catch(e => {
+      this.getDevices(baseUrl, token).catch((e) => {
         errors.push(`Devices: ${e.message}`);
         return [] as CrowdStrikeDevice[];
       }),
-      this.getDetections(baseUrl, token).catch(e => {
+      this.getDetections(baseUrl, token).catch((e) => {
         errors.push(`Detections: ${e.message}`);
         return [] as CrowdStrikeDetection[];
       }),
-      this.getVulnerabilities(baseUrl, token).catch(e => {
+      this.getVulnerabilities(baseUrl, token).catch((e) => {
         errors.push(`Vulnerabilities: ${e.message}`);
         return [] as CrowdStrikeVulnerability[];
       }),
     ]);
 
     // Process devices
-    const onlineDevices = devices.filter(d => d.status === 'normal' || d.status === 'contained');
-    const offlineDevices = devices.filter(d => d.status === 'offline' || d.status === 'unknown');
-    const reducedFunctionality = devices.filter(d => d.reduced_functionality_mode === 'yes');
-    
+    const onlineDevices = devices.filter((d) => d.status === 'normal' || d.status === 'contained');
+    const offlineDevices = devices.filter((d) => d.status === 'offline' || d.status === 'unknown');
+    const reducedFunctionality = devices.filter((d) => d.reduced_functionality_mode === 'yes');
+
     const byPlatform: Record<string, number> = {};
     for (const device of devices) {
       byPlatform[device.platform_name] = (byPlatform[device.platform_name] || 0) + 1;
     }
 
-    const withPrevention = devices.filter(d => d.device_policies?.prevention?.applied).length;
+    const withPrevention = devices.filter((d) => d.device_policies?.prevention?.applied).length;
 
     // Process detections
     const severityMap: Record<number, string> = {
-      1: 'informational', 2: 'informational',
-      3: 'low', 4: 'low',
-      5: 'medium', 6: 'medium',
-      7: 'high', 8: 'high',
-      9: 'critical', 10: 'critical',
+      1: 'informational',
+      2: 'informational',
+      3: 'low',
+      4: 'low',
+      5: 'medium',
+      6: 'medium',
+      7: 'high',
+      8: 'high',
+      9: 'critical',
+      10: 'critical',
     };
 
-    const criticalDetections = detections.filter(d => d.max_severity >= 9);
-    const highDetections = detections.filter(d => d.max_severity >= 7 && d.max_severity < 9);
-    const mediumDetections = detections.filter(d => d.max_severity >= 5 && d.max_severity < 7);
-    const lowDetections = detections.filter(d => d.max_severity >= 3 && d.max_severity < 5);
-    const infoDetections = detections.filter(d => d.max_severity < 3);
+    const criticalDetections = detections.filter((d) => d.max_severity >= 9);
+    const highDetections = detections.filter((d) => d.max_severity >= 7 && d.max_severity < 9);
+    const mediumDetections = detections.filter((d) => d.max_severity >= 5 && d.max_severity < 7);
+    const lowDetections = detections.filter((d) => d.max_severity >= 3 && d.max_severity < 5);
+    const infoDetections = detections.filter((d) => d.max_severity < 3);
 
     // Process vulnerabilities
-    const criticalVulns = vulnerabilities.filter(v => v.cve?.severity === 'CRITICAL');
-    const highVulns = vulnerabilities.filter(v => v.cve?.severity === 'HIGH');
-    const mediumVulns = vulnerabilities.filter(v => v.cve?.severity === 'MEDIUM');
-    const lowVulns = vulnerabilities.filter(v => v.cve?.severity === 'LOW');
+    const criticalVulns = vulnerabilities.filter((v) => v.cve?.severity === 'CRITICAL');
+    const highVulns = vulnerabilities.filter((v) => v.cve?.severity === 'HIGH');
+    const mediumVulns = vulnerabilities.filter((v) => v.cve?.severity === 'MEDIUM');
+    const lowVulns = vulnerabilities.filter((v) => v.cve?.severity === 'LOW');
 
-    this.logger.log(`CrowdStrike sync complete: ${devices.length} devices, ${detections.length} detections`);
+    this.logger.log(
+      `CrowdStrike sync complete: ${devices.length} devices, ${detections.length} detections`
+    );
 
     return {
       devices: {
@@ -274,7 +293,7 @@ export class CrowdStrikeConnector {
         reduced_functionality: reducedFunctionality.length,
         byPlatform,
         withPreventionPolicy: withPrevention,
-        items: devices.slice(0, 100).map(d => ({
+        items: devices.slice(0, 100).map((d) => ({
           id: d.device_id,
           hostname: d.hostname,
           platform: d.platform_name,
@@ -292,10 +311,13 @@ export class CrowdStrikeConnector {
         medium: mediumDetections.length,
         low: lowDetections.length,
         informational: infoDetections.length,
-        newDetections: detections.filter(d => d.status === 'new').length,
-        inProgress: detections.filter(d => d.status === 'in_progress').length,
-        resolved: detections.filter(d => d.status === 'closed' || d.status === 'true_positive' || d.status === 'false_positive').length,
-        items: detections.slice(0, 50).map(d => ({
+        newDetections: detections.filter((d) => d.status === 'new').length,
+        inProgress: detections.filter((d) => d.status === 'in_progress').length,
+        resolved: detections.filter(
+          (d) =>
+            d.status === 'closed' || d.status === 'true_positive' || d.status === 'false_positive'
+        ).length,
+        items: detections.slice(0, 50).map((d) => ({
           id: d.detection_id,
           hostname: d.device?.hostname || 'Unknown',
           severity: severityMap[d.max_severity] || 'unknown',
@@ -312,7 +334,7 @@ export class CrowdStrikeConnector {
         high: highVulns.length,
         medium: mediumVulns.length,
         low: lowVulns.length,
-        items: vulnerabilities.slice(0, 100).map(v => ({
+        items: vulnerabilities.slice(0, 100).map((v) => ({
           cveId: v.cve?.id || v.id,
           severity: v.cve?.severity || 'unknown',
           score: v.cve?.base_score || 0,
@@ -324,9 +346,8 @@ export class CrowdStrikeConnector {
       prevention: {
         policiesApplied: withPrevention,
         devicesProtected: withPrevention,
-        protectionPercentage: devices.length > 0 
-          ? Math.round((withPrevention / devices.length) * 100) 
-          : 0,
+        protectionPercentage:
+          devices.length > 0 ? Math.round((withPrevention / devices.length) * 100) : 0,
       },
       collectedAt: new Date().toISOString(),
       errors,
@@ -340,16 +361,24 @@ export class CrowdStrikeConnector {
     const baseUrl = config.baseUrl || this.DEFAULT_BASE_URL;
 
     try {
-      const response = await fetch(`${baseUrl}/oauth2/token`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-        },
-        body: new URLSearchParams({
-          client_id: config.clientId,
-          client_secret: config.clientSecret,
-        }),
-      });
+      let response: Response;
+      try {
+        response = await safeFetch(`${baseUrl}/oauth2/token`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+          },
+          body: new URLSearchParams({
+            client_id: config.clientId,
+            client_secret: config.clientSecret,
+          }),
+        });
+      } catch (error) {
+        if (error instanceof SSRFProtectionError) {
+          throw new BadRequestException(`SSRF protection blocked: ${error.message}`);
+        }
+        throw error;
+      }
 
       if (!response.ok) {
         this.logger.error(`CrowdStrike OAuth failed: ${response.status}`);
@@ -359,6 +388,9 @@ export class CrowdStrikeConnector {
       const data = await response.json();
       return data.access_token;
     } catch (error) {
+      if (error instanceof BadRequestException) {
+        throw error;
+      }
       this.logger.error('Failed to get CrowdStrike access token', error);
       return null;
     }
@@ -369,10 +401,17 @@ export class CrowdStrikeConnector {
    */
   private async getDevices(baseUrl: string, token: string): Promise<CrowdStrikeDevice[]> {
     // First get device IDs
-    const idsResponse = await fetch(
-      `${baseUrl}/devices/queries/devices/v1?limit=500`,
-      { headers: this.buildHeaders(token) },
-    );
+    let idsResponse: Response;
+    try {
+      idsResponse = await safeFetch(`${baseUrl}/devices/queries/devices/v1?limit=500`, {
+        headers: this.buildHeaders(token),
+      });
+    } catch (error) {
+      if (error instanceof SSRFProtectionError) {
+        throw new BadRequestException(`SSRF protection blocked: ${error.message}`);
+      }
+      throw error;
+    }
 
     if (!idsResponse.ok) {
       throw new Error(`Failed to fetch device IDs: ${idsResponse.status}`);
@@ -389,14 +428,19 @@ export class CrowdStrikeConnector {
     const devices: CrowdStrikeDevice[] = [];
     for (let i = 0; i < deviceIds.length; i += 100) {
       const batch = deviceIds.slice(i, i + 100);
-      const detailsResponse = await fetch(
-        `${baseUrl}/devices/entities/devices/v2`,
-        {
+      let detailsResponse: Response;
+      try {
+        detailsResponse = await safeFetch(`${baseUrl}/devices/entities/devices/v2`, {
           method: 'POST',
           headers: this.buildHeaders(token),
           body: JSON.stringify({ ids: batch }),
-        },
-      );
+        });
+      } catch (error) {
+        if (error instanceof SSRFProtectionError) {
+          throw new BadRequestException(`SSRF protection blocked: ${error.message}`);
+        }
+        throw error;
+      }
 
       if (detailsResponse.ok) {
         const detailsData = await detailsResponse.json();
@@ -413,11 +457,19 @@ export class CrowdStrikeConnector {
   private async getDetections(baseUrl: string, token: string): Promise<CrowdStrikeDetection[]> {
     // Get detection IDs from last 30 days
     const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
-    
-    const idsResponse = await fetch(
-      `${baseUrl}/detects/queries/detects/v1?limit=200&filter=created_timestamp:>'${thirtyDaysAgo}'`,
-      { headers: this.buildHeaders(token) },
-    );
+
+    let idsResponse: Response;
+    try {
+      idsResponse = await safeFetch(
+        `${baseUrl}/detects/queries/detects/v1?limit=200&filter=created_timestamp:>'${thirtyDaysAgo}'`,
+        { headers: this.buildHeaders(token) }
+      );
+    } catch (error) {
+      if (error instanceof SSRFProtectionError) {
+        throw new BadRequestException(`SSRF protection blocked: ${error.message}`);
+      }
+      throw error;
+    }
 
     if (!idsResponse.ok) {
       throw new Error(`Failed to fetch detection IDs: ${idsResponse.status}`);
@@ -431,14 +483,19 @@ export class CrowdStrikeConnector {
     }
 
     // Get detection details
-    const detailsResponse = await fetch(
-      `${baseUrl}/detects/entities/summaries/GET/v1`,
-      {
+    let detailsResponse: Response;
+    try {
+      detailsResponse = await safeFetch(`${baseUrl}/detects/entities/summaries/GET/v1`, {
         method: 'POST',
         headers: this.buildHeaders(token),
         body: JSON.stringify({ ids: detectionIds.slice(0, 100) }),
-      },
-    );
+      });
+    } catch (error) {
+      if (error instanceof SSRFProtectionError) {
+        throw new BadRequestException(`SSRF protection blocked: ${error.message}`);
+      }
+      throw error;
+    }
 
     if (!detailsResponse.ok) {
       throw new Error(`Failed to fetch detection details: ${detailsResponse.status}`);
@@ -451,12 +508,23 @@ export class CrowdStrikeConnector {
   /**
    * Get vulnerabilities (Spotlight)
    */
-  private async getVulnerabilities(baseUrl: string, token: string): Promise<CrowdStrikeVulnerability[]> {
+  private async getVulnerabilities(
+    baseUrl: string,
+    token: string
+  ): Promise<CrowdStrikeVulnerability[]> {
     try {
-      const response = await fetch(
-        `${baseUrl}/spotlight/queries/vulnerabilities/v1?limit=200&filter=status:'open'`,
-        { headers: this.buildHeaders(token) },
-      );
+      let response: Response;
+      try {
+        response = await safeFetch(
+          `${baseUrl}/spotlight/queries/vulnerabilities/v1?limit=200&filter=status:'open'`,
+          { headers: this.buildHeaders(token) }
+        );
+      } catch (error) {
+        if (error instanceof SSRFProtectionError) {
+          throw new BadRequestException(`SSRF protection blocked: ${error.message}`);
+        }
+        throw error;
+      }
 
       if (!response.ok) {
         // Spotlight might not be enabled
@@ -474,10 +542,18 @@ export class CrowdStrikeConnector {
       }
 
       // Get vulnerability details
-      const detailsResponse = await fetch(
-        `${baseUrl}/spotlight/entities/vulnerabilities/v2?ids=${vulnIds.slice(0, 100).join('&ids=')}`,
-        { headers: this.buildHeaders(token) },
-      );
+      let detailsResponse: Response;
+      try {
+        detailsResponse = await safeFetch(
+          `${baseUrl}/spotlight/entities/vulnerabilities/v2?ids=${vulnIds.slice(0, 100).join('&ids=')}`,
+          { headers: this.buildHeaders(token) }
+        );
+      } catch (error) {
+        if (error instanceof SSRFProtectionError) {
+          throw new BadRequestException(`SSRF protection blocked: ${error.message}`);
+        }
+        throw error;
+      }
 
       if (!detailsResponse.ok) {
         return [];
@@ -485,7 +561,10 @@ export class CrowdStrikeConnector {
 
       const detailsData = await detailsResponse.json();
       return detailsData.resources || [];
-    } catch {
+    } catch (error) {
+      if (error instanceof BadRequestException) {
+        throw error;
+      }
       this.logger.warn('Spotlight vulnerabilities not available');
       return [];
     }
@@ -496,10 +575,9 @@ export class CrowdStrikeConnector {
    */
   private buildHeaders(token: string): Record<string, string> {
     return {
-      'Authorization': `Bearer ${token}`,
-      'Accept': 'application/json',
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/json',
       'Content-Type': 'application/json',
     };
   }
 }
-

--- a/services/controls/src/integrations/connectors/jira.connector.ts
+++ b/services/controls/src/integrations/connectors/jira.connector.ts
@@ -1,13 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, BadRequestException } from '@nestjs/common';
+import { safeFetch, SSRFProtectionError } from '@gigachad-grc/shared';
 
 /**
  * Jira Integration Configuration
  */
 export interface JiraConfig {
-  domain: string;       // e.g., "company.atlassian.net"
-  email: string;        // Atlassian account email
-  apiToken: string;     // API token from Atlassian
+  domain: string; // e.g., "company.atlassian.net"
+  email: string; // Atlassian account email
+  apiToken: string; // API token from Atlassian
   projectKeys?: string[]; // Optional: specific projects to sync
 }
 
@@ -91,8 +92,8 @@ export interface JiraSyncResult {
     }>;
   };
   slaMetrics: {
-    avgResolutionTime: number;  // in days
-    onTimeResolution: number;   // percentage
+    avgResolutionTime: number; // in days
+    onTimeResolution: number; // percentage
     openOverdue: number;
   };
   recentActivity: {
@@ -122,27 +123,46 @@ export class JiraConnector {
 
     try {
       const baseUrl = this.getBaseUrl(config.domain);
-      
+
       // Test by getting myself
-      const response = await fetch(`${baseUrl}/rest/api/3/myself`, {
-        headers: this.buildHeaders(config.email, config.apiToken),
-      });
+      let response: Response;
+      try {
+        response = await safeFetch(`${baseUrl}/rest/api/3/myself`, {
+          headers: this.buildHeaders(config.email, config.apiToken),
+        });
+      } catch (error) {
+        if (error instanceof SSRFProtectionError) {
+          throw new BadRequestException(`SSRF protection blocked: ${error.message}`);
+        }
+        throw error;
+      }
 
       if (!response.ok) {
         if (response.status === 401) {
           return { success: false, message: 'Invalid credentials' };
         }
         const error = await response.text();
-        return { success: false, message: `API error: ${response.status} - ${error.substring(0, 100)}` };
+        return {
+          success: false,
+          message: `API error: ${response.status} - ${error.substring(0, 100)}`,
+        };
       }
 
       const user = await response.json();
 
       // Get project count
-      const projectsResponse = await fetch(`${baseUrl}/rest/api/3/project?maxResults=1`, {
-        headers: this.buildHeaders(config.email, config.apiToken),
-      });
-      
+      let projectsResponse: Response;
+      try {
+        projectsResponse = await safeFetch(`${baseUrl}/rest/api/3/project?maxResults=1`, {
+          headers: this.buildHeaders(config.email, config.apiToken),
+        });
+      } catch (error) {
+        if (error instanceof SSRFProtectionError) {
+          throw new BadRequestException(`SSRF protection blocked: ${error.message}`);
+        }
+        throw error;
+      }
+
       let projectCount = 0;
       if (projectsResponse.ok) {
         const projects = await projectsResponse.json();
@@ -161,6 +181,9 @@ export class JiraConnector {
       };
     } catch (error: any) {
       this.logger.error('Jira connection test failed', error);
+      if (error instanceof BadRequestException) {
+        throw error;
+      }
       return { success: false, message: error.message || 'Connection failed' };
     }
   }
@@ -175,19 +198,19 @@ export class JiraConnector {
     this.logger.log('Starting Jira sync...');
 
     // Get projects
-    const projects = await this.getProjects(baseUrl, config).catch(e => {
+    const projects = await this.getProjects(baseUrl, config).catch((e) => {
       errors.push(`Projects: ${e.message}`);
       return [] as JiraProject[];
     });
 
     // Get all issues
-    const allIssues = await this.getIssues(baseUrl, config, config.projectKeys).catch(e => {
+    const allIssues = await this.getIssues(baseUrl, config, config.projectKeys).catch((e) => {
       errors.push(`Issues: ${e.message}`);
       return [] as JiraIssue[];
     });
 
     // Get security/compliance related issues
-    const securityIssues = await this.getSecurityIssues(baseUrl, config).catch(e => {
+    const securityIssues = await this.getSecurityIssues(baseUrl, config).catch((e) => {
       errors.push(`Security issues: ${e.message}`);
       return [] as JiraIssue[];
     });
@@ -226,7 +249,11 @@ export class JiraConnector {
 
       // Open/closed
       const statusCategory = statusName.toLowerCase();
-      if (statusCategory.includes('done') || statusCategory.includes('closed') || statusCategory.includes('resolved')) {
+      if (
+        statusCategory.includes('done') ||
+        statusCategory.includes('closed') ||
+        statusCategory.includes('resolved')
+      ) {
         closedIssues++;
       } else {
         openIssues++;
@@ -235,7 +262,11 @@ export class JiraConnector {
       // Overdue
       if (issue.fields.duedate) {
         const dueDate = new Date(issue.fields.duedate);
-        if (dueDate < now && !statusCategory.includes('done') && !statusCategory.includes('closed')) {
+        if (
+          dueDate < now &&
+          !statusCategory.includes('done') &&
+          !statusCategory.includes('closed')
+        ) {
           overdueIssues++;
         }
       }
@@ -243,7 +274,7 @@ export class JiraConnector {
       // Recent activity
       const created = new Date(issue.fields.created);
       const updated = new Date(issue.fields.updated);
-      
+
       if (created > sevenDaysAgo) {
         issuesCreatedLast7Days++;
       }
@@ -276,31 +307,35 @@ export class JiraConnector {
     // Count security/compliance issues
     const securityKeywords = ['security', 'vulnerability', 'cve', 'pentest', 'audit'];
     const complianceKeywords = ['compliance', 'soc2', 'iso', 'gdpr', 'hipaa', 'pci'];
-    
-    const securityRelated = allIssues.filter(i => {
-      const text = `${i.fields.summary} ${i.fields.description || ''} ${i.fields.labels?.join(' ') || ''}`.toLowerCase();
-      return securityKeywords.some(k => text.includes(k));
+
+    const securityRelated = allIssues.filter((i) => {
+      const text =
+        `${i.fields.summary} ${i.fields.description || ''} ${i.fields.labels?.join(' ') || ''}`.toLowerCase();
+      return securityKeywords.some((k) => text.includes(k));
     }).length;
 
-    const complianceRelated = allIssues.filter(i => {
-      const text = `${i.fields.summary} ${i.fields.description || ''} ${i.fields.labels?.join(' ') || ''}`.toLowerCase();
-      return complianceKeywords.some(k => text.includes(k));
+    const complianceRelated = allIssues.filter((i) => {
+      const text =
+        `${i.fields.summary} ${i.fields.description || ''} ${i.fields.labels?.join(' ') || ''}`.toLowerCase();
+      return complianceKeywords.some((k) => text.includes(k));
     }).length;
 
     // Process security issues by priority
-    const criticalSecurity = securityIssues.filter(i => 
-      i.fields.priority?.name?.toLowerCase().includes('critical') || 
-      i.fields.priority?.name?.toLowerCase().includes('highest')
+    const criticalSecurity = securityIssues.filter(
+      (i) =>
+        i.fields.priority?.name?.toLowerCase().includes('critical') ||
+        i.fields.priority?.name?.toLowerCase().includes('highest')
     );
-    const highSecurity = securityIssues.filter(i => 
+    const highSecurity = securityIssues.filter((i) =>
       i.fields.priority?.name?.toLowerCase().includes('high')
     );
-    const mediumSecurity = securityIssues.filter(i => 
+    const mediumSecurity = securityIssues.filter((i) =>
       i.fields.priority?.name?.toLowerCase().includes('medium')
     );
-    const lowSecurity = securityIssues.filter(i => 
-      i.fields.priority?.name?.toLowerCase().includes('low') ||
-      i.fields.priority?.name?.toLowerCase().includes('lowest')
+    const lowSecurity = securityIssues.filter(
+      (i) =>
+        i.fields.priority?.name?.toLowerCase().includes('low') ||
+        i.fields.priority?.name?.toLowerCase().includes('lowest')
     );
 
     this.logger.log(`Jira sync complete: ${projects.length} projects, ${allIssues.length} issues`);
@@ -308,11 +343,11 @@ export class JiraConnector {
     return {
       projects: {
         total: projects.length,
-        items: projects.slice(0, 20).map(p => ({
+        items: projects.slice(0, 20).map((p) => ({
           key: p.key,
           name: p.name,
           lead: p.lead?.displayName || 'Unassigned',
-          issueCount: allIssues.filter(i => i.fields.project?.key === p.key).length,
+          issueCount: allIssues.filter((i) => i.fields.project?.key === p.key).length,
         })),
       },
       issues: {
@@ -332,7 +367,7 @@ export class JiraConnector {
         high: highSecurity.length,
         medium: mediumSecurity.length,
         low: lowSecurity.length,
-        items: securityIssues.slice(0, 50).map(i => ({
+        items: securityIssues.slice(0, 50).map((i) => ({
           key: i.key,
           summary: i.fields.summary,
           priority: i.fields.priority?.name || 'None',
@@ -343,7 +378,8 @@ export class JiraConnector {
         })),
       },
       slaMetrics: {
-        avgResolutionTime: resolvedCount > 0 ? Math.round(totalResolutionTime / resolvedCount * 10) / 10 : 0,
+        avgResolutionTime:
+          resolvedCount > 0 ? Math.round((totalResolutionTime / resolvedCount) * 10) / 10 : 0,
         onTimeResolution: resolvedCount > 0 ? Math.round((onTimeCount / resolvedCount) * 100) : 0,
         openOverdue: overdueIssues,
       },
@@ -361,9 +397,17 @@ export class JiraConnector {
    * Get all projects
    */
   private async getProjects(baseUrl: string, config: JiraConfig): Promise<JiraProject[]> {
-    const response = await fetch(`${baseUrl}/rest/api/3/project?expand=lead`, {
-      headers: this.buildHeaders(config.email, config.apiToken),
-    });
+    let response: Response;
+    try {
+      response = await safeFetch(`${baseUrl}/rest/api/3/project?expand=lead`, {
+        headers: this.buildHeaders(config.email, config.apiToken),
+      });
+    } catch (error) {
+      if (error instanceof SSRFProtectionError) {
+        throw new BadRequestException(`SSRF protection blocked: ${error.message}`);
+      }
+      throw error;
+    }
 
     if (!response.ok) {
       throw new Error(`Failed to fetch projects: ${response.status}`);
@@ -376,9 +420,9 @@ export class JiraConnector {
    * Get issues with JQL query
    */
   private async getIssues(
-    baseUrl: string, 
+    baseUrl: string,
     config: JiraConfig,
-    projectKeys?: string[],
+    projectKeys?: string[]
   ): Promise<JiraIssue[]> {
     const issues: JiraIssue[] = [];
     let startAt = 0;
@@ -391,10 +435,18 @@ export class JiraConnector {
     }
 
     while (issues.length < 1000) {
-      const response = await fetch(
-        `${baseUrl}/rest/api/3/search?jql=${encodeURIComponent(jql)}&startAt=${startAt}&maxResults=${maxResults}&fields=summary,description,issuetype,status,priority,assignee,reporter,created,updated,resolutiondate,duedate,labels,project,components`,
-        { headers: this.buildHeaders(config.email, config.apiToken) },
-      );
+      let response: Response;
+      try {
+        response = await safeFetch(
+          `${baseUrl}/rest/api/3/search?jql=${encodeURIComponent(jql)}&startAt=${startAt}&maxResults=${maxResults}&fields=summary,description,issuetype,status,priority,assignee,reporter,created,updated,resolutiondate,duedate,labels,project,components`,
+          { headers: this.buildHeaders(config.email, config.apiToken) }
+        );
+      } catch (error) {
+        if (error instanceof SSRFProtectionError) {
+          throw new BadRequestException(`SSRF protection blocked: ${error.message}`);
+        }
+        throw error;
+      }
 
       if (!response.ok) {
         throw new Error(`Failed to fetch issues: ${response.status}`);
@@ -420,10 +472,18 @@ export class JiraConnector {
     // Search for issues with security-related labels or summary
     const jql = `(labels IN (security, vulnerability, cve, pentest, audit) OR summary ~ "security" OR summary ~ "vulnerability" OR summary ~ "CVE") AND resolution = Unresolved ORDER BY priority DESC, created DESC`;
 
-    const response = await fetch(
-      `${baseUrl}/rest/api/3/search?jql=${encodeURIComponent(jql)}&maxResults=100&fields=summary,description,issuetype,status,priority,assignee,reporter,created,updated,duedate,labels,project`,
-      { headers: this.buildHeaders(config.email, config.apiToken) },
-    );
+    let response: Response;
+    try {
+      response = await safeFetch(
+        `${baseUrl}/rest/api/3/search?jql=${encodeURIComponent(jql)}&maxResults=100&fields=summary,description,issuetype,status,priority,assignee,reporter,created,updated,duedate,labels,project`,
+        { headers: this.buildHeaders(config.email, config.apiToken) }
+      );
+    } catch (error) {
+      if (error instanceof SSRFProtectionError) {
+        throw new BadRequestException(`SSRF protection blocked: ${error.message}`);
+      }
+      throw error;
+    }
 
     if (!response.ok) {
       // Not a critical error - security issues might not exist
@@ -451,10 +511,9 @@ export class JiraConnector {
   private buildHeaders(email: string, apiToken: string): Record<string, string> {
     const auth = Buffer.from(`${email}:${apiToken}`).toString('base64');
     return {
-      'Authorization': `Basic ${auth}`,
-      'Accept': 'application/json',
+      Authorization: `Basic ${auth}`,
+      Accept: 'application/json',
       'Content-Type': 'application/json',
     };
   }
 }
-

--- a/services/controls/src/integrations/custom/dto/custom-config.dto.ts
+++ b/services/controls/src/integrations/custom/dto/custom-config.dto.ts
@@ -1,5 +1,14 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsString, IsOptional, IsIn, IsArray, ValidateNested, IsObject } from 'class-validator';
+import {
+  IsString,
+  IsOptional,
+  IsIn,
+  IsArray,
+  ValidateNested,
+  IsObject,
+  IsUrl,
+  MaxLength,
+} from 'class-validator';
 import { Type } from 'class-transformer';
 
 // Endpoint configuration for visual mode
@@ -67,7 +76,7 @@ export class ApiKeyAuthConfigDto {
 // OAuth 2.0 authentication config
 export class OAuth2AuthConfigDto {
   @ApiProperty({ description: 'Token endpoint URL' })
-  @IsString()
+  @IsUrl({}, { message: 'Must be a valid URL' })
   tokenUrl: string;
 
   @ApiProperty({ description: 'Client ID' })
@@ -94,7 +103,7 @@ export class SaveCustomConfigDto {
   // Visual mode fields
   @ApiPropertyOptional({ description: 'Base URL for API calls' })
   @IsOptional()
-  @IsString()
+  @IsUrl({}, { message: 'Must be a valid URL' })
   baseUrl?: string;
 
   @ApiPropertyOptional({
@@ -130,6 +139,7 @@ export class SaveCustomConfigDto {
   @ApiPropertyOptional({ description: 'Custom JavaScript code for advanced integrations' })
   @IsOptional()
   @IsString()
+  @MaxLength(50000)
   customCode?: string;
 }
 
@@ -141,7 +151,7 @@ export class TestEndpointDto {
 
   @ApiPropertyOptional({ description: 'Override base URL for testing' })
   @IsOptional()
-  @IsString()
+  @IsUrl({}, { message: 'Must be a valid URL' })
   baseUrl?: string;
 
   // SECURITY: Removed authConfig override - tests must use stored encrypted credentials

--- a/services/controls/src/integrations/servicenow/servicenow.service.ts
+++ b/services/controls/src/integrations/servicenow/servicenow.service.ts
@@ -7,7 +7,7 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
-import { encrypt, decrypt } from '@gigachad-grc/shared';
+import { encrypt, decrypt, safeFetch, SSRFProtectionError } from '@gigachad-grc/shared';
 import {
   ServiceNowConnectionConfigDto,
   ServiceNowConnectionResponseDto,
@@ -128,18 +128,26 @@ export class ServiceNowService {
 
     const credentials = this.decryptCredentials(connection.credentials);
 
-    // Exchange code for tokens
-    const tokenResponse = await fetch(`${connection.instanceUrl}/oauth_token.do`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: new URLSearchParams({
-        grant_type: 'authorization_code',
-        client_id: credentials.clientId || '',
-        client_secret: credentials.clientSecret || '',
-        code,
-        redirect_uri: redirectUri,
-      }).toString(),
-    });
+    // SECURITY: Use safeFetch to prevent SSRF via malicious instanceUrl
+    let tokenResponse: Response;
+    try {
+      tokenResponse = await safeFetch(`${connection.instanceUrl}/oauth_token.do`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          grant_type: 'authorization_code',
+          client_id: credentials.clientId || '',
+          client_secret: credentials.clientSecret || '',
+          code,
+          redirect_uri: redirectUri,
+        }).toString(),
+      });
+    } catch (error) {
+      if (error instanceof SSRFProtectionError) {
+        throw new BadRequestException(`Invalid ServiceNow URL: ${error.message}`);
+      }
+      throw error;
+    }
 
     if (!tokenResponse.ok) {
       throw new BadRequestException('Failed to exchange OAuth code');
@@ -444,16 +452,25 @@ export class ServiceNowService {
     // Decrypt the stored refresh token
     const decryptedRefreshToken = decrypt(connection.refreshToken);
 
-    const response = await fetch(`${connection.instanceUrl}/oauth_token.do`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: new URLSearchParams({
-        grant_type: 'refresh_token',
-        client_id: credentials.clientId || '',
-        client_secret: credentials.clientSecret || '',
-        refresh_token: decryptedRefreshToken,
-      }).toString(),
-    });
+    // SECURITY: Use safeFetch to prevent SSRF
+    let response: Response;
+    try {
+      response = await safeFetch(`${connection.instanceUrl}/oauth_token.do`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          grant_type: 'refresh_token',
+          client_id: credentials.clientId || '',
+          client_secret: credentials.clientSecret || '',
+          refresh_token: decryptedRefreshToken,
+        }).toString(),
+      });
+    } catch (error) {
+      if (error instanceof SSRFProtectionError) {
+        throw new BadRequestException(`Invalid ServiceNow URL: ${error.message}`);
+      }
+      throw error;
+    }
 
     if (!response.ok) {
       await this.prisma.serviceNowConnection.update({
@@ -494,9 +511,13 @@ export class ServiceNowService {
         return { success: true }; // Skip test for OAuth initial setup
       }
 
-      const response = await fetch(`${dto.instanceUrl}/api/now/table/sys_user?sysparm_limit=1`, {
-        headers: { Authorization: auth, Accept: 'application/json' },
-      });
+      // SECURITY: Use safeFetch to prevent SSRF via malicious instanceUrl
+      const response = await safeFetch(
+        `${dto.instanceUrl}/api/now/table/sys_user?sysparm_limit=1`,
+        {
+          headers: { Authorization: auth, Accept: 'application/json' },
+        }
+      );
 
       if (!response.ok) {
         return { success: false, error: `HTTP ${response.status}` };
@@ -504,6 +525,9 @@ export class ServiceNowService {
 
       return { success: true };
     } catch (error: any) {
+      if (error instanceof SSRFProtectionError) {
+        return { success: false, error: `Invalid URL: ${error.message}` };
+      }
       return { success: false, error: error.message };
     }
   }
@@ -535,15 +559,24 @@ export class ServiceNowService {
       throw new UnauthorizedException('No authentication available');
     }
 
-    const response = await fetch(`${connection.instanceUrl}${path}`, {
-      method,
-      headers: {
-        Authorization: auth,
-        'Content-Type': 'application/json',
-        Accept: 'application/json',
-      },
-      body: body ? JSON.stringify(body) : undefined,
-    });
+    // SECURITY: Use safeFetch to prevent SSRF
+    let response: Response;
+    try {
+      response = await safeFetch(`${connection.instanceUrl}${path}`, {
+        method,
+        headers: {
+          Authorization: auth,
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: body ? JSON.stringify(body) : undefined,
+      });
+    } catch (error) {
+      if (error instanceof SSRFProtectionError) {
+        throw new BadRequestException(`Invalid ServiceNow URL: ${error.message}`);
+      }
+      throw error;
+    }
 
     if (!response.ok) {
       throw new Error(`ServiceNow API error: ${response.status}`);

--- a/services/controls/src/mcp/dto/mcp.dto.ts
+++ b/services/controls/src/mcp/dto/mcp.dto.ts
@@ -1,4 +1,15 @@
-import { IsString, IsOptional, IsEnum, IsArray, IsObject, ValidateNested, IsBoolean, IsNumber, MaxLength } from 'class-validator';
+import {
+  IsString,
+  IsOptional,
+  IsEnum,
+  IsArray,
+  IsObject,
+  ValidateNested,
+  IsBoolean,
+  IsNumber,
+  MaxLength,
+  IsUrl,
+} from 'class-validator';
 import { Type } from 'class-transformer';
 
 // Transport types for MCP servers
@@ -121,7 +132,7 @@ export class MCPServerConfigDto {
   @IsOptional()
   args?: string[]; // Command arguments for stdio
 
-  @IsString()
+  @IsUrl({}, { message: 'Must be a valid URL' })
   @IsOptional()
   url?: string; // For SSE/WebSocket transport
 
@@ -164,7 +175,7 @@ export class CreateMCPServerDto {
   @IsOptional()
   args?: string[];
 
-  @IsString()
+  @IsUrl({}, { message: 'Must be a valid URL' })
   @IsOptional()
   url?: string;
 
@@ -201,7 +212,7 @@ export class UpdateMCPServerDto {
   @IsOptional()
   args?: string[];
 
-  @IsString()
+  @IsUrl({}, { message: 'Must be a valid URL' })
   @IsOptional()
   url?: string;
 
@@ -455,4 +466,3 @@ export class ReadResourceDto {
   @MaxLength(2000)
   uri: string;
 }
-

--- a/services/controls/src/risk/assets.service.ts
+++ b/services/controls/src/risk/assets.service.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Injectable, NotFoundException, Logger } from '@nestjs/common';
+import { Injectable, NotFoundException, Logger, BadRequestException } from '@nestjs/common';
+import { safeFetch, SSRFProtectionError } from '@gigachad-grc/shared';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
 import {
@@ -19,7 +20,7 @@ export class AssetsService {
 
   constructor(
     private prisma: PrismaService,
-    private auditService: AuditService,
+    private auditService: AuditService
   ) {}
 
   // ===========================
@@ -30,7 +31,7 @@ export class AssetsService {
     organizationId: string,
     filters: AssetFilterDto,
     page: number = 1,
-    limit: number = 50,
+    limit: number = 50
   ) {
     const where: any = { organizationId };
 
@@ -69,10 +70,7 @@ export class AssetsService {
             select: { riskAssets: true },
           },
         },
-        orderBy: [
-          { criticality: 'desc' },
-          { name: 'asc' },
-        ],
+        orderBy: [{ criticality: 'desc' }, { name: 'asc' }],
         skip: (page - 1) * limit,
         take: limit,
       }),
@@ -80,7 +78,7 @@ export class AssetsService {
     ]);
 
     return {
-      assets: assets.map(asset => this.toResponseDto(asset)),
+      assets: assets.map((asset) => this.toResponseDto(asset)),
       total,
       page,
       limit,
@@ -113,7 +111,7 @@ export class AssetsService {
 
     return {
       ...this.toResponseDto(asset),
-      risks: asset.riskAssets.map(ra => ({
+      risks: asset.riskAssets.map((ra) => ({
         id: ra.risk.id,
         riskId: ra.risk.riskId,
         title: ra.risk.title,
@@ -127,7 +125,7 @@ export class AssetsService {
     organizationId: string,
     dto: CreateAssetDto,
     userId: string,
-    userEmail?: string,
+    userEmail?: string
   ): Promise<AssetResponseDto> {
     const asset = await this.prisma.asset.create({
       data: {
@@ -167,7 +165,7 @@ export class AssetsService {
     organizationId: string,
     dto: UpdateAssetDto,
     userId: string,
-    userEmail?: string,
+    userEmail?: string
   ): Promise<AssetResponseDto> {
     const existing = await this.prisma.asset.findFirst({
       where: { id, organizationId },
@@ -213,7 +211,7 @@ export class AssetsService {
     id: string,
     organizationId: string,
     userId: string,
-    userEmail?: string,
+    userEmail?: string
   ): Promise<void> {
     const asset = await this.prisma.asset.findFirst({
       where: { id, organizationId },
@@ -245,49 +243,43 @@ export class AssetsService {
   async getStats(organizationId: string): Promise<AssetStatsDto> {
     const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
 
-    const [
-      totalAssets,
-      bySource,
-      byType,
-      byCriticality,
-      byStatus,
-      recentlySynced,
-    ] = await Promise.all([
-      this.prisma.asset.count({ where: { organizationId } }),
-      this.prisma.asset.groupBy({
-        by: ['source'],
-        where: { organizationId },
-        _count: true,
-      }),
-      this.prisma.asset.groupBy({
-        by: ['type'],
-        where: { organizationId },
-        _count: true,
-      }),
-      this.prisma.asset.groupBy({
-        by: ['criticality'],
-        where: { organizationId },
-        _count: true,
-      }),
-      this.prisma.asset.groupBy({
-        by: ['status'],
-        where: { organizationId },
-        _count: true,
-      }),
-      this.prisma.asset.count({
-        where: {
-          organizationId,
-          lastSyncAt: { gte: oneHourAgo },
-        },
-      }),
-    ]);
+    const [totalAssets, bySource, byType, byCriticality, byStatus, recentlySynced] =
+      await Promise.all([
+        this.prisma.asset.count({ where: { organizationId } }),
+        this.prisma.asset.groupBy({
+          by: ['source'],
+          where: { organizationId },
+          _count: true,
+        }),
+        this.prisma.asset.groupBy({
+          by: ['type'],
+          where: { organizationId },
+          _count: true,
+        }),
+        this.prisma.asset.groupBy({
+          by: ['criticality'],
+          where: { organizationId },
+          _count: true,
+        }),
+        this.prisma.asset.groupBy({
+          by: ['status'],
+          where: { organizationId },
+          _count: true,
+        }),
+        this.prisma.asset.count({
+          where: {
+            organizationId,
+            lastSyncAt: { gte: oneHourAgo },
+          },
+        }),
+      ]);
 
     return {
       totalAssets,
-      bySource: bySource.map(s => ({ source: s.source, count: s._count })),
-      byType: byType.map(t => ({ type: t.type, count: t._count })),
-      byCriticality: byCriticality.map(c => ({ criticality: c.criticality, count: c._count })),
-      byStatus: byStatus.map(s => ({ status: s.status, count: s._count })),
+      bySource: bySource.map((s) => ({ source: s.source, count: s._count })),
+      byType: byType.map((t) => ({ type: t.type, count: t._count })),
+      byCriticality: byCriticality.map((c) => ({ criticality: c.criticality, count: c._count })),
+      byStatus: byStatus.map((s) => ({ status: s.status, count: s._count })),
       recentlySynced,
     };
   }
@@ -298,7 +290,7 @@ export class AssetsService {
       select: { source: true },
       distinct: ['source'],
     });
-    return sources.map(s => s.source);
+    return sources.map((s) => s.source);
   }
 
   async getDepartments(organizationId: string): Promise<string[]> {
@@ -307,7 +299,7 @@ export class AssetsService {
       select: { department: true },
       distinct: ['department'],
     });
-    return departments.map(d => d.department!).filter(Boolean);
+    return departments.map((d) => d.department!).filter(Boolean);
   }
 
   // ===========================
@@ -318,7 +310,7 @@ export class AssetsService {
     organizationId: string,
     integrationId: string,
     userId: string,
-    userEmail?: string,
+    userEmail?: string
   ): Promise<SyncResultDto> {
     const startTime = Date.now();
     const result: SyncResultDto = {
@@ -346,18 +338,26 @@ export class AssetsService {
         throw new Error('Jamf integration not properly configured');
       }
 
-      // Get access token
-      const tokenResponse = await fetch(`${config.serverUrl}/api/oauth/token`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-        },
-        body: new URLSearchParams({
-          grant_type: 'client_credentials',
-          client_id: config.clientId,
-          client_secret: config.clientSecret,
-        }),
-      });
+      // SECURITY: Use safeFetch to prevent SSRF via user-controlled serverUrl
+      let tokenResponse;
+      try {
+        tokenResponse = await safeFetch(`${config.serverUrl}/api/oauth/token`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+          },
+          body: new URLSearchParams({
+            grant_type: 'client_credentials',
+            client_id: config.clientId,
+            client_secret: config.clientSecret,
+          }),
+        });
+      } catch (error: any) {
+        if (error instanceof SSRFProtectionError) {
+          throw new BadRequestException(`Invalid Jamf URL: ${error.message}`);
+        }
+        throw error;
+      }
 
       if (!tokenResponse.ok) {
         throw new Error('Failed to obtain Jamf access token');
@@ -367,15 +367,23 @@ export class AssetsService {
       const accessToken = tokenData.access_token;
 
       // Fetch computers
-      const computersResponse = await fetch(
-        `${config.serverUrl}/api/v1/computers-inventory?section=GENERAL&section=HARDWARE&section=OPERATING_SYSTEM`,
-        {
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-            Accept: 'application/json',
-          },
-        },
-      );
+      let computersResponse;
+      try {
+        computersResponse = await safeFetch(
+          `${config.serverUrl}/api/v1/computers-inventory?section=GENERAL&section=HARDWARE&section=OPERATING_SYSTEM`,
+          {
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+              Accept: 'application/json',
+            },
+          }
+        );
+      } catch (error: any) {
+        if (error instanceof SSRFProtectionError) {
+          throw new BadRequestException(`Invalid Jamf URL: ${error.message}`);
+        }
+        throw error;
+      }
 
       if (computersResponse.ok) {
         const computersData = await computersResponse.json();
@@ -394,15 +402,20 @@ export class AssetsService {
       }
 
       // Fetch mobile devices
-      const mobileResponse = await fetch(
-        `${config.serverUrl}/api/v2/mobile-devices`,
-        {
+      let mobileResponse;
+      try {
+        mobileResponse = await safeFetch(`${config.serverUrl}/api/v2/mobile-devices`, {
           headers: {
             Authorization: `Bearer ${accessToken}`,
             Accept: 'application/json',
           },
-        },
-      );
+        });
+      } catch (error: any) {
+        if (error instanceof SSRFProtectionError) {
+          throw new BadRequestException(`Invalid Jamf URL: ${error.message}`);
+        }
+        throw error;
+      }
 
       if (mobileResponse.ok) {
         const mobileData = await mobileResponse.json();
@@ -440,7 +453,6 @@ export class AssetsService {
         entityName: 'Jamf Asset Sync',
         description: `Synced ${result.itemsProcessed} assets from Jamf (${result.itemsCreated} created/updated, ${result.itemsFailed} failed)`,
       });
-
     } catch (error: any) {
       this.logger.error(`Jamf sync failed: ${error.message}`);
       result.errors.push(error.message);
@@ -453,16 +465,19 @@ export class AssetsService {
   private async upsertAssetFromJamf(
     organizationId: string,
     data: any,
-    deviceType: 'computer' | 'mobile',
+    deviceType: 'computer' | 'mobile'
   ) {
     const externalId = String(data.id);
     const general = data.general || data;
     const hardware = data.hardware || {};
     const os = data.operatingSystem || {};
 
-    const assetType = deviceType === 'computer' 
-      ? (hardware.model?.toLowerCase().includes('macbook') ? AssetType.WORKSTATION : AssetType.SERVER)
-      : AssetType.MOBILE;
+    const assetType =
+      deviceType === 'computer'
+        ? hardware.model?.toLowerCase().includes('macbook')
+          ? AssetType.WORKSTATION
+          : AssetType.SERVER
+        : AssetType.MOBILE;
 
     await this.prisma.asset.upsert({
       where: {
@@ -538,4 +553,3 @@ export class AssetsService {
     };
   }
 }
-

--- a/services/controls/src/users/users.controller.ts
+++ b/services/controls/src/users/users.controller.ts
@@ -173,7 +173,8 @@ export class UsersController {
   }
 
   @Get('keycloak/:keycloakId')
-  async getUserByKeycloakId(@Param('keycloakId') keycloakId: string) {
-    return this.usersService.findByKeycloakId(keycloakId);
+  async getUserByKeycloakId(@Param('keycloakId') keycloakId: string, @User() user: UserContext) {
+    // SECURITY: Pass organizationId to ensure tenant isolation (IDOR prevention)
+    return this.usersService.findByKeycloakId(keycloakId, user.organizationId);
   }
 }

--- a/services/shared/src/auth/dev-auth.guard.ts
+++ b/services/shared/src/auth/dev-auth.guard.ts
@@ -132,12 +132,16 @@ export class DevAuthGuard implements CanActivate {
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    // SECURITY: Prevent usage in production
-    const nodeEnv = process.env.NODE_ENV || 'development';
-    if (nodeEnv === 'production') {
+    // SECURITY: Only allow in explicit development/test environments
+    // NEVER allow bypass if NODE_ENV is not set or is production/staging
+    const nodeEnv = process.env.NODE_ENV;
+    const allowedEnvs = ['development', 'test'];
+
+    if (!nodeEnv || !allowedEnvs.includes(nodeEnv)) {
       throw new Error(
-        'SECURITY ERROR: DevAuthGuard is configured but NODE_ENV is set to production. ' +
-          'This is a critical security vulnerability. Please use proper JWT authentication in production.'
+        `SECURITY ERROR: DevAuthGuard cannot be used in ${nodeEnv || 'undefined'} environment. ` +
+          'This guard is only permitted in development or test environments. ' +
+          'Please use proper JWT authentication in production.'
       );
     }
 

--- a/services/tprm/src/vendors/vendors.service.ts
+++ b/services/tprm/src/vendors/vendors.service.ts
@@ -8,26 +8,48 @@ import { UpdateVendorDto } from './dto/update-vendor.dto';
 import { Prisma, VendorCategory, VendorTier, VendorStatus, VendorRiskScore } from '@prisma/client';
 
 // Valid enum values for type guards
-const VALID_CATEGORIES: VendorCategory[] = ['software_vendor', 'cloud_provider', 'professional_services', 'hardware_vendor', 'consultant'];
+const VALID_CATEGORIES: VendorCategory[] = [
+  'software_vendor',
+  'cloud_provider',
+  'professional_services',
+  'hardware_vendor',
+  'consultant',
+];
 const VALID_TIERS: VendorTier[] = ['tier_1', 'tier_2', 'tier_3', 'tier_4'];
-const VALID_STATUSES: VendorStatus[] = ['active', 'inactive', 'pending_onboarding', 'offboarding', 'terminated'];
+const VALID_STATUSES: VendorStatus[] = [
+  'active',
+  'inactive',
+  'pending_onboarding',
+  'offboarding',
+  'terminated',
+];
 const VALID_RISK_SCORES: VendorRiskScore[] = ['very_low', 'low', 'medium', 'high', 'critical'];
 
 // Helper functions to convert strings to enum types
-function toVendorCategory(value: string | undefined, defaultValue: VendorCategory = 'software_vendor'): VendorCategory {
-  return VALID_CATEGORIES.includes(value as VendorCategory) ? value as VendorCategory : defaultValue;
+function toVendorCategory(
+  value: string | undefined,
+  defaultValue: VendorCategory = 'software_vendor'
+): VendorCategory {
+  return VALID_CATEGORIES.includes(value as VendorCategory)
+    ? (value as VendorCategory)
+    : defaultValue;
 }
 
 function toVendorTier(value: string | undefined, defaultValue: VendorTier = 'tier_3'): VendorTier {
-  return VALID_TIERS.includes(value as VendorTier) ? value as VendorTier : defaultValue;
+  return VALID_TIERS.includes(value as VendorTier) ? (value as VendorTier) : defaultValue;
 }
 
-function toVendorStatus(value: string | undefined, defaultValue: VendorStatus = 'active'): VendorStatus {
-  return VALID_STATUSES.includes(value as VendorStatus) ? value as VendorStatus : defaultValue;
+function toVendorStatus(
+  value: string | undefined,
+  defaultValue: VendorStatus = 'active'
+): VendorStatus {
+  return VALID_STATUSES.includes(value as VendorStatus) ? (value as VendorStatus) : defaultValue;
 }
 
 function toVendorRiskScore(value: string | undefined): VendorRiskScore | undefined {
-  return VALID_RISK_SCORES.includes(value as VendorRiskScore) ? value as VendorRiskScore : undefined;
+  return VALID_RISK_SCORES.includes(value as VendorRiskScore)
+    ? (value as VendorRiskScore)
+    : undefined;
 }
 
 // ============================================
@@ -75,7 +97,7 @@ export function parseFrequencyToMonths(frequency: string): number {
   if (FREQUENCY_MONTHS[frequency]) {
     return FREQUENCY_MONTHS[frequency];
   }
-  
+
   // Check for custom_X format
   if (frequency.startsWith('custom_')) {
     const months = parseInt(frequency.replace('custom_', ''), 10);
@@ -83,7 +105,7 @@ export function parseFrequencyToMonths(frequency: string): number {
       return months;
     }
   }
-  
+
   // Default to annual if unparseable
   return 12;
 }
@@ -95,7 +117,7 @@ export function formatFrequencyLabel(frequency: string): string {
   if (FREQUENCY_LABELS[frequency]) {
     return FREQUENCY_LABELS[frequency];
   }
-  
+
   if (frequency.startsWith('custom_')) {
     const months = parseInt(frequency.replace('custom_', ''), 10);
     if (!isNaN(months) && months > 0) {
@@ -106,7 +128,7 @@ export function formatFrequencyLabel(frequency: string): string {
       return `${months} Months`;
     }
   }
-  
+
   return frequency;
 }
 
@@ -114,10 +136,7 @@ export function formatFrequencyLabel(frequency: string): string {
  * Calculate the next review due date based on frequency
  * Supports both predefined and custom frequencies
  */
-export function calculateNextReviewDate(
-  lastReviewDate: Date | null,
-  frequency: string,
-): Date {
+export function calculateNextReviewDate(lastReviewDate: Date | null, frequency: string): Date {
   const baseDate = lastReviewDate || new Date();
   const months = parseFrequencyToMonths(frequency);
   const nextDate = new Date(baseDate);
@@ -150,7 +169,7 @@ export class VendorsService {
     private readonly prisma: PrismaService,
     private readonly audit: AuditService,
     private readonly tprmConfig: TprmConfigService,
-    private readonly cache: CacheService,
+    private readonly cache: CacheService
   ) {}
 
   /**
@@ -163,8 +182,8 @@ export class VendorsService {
     const vendors = await this.prisma.vendor.findMany({
       select: { vendorId: true },
       where: {
-        vendorId: { startsWith: 'VND-' }
-      }
+        vendorId: { startsWith: 'VND-' },
+      },
     });
 
     let maxNum = 0;
@@ -198,17 +217,18 @@ export class VendorsService {
 
   async create(createVendorDto: CreateVendorDto, userId: string) {
     // Auto-generate vendorId if not provided
-    const vendorId = createVendorDto.vendorId || await this.generateVendorId();
-    
+    const vendorId = createVendorDto.vendorId || (await this.generateVendorId());
+
     // Set defaults for category and tier if not provided
     const category = toVendorCategory(createVendorDto.category);
     const tier = toVendorTier(createVendorDto.tier);
     const status = toVendorStatus(createVendorDto.status);
-    
+
     // Auto-set review frequency based on tier if not provided
-    const reviewFrequency = createVendorDto.reviewFrequency || 
-      await this.getFrequencyForTier(createVendorDto.organizationId!, tier);
-    
+    const reviewFrequency =
+      createVendorDto.reviewFrequency ||
+      (await this.getFrequencyForTier(createVendorDto.organizationId!, tier));
+
     // Calculate next review due date
     const nextReviewDue = calculateNextReviewDate(null, reviewFrequency);
 
@@ -252,8 +272,14 @@ export class VendorsService {
     tier?: string;
     status?: string;
     search?: string;
+    organizationId?: string;
   }) {
     const where: Prisma.VendorWhereInput = {};
+
+    // SECURITY: Filter by organizationId to ensure tenant isolation (IDOR prevention)
+    if (filters?.organizationId) {
+      where.organizationId = filters.organizationId;
+    }
 
     if (filters?.category) {
       where.category = toVendorCategory(filters.category);
@@ -302,8 +328,8 @@ export class VendorsService {
     // SECURITY: Include organizationId in query to prevent IDOR
     // This ensures users can only access vendors within their organization
     const vendor = await this.prisma.vendor.findFirst({
-      where: { 
-        id, 
+      where: {
+        id,
         organizationId, // Tenant isolation - prevents cross-organization access
         deletedAt: null,
       },
@@ -332,29 +358,31 @@ export class VendorsService {
     return vendor;
   }
 
-  async update(id: string, updateVendorDto: UpdateVendorDto, userId: string, organizationId: string) {
+  async update(
+    id: string,
+    updateVendorDto: UpdateVendorDto,
+    userId: string,
+    organizationId: string
+  ) {
     // SECURITY: Verify vendor belongs to user's organization before updating
     const currentVendor = await this.findOne(id, organizationId);
-    
+
     const { category, tier, status, ...restDto } = updateVendorDto;
     const updateData: Prisma.VendorUpdateInput = { ...restDto };
-    
+
     if (category) {
       updateData.category = toVendorCategory(category);
     }
-    
+
     if (status) {
       updateData.status = toVendorStatus(status);
     }
-    
+
     // If tier is being changed, update review frequency and next review date using org config
     if (tier && tier !== currentVendor.tier) {
       const newTier = toVendorTier(tier);
       updateData.tier = newTier;
-      const newFrequency = await this.getFrequencyForTier(
-        currentVendor.organizationId,
-        tier
-      );
+      const newFrequency = await this.getFrequencyForTier(currentVendor.organizationId, tier);
       updateData.reviewFrequency = newFrequency;
       updateData.nextReviewDue = calculateNextReviewDate(
         currentVendor.lastReviewedAt,
@@ -409,10 +437,15 @@ export class VendorsService {
     return vendor;
   }
 
-  async updateRiskScore(id: string, inherentRiskScore: string, userId: string, organizationId: string) {
+  async updateRiskScore(
+    id: string,
+    inherentRiskScore: string,
+    userId: string,
+    organizationId: string
+  ) {
     // SECURITY: Verify vendor belongs to user's organization before updating
     const existingVendor = await this.findOne(id, organizationId);
-    
+
     const vendor = await this.prisma.vendor.update({
       where: { id: existingVendor.id },
       data: { inherentRiskScore: toVendorRiskScore(inherentRiskScore) },
@@ -432,7 +465,10 @@ export class VendorsService {
     return vendor;
   }
 
-  async getDashboardStats() {
+  async getDashboardStats(organizationId: string) {
+    // SECURITY: Filter by organizationId to ensure tenant isolation (IDOR prevention)
+    const baseWhere = { organizationId, deletedAt: null };
+
     const [
       totalVendors,
       activeVendors,
@@ -441,26 +477,26 @@ export class VendorsService {
       highRiskVendors,
       recentVendors,
     ] = await Promise.all([
-      this.prisma.vendor.count({ where: { deletedAt: null } }),
-      this.prisma.vendor.count({ where: { status: 'active', deletedAt: null } }),
+      this.prisma.vendor.count({ where: baseWhere }),
+      this.prisma.vendor.count({ where: { ...baseWhere, status: 'active' } }),
       this.prisma.vendor.groupBy({
         by: ['tier'],
-        where: { deletedAt: null },
+        where: baseWhere,
         _count: true,
       }),
       this.prisma.vendor.groupBy({
         by: ['category'],
-        where: { deletedAt: null },
+        where: baseWhere,
         _count: true,
       }),
       this.prisma.vendor.count({
         where: {
+          ...baseWhere,
           inherentRiskScore: { in: ['high', 'critical'] },
-          deletedAt: null,
         },
       }),
       this.prisma.vendor.findMany({
-        where: { deletedAt: null },
+        where: baseWhere,
         take: 5,
         orderBy: { createdAt: 'desc' },
         select: {
@@ -496,11 +532,11 @@ export class VendorsService {
    */
   async getVendorsDueForReview(organizationId?: string) {
     const cacheKey = `vendor-reviews-due:${organizationId || 'all'}`;
-    
+
     return this.cache.getOrSet(
       cacheKey,
       async () => this.getVendorsDueForReviewUncached(organizationId),
-      300, // 5 minute cache
+      300 // 5 minute cache
     );
   }
 
@@ -596,7 +632,9 @@ export class VendorsService {
     return {
       overdue: overdue.map((v) => ({
         ...v,
-        daysOverdue: getDaysUntilReview(v.nextReviewDue) ? Math.abs(getDaysUntilReview(v.nextReviewDue)!) : 0,
+        daysOverdue: getDaysUntilReview(v.nextReviewDue)
+          ? Math.abs(getDaysUntilReview(v.nextReviewDue)!)
+          : 0,
       })),
       dueThisWeek: dueThisWeek.map((v) => ({
         ...v,

--- a/services/trust/src/questionnaires/questionnaires.service.spec.ts
+++ b/services/trust/src/questionnaires/questionnaires.service.spec.ts
@@ -85,7 +85,7 @@ describe('QuestionnairesService', () => {
             title: 'Security Questionnaire',
             requesterName: 'John Doe',
           }),
-        }),
+        })
       );
       expect(mockAuditService.log).toHaveBeenCalled();
       expect(result).toEqual(mockCreatedQuestionnaire);
@@ -102,7 +102,7 @@ describe('QuestionnairesService', () => {
             status: 'pending',
             priority: 'medium',
           }),
-        }),
+        })
       );
     });
   });
@@ -186,10 +186,10 @@ describe('QuestionnairesService', () => {
     it('should return a questionnaire by id', async () => {
       mockPrismaService.questionnaireRequest.findFirst.mockResolvedValue(mockQuestionnaire);
 
-      const result = await service.findOne('quest-123');
+      const result = await service.findOne('quest-123', 'org-123');
 
       expect(mockPrismaService.questionnaireRequest.findFirst).toHaveBeenCalledWith({
-        where: { id: 'quest-123', deletedAt: null },
+        where: { id: 'quest-123', organizationId: 'org-123', deletedAt: null },
         include: expect.any(Object),
       });
       expect(result).toEqual(mockQuestionnaire);
@@ -198,7 +198,7 @@ describe('QuestionnairesService', () => {
     it('should throw NotFoundException if questionnaire not found', async () => {
       mockPrismaService.questionnaireRequest.findFirst.mockResolvedValue(null);
 
-      await expect(service.findOne('nonexistent')).rejects.toThrow(NotFoundException);
+      await expect(service.findOne('nonexistent', 'org-123')).rejects.toThrow(NotFoundException);
     });
   });
 
@@ -214,10 +214,13 @@ describe('QuestionnairesService', () => {
     };
 
     it('should update a questionnaire', async () => {
-      mockPrismaService.questionnaireRequest.findFirst.mockResolvedValue({ id: 'quest-123' });
+      mockPrismaService.questionnaireRequest.findFirst.mockResolvedValue({
+        id: 'quest-123',
+        organizationId: 'org-123',
+      });
       mockPrismaService.questionnaireRequest.update.mockResolvedValue(mockUpdatedQuestionnaire);
 
-      const result = await service.update('quest-123', mockUpdateDto, 'user-123');
+      const result = await service.update('quest-123', mockUpdateDto, 'user-123', 'org-123');
 
       expect(mockPrismaService.questionnaireRequest.update).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -225,7 +228,7 @@ describe('QuestionnairesService', () => {
           data: expect.objectContaining({
             title: 'Updated Questionnaire',
           }),
-        }),
+        })
       );
       expect(result.title).toBe('Updated Questionnaire');
     });
@@ -234,7 +237,7 @@ describe('QuestionnairesService', () => {
       mockPrismaService.questionnaireRequest.findFirst.mockResolvedValue(null);
 
       await expect(
-        service.update('nonexistent', mockUpdateDto, 'user-123'),
+        service.update('nonexistent', mockUpdateDto, 'user-123', 'org-123')
       ).rejects.toThrow(NotFoundException);
     });
   });

--- a/services/trust/src/templates/templates.service.ts
+++ b/services/trust/src/templates/templates.service.ts
@@ -25,7 +25,7 @@ export interface UpdateTemplateDto {
 export class TemplatesService {
   constructor(
     private prisma: PrismaService,
-    private audit: AuditService,
+    private audit: AuditService
   ) {}
 
   async create(dto: CreateTemplateDto, userId: string) {
@@ -58,11 +58,14 @@ export class TemplatesService {
     return template;
   }
 
-  async findAll(organizationId: string, filters?: {
-    category?: string;
-    status?: string;
-    search?: string;
-  }) {
+  async findAll(
+    organizationId: string,
+    filters?: {
+      category?: string;
+      status?: string;
+      search?: string;
+    }
+  ) {
     const where: Prisma.AnswerTemplateWhereInput = {
       organizationId,
       deletedAt: null,
@@ -86,10 +89,7 @@ export class TemplatesService {
 
     return this.prisma.answerTemplate.findMany({
       where,
-      orderBy: [
-        { usageCount: 'desc' },
-        { updatedAt: 'desc' },
-      ],
+      orderBy: [{ usageCount: 'desc' }, { updatedAt: 'desc' }],
     });
   }
 
@@ -97,8 +97,8 @@ export class TemplatesService {
     // SECURITY: Include organizationId in query to prevent IDOR
     // This ensures users can only access templates within their organization
     const template = await this.prisma.answerTemplate.findFirst({
-      where: { 
-        id, 
+      where: {
+        id,
         organizationId, // Tenant isolation - prevents cross-organization access
         deletedAt: null,
       },
@@ -121,10 +121,15 @@ export class TemplatesService {
       variables = this.extractVariables(dto.content);
     }
 
+    // SECURITY: Explicit field mapping to prevent mass assignment vulnerabilities
     const updated = await this.prisma.answerTemplate.update({
       where: { id },
       data: {
-        ...dto,
+        title: dto.title,
+        content: dto.content,
+        category: dto.category,
+        tags: dto.tags,
+        status: dto.status,
         variables: variables !== undefined ? variables : undefined,
         updatedBy: userId,
       },
@@ -183,7 +188,7 @@ export class TemplatesService {
   async incrementUsage(id: string, organizationId: string) {
     // SECURITY: Verify template belongs to organization before incrementing
     const template = await this.findOne(id, organizationId);
-    
+
     await this.prisma.answerTemplate.update({
       where: { id: template.id },
       data: {
@@ -239,7 +244,7 @@ export class TemplatesService {
 
     return {
       categories: defaultCategories,
-      usedCategories: categories.map(c => ({
+      usedCategories: categories.map((c) => ({
         category: c.category,
         count: c._count,
       })),
@@ -295,7 +300,7 @@ export class TemplatesService {
       total,
       active,
       archived,
-      byCategory: byCategory.map(c => ({
+      byCategory: byCategory.map((c) => ({
         category: c.category || 'uncategorized',
         count: c._count,
       })),
@@ -303,4 +308,3 @@ export class TemplatesService {
     };
   }
 }
-


### PR DESCRIPTION
## Summary
This PR implements comprehensive security fixes identified during the security audit plan, addressing 9 major vulnerability categories across 45 files.

### Security Fixes Implemented

**SSRF Protection (24+ fetch calls hardened)**
- Replaced `fetch()` with `safeFetch()` across collectors, connectors (jira, crowdstrike, jamf, okta, zendesk, wiz), integrations (servicenow, jira), fieldguide, and asset services
- Added SSRF validation to MCP screenshot-capture tool (blocks localhost, private IPs, cloud metadata endpoints)
- Added path traversal protection to google-workspace-evidence tool (validates service account key paths)

**Authentication & Authorization Fixes**
- Fixed DevAuthGuard to only allow bypass in explicit `development` or `test` environments (prevents production bypass)
- Changed PermissionGuard default from allow to deny when no permission decorator is present
- Fixed header spoofing vulnerability - now uses `request.user?.userId` instead of trusting `x-user-id` header

**IDOR Prevention**
- Added organization validation to vendors, requests, users, questionnaires endpoints
- Validates document/request ownership before returning data

**Mass Assignment Prevention**
- Replaced `...dto` spread operators with explicit field mapping in 6 service methods:
  - controls.service.ts (create/update)
  - evidence.service.ts (update)
  - implementations.service.ts (update)
  - remediation.service.ts (updateMilestone)
  - templates.service.ts (update)
  - requests.service.ts (addComment)

**DTO Validation**
- Added `@IsUrl()` validation to collector baseUrl, dashboard iframeUrl, MCP server url
- Added `@MaxLength()` to collector name/description, control description/guidance, evidence description/notes, dashboard rawQuery, customCode

**Secrets Removal**
- Removed hardcoded default passwords from docker-compose.yml, docker-compose.monitoring.yml
- Removed hardcoded DB credentials from db-migrate.sh
- Added DATABASE_URL requirement to import scripts and seed-database.ts

**Test Fixes**
- Updated collectors.service.spec.ts to mock safeFetch instead of global.fetch
- Updated permission.guard.spec.ts to test new secure default behavior
- Fixed pre-existing test failures in audits.service.spec.ts and questionnaires.service.spec.ts

## Test plan
- [x] All frontend tests pass (30 test files, 331 tests)
- [x] All controls service tests pass (11 test suites, 224 tests)
- [x] ESLint and Prettier pass via pre-commit hooks
- [x] Pre-commit security checks pass
- [ ] Manual verification of SSRF protection with test URLs
- [ ] Verify permission guard denies access on undecorated routes