### PR TITLE
fix(frontend): bump keycloak-js from v23 to v25 to match server

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,7 +39,7 @@
     "exceljs": "^4.4.0",
     "html2canvas": "^1.4.1",
     "jspdf": "^4.1.0",
-    "keycloak-js": "^23.0.3",
+    "keycloak-js": "^25.0.0",
     "lucide-react": "^0.563.0",
     "mammoth": "^1.11.0",
     "react": "^18.2.0",


### PR DESCRIPTION
## Summary
- Upgrades `keycloak-js` from `^23.0.3` to `^25.0.0` to match the Keycloak server version (v25.0)
- Fixes "Keycloak initialization failed: undefined" error caused by keycloak-js v23 not handling the `iss` parameter (RFC 9207) that Keycloak v25 adds to the authorization response fragment

## Test plan
- [x] Rebuild frontend container (`docker compose build frontend`)
- [x] Verify Keycloak login flow completes without console errors
- [x] Verify token refresh works after initial authentication
- [x] Check browser console for absence of "Keycloak initialization failed" errors