### PR TITLE
fix(keycloak): use dedicated keycloak database instead of app database

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -172,7 +172,7 @@ services:
     environment:
       # Database
       KC_DB: postgres
-      KC_DB_URL: jdbc:postgresql://postgres:5432/${POSTGRES_DB}
+      KC_DB_URL: jdbc:postgresql://postgres:5432/${KEYCLOAK_DB:-keycloak}
       KC_DB_USERNAME: ${POSTGRES_USER}
       KC_DB_PASSWORD: ${POSTGRES_PASSWORD}
       KC_DB_POOL_INITIAL_SIZE: ${KC_DB_POOL_INITIAL_SIZE:-5}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,7 @@ services:
     command: start-dev --import-realm
     environment:
       KC_DB: postgres
-      KC_DB_URL: jdbc:postgresql://postgres:5432/${POSTGRES_DB:-gigachad_grc}
+      KC_DB_URL: jdbc:postgresql://postgres:5432/${KEYCLOAK_DB:-keycloak}
       KC_DB_USERNAME: ${POSTGRES_USER:-grc}
       KC_DB_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
       KC_HOSTNAME: ${KEYCLOAK_HOSTNAME:-localhost}


### PR DESCRIPTION
## Summary
- Fix `KC_DB_URL` in both `docker-compose.yml` and `docker-compose.prod.yml` to point to the dedicated `keycloak` database instead of the application database

## Context
We moved Keycloak's tables into their own dedicated `keycloak` database (created by `database/init/00-create-keycloak-db.sh`) to isolate identity data from application data. However, the `KC_DB_URL` environment variable in both compose files was still referencing `${POSTGRES_DB}` / `${POSTGRES_DB:-gigachad_grc}` — the application database.

This mismatch caused HTTP 500 on all Keycloak OIDC endpoints (`relation "realm" does not exist`) since Keycloak's schema lives in the dedicated database, not the app database.

The fix updates `KC_DB_URL` to use `${KEYCLOAK_DB:-keycloak}`, matching the init script and keeping it configurable via environment variable.

## Test plan
- [ ] `docker compose up keycloak` starts without errors
- [ ] Keycloak admin console loads at `http://localhost:8080`
- [ ] Frontend SSO login flow completes successfully
- [ ] Production compose file also uses correct DB URL