### PR TITLE
fix(frontend): track SSO session expiry instead of access token

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -123,7 +123,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
                   <WorkspaceProvider>
                     {/* Global UI components */}
                     <NetworkStatus />
-                    <SessionWarning warningThreshold={5 * 60 * 1000} />
+                    <SessionWarning warningThreshold={2 * 60 * 1000} />
                     <App />
                     <Toaster
                       position="top-right"


### PR DESCRIPTION
## Summary
- Fix `SessionWarning` component to track the SSO session (refresh token) expiry instead of the short-lived access token expiry
- Reduce warning threshold from 5 minutes to 2 minutes

## Context
The session warning toast appeared immediately after login because it was comparing the access token's 5-minute lifespan against a 5-minute warning threshold. Since `5min - now ≤ 5min` is always true, the warning showed right away.

Access tokens are short-lived (5 min default) and auto-refresh silently via Keycloak — users should never see warnings about those. The actual SSO session (30 min idle timeout) is what matters for user-facing warnings.

### Changes
- **`AuthContext.tsx`**: Added `sessionExpiry` state derived from `kc.refreshTokenParsed.exp` (the SSO session), updated on init and each token refresh
- **`SessionWarning.tsx`**: Reads `sessionExpiry` from auth context instead of parsing the access token JWT directly
- **`main.tsx`**: Threshold reduced from 5 min to 2 min to avoid premature warnings

## Test plan
- [ ] No session warning appears immediately after login
- [ ] Warning appears ~2 minutes before SSO session expires (testable by reducing Keycloak SSO idle timeout)
- [ ] Dismissing the warning works; it reappears if session expiry changes
- [ ] Token refresh does not trigger false warnings