### PR TITLE
feat(KMS): add secrets/key management abstraction and Infisical integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,17 +24,17 @@ NODE_ENV=development
 
 # 64-character hex key for encrypting sensitive data
 # Generate: openssl rand -hex 32
-# NOTE: Managed by Infisical after initial setup (see Infisical section below)
+# NOTE: Can be managed by external secrets provider (see SECRETS_PROVIDER)
 ENCRYPTION_KEY=generate-a-64-char-hex-key-using-openssl-rand-hex-32
 
 # Base64 secret for JWT token signing (64+ characters)
 # Generate: openssl rand -base64 64
-# NOTE: Managed by Infisical after initial setup
+# NOTE: Can be managed by external secrets provider (see SECRETS_PROVIDER)
 JWT_SECRET=generate-a-secure-jwt-secret-using-openssl-rand-base64-64
 
 # Base64 secret for session encryption (64+ characters)
 # Generate: openssl rand -base64 64
-# NOTE: Managed by Infisical after initial setup
+# NOTE: Can be managed by external secrets provider (see SECRETS_PROVIDER)
 SESSION_SECRET=generate-a-secure-session-secret-using-openssl-rand-base64-64
 
 # =============================================================================
@@ -127,16 +127,26 @@ VITE_ENABLE_AI_MODULE=true
 # VITE_TRAINING_CDN_URL=https://training.example.com
 
 # =============================================================================
-# Infisical Secrets Manager (Bootstrap)
+# Secrets Management (Optional)
 # =============================================================================
-# These are bootstrap secrets needed before Infisical starts.
-# Application secrets (ENCRYPTION_KEY, JWT_SECRET, etc.) are managed in Infisical
-# after initial setup. See: make secrets-seed
-#
-# Generate encryption key: openssl rand -hex 16
-INFISICAL_ENCRYPTION_KEY=generate-a-32-char-hex-key
-# Generate auth secret: openssl rand -base64 32
-INFISICAL_AUTH_SECRET=generate-a-secure-auth-secret
+# Provider for external secrets storage (integration credentials).
+# Default: env (credentials encrypted locally with AES-256-GCM, no extra infrastructure)
+# Built-in providers: env, infisical
+# To add custom providers, see docs/secrets-management.md
+SECRETS_PROVIDER=env
+# SECRETS_CACHE_TTL=300
+
+# --- Infisical (SECRETS_PROVIDER=infisical) ---
+# Requires: docker compose --profile infisical up -d
+# INFISICAL_SITE_URL=http://localhost:8443
+# INFISICAL_CLIENT_ID=
+# INFISICAL_CLIENT_SECRET=
+# INFISICAL_PROJECT_ID=
+# INFISICAL_ENVIRONMENT=dev
+# INFISICAL_SECRET_PATH=/
+# Bootstrap secrets (for self-hosted Infisical container only):
+# INFISICAL_ENCRYPTION_KEY=
+# INFISICAL_AUTH_SECRET=
 
 # =============================================================================
 # Optional: AI Integration

--- a/.env.example
+++ b/.env.example
@@ -24,14 +24,17 @@ NODE_ENV=development
 
 # 64-character hex key for encrypting sensitive data
 # Generate: openssl rand -hex 32
+# NOTE: Managed by Infisical after initial setup (see Infisical section below)
 ENCRYPTION_KEY=generate-a-64-char-hex-key-using-openssl-rand-hex-32
 
 # Base64 secret for JWT token signing (64+ characters)
 # Generate: openssl rand -base64 64
+# NOTE: Managed by Infisical after initial setup
 JWT_SECRET=generate-a-secure-jwt-secret-using-openssl-rand-base64-64
 
 # Base64 secret for session encryption (64+ characters)
 # Generate: openssl rand -base64 64
+# NOTE: Managed by Infisical after initial setup
 SESSION_SECRET=generate-a-secure-session-secret-using-openssl-rand-base64-64
 
 # =============================================================================
@@ -122,6 +125,18 @@ VITE_ENABLE_DEV_AUTH=false
 VITE_ENABLE_AI_MODULE=true
 # Optional: CDN URL for training content (used for postMessage origin validation)
 # VITE_TRAINING_CDN_URL=https://training.example.com
+
+# =============================================================================
+# Infisical Secrets Manager (Bootstrap)
+# =============================================================================
+# These are bootstrap secrets needed before Infisical starts.
+# Application secrets (ENCRYPTION_KEY, JWT_SECRET, etc.) are managed in Infisical
+# after initial setup. See: make secrets-seed
+#
+# Generate encryption key: openssl rand -hex 16
+INFISICAL_ENCRYPTION_KEY=generate-a-32-char-hex-key
+# Generate auth secret: openssl rand -base64 32
+INFISICAL_AUTH_SECRET=generate-a-secure-auth-secret
 
 # =============================================================================
 # Optional: AI Integration

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@ services/policies/storage/
 *.key
 *.p12
 
+# Infisical
+.infisical.json
+.infisical-initialized
+
 # Storage directories - contain user data
 services/*/storage/
 **/storage/evidence/

--- a/Makefile
+++ b/Makefile
@@ -74,12 +74,8 @@ docker: ## Start all services via Docker only
 # Docker Commands
 # ─────────────────────────────────────────────────────────────────────────────
 
-up: ## Start all Docker containers (with Infisical secret injection)
-	@if command -v infisical >/dev/null 2>&1 && [ -f .infisical.json ]; then \
-		infisical run --env=dev -- docker compose up -d; \
-	else \
-		docker compose up -d; \
-	fi
+up: ## Start all Docker containers
+	docker compose up -d
 
 down: ## Stop all Docker containers
 	docker compose down
@@ -101,16 +97,18 @@ restart: ## Restart containers (use: make restart s=controls)
 		docker compose restart; \
 	fi
 
-infra: ## Start infrastructure only (postgres, redis, keycloak, rustfs, infisical)
-	docker compose up -d postgres redis keycloak rustfs infisical
+infra: ## Start infrastructure only (postgres, redis, keycloak, rustfs)
+	docker compose up -d postgres redis keycloak rustfs
 
 services: ## Start application services only (requires infra running)
 	docker compose up -d controls frameworks policies tprm trust audit
 
-secrets-ui: ## Open Infisical secrets UI
+secrets-ui: ## Open Infisical secrets UI (requires SECRETS_PROVIDER=infisical)
+	@if [ "$$(grep -s '^SECRETS_PROVIDER=' .env | cut -d= -f2)" != "infisical" ]; then echo "SECRETS_PROVIDER is not set to 'infisical'. Set it in .env first."; exit 1; fi
 	@open http://localhost:8443 2>/dev/null || xdg-open http://localhost:8443 2>/dev/null || echo "Visit http://localhost:8443"
 
-secrets-seed: ## Seed secrets into Infisical (first-time setup)
+secrets-seed: ## Seed secrets into Infisical (requires SECRETS_PROVIDER=infisical)
+	@if [ "$$(grep -s '^SECRETS_PROVIDER=' .env | cut -d= -f2)" != "infisical" ]; then echo "SECRETS_PROVIDER is not set to 'infisical'. Set it in .env first."; exit 1; fi
 	@bash scripts/seed-infisical.sh
 
 rebuild: ## Rebuild and restart a service (use: make rebuild s=controls)

--- a/database/init/00-create-keycloak-db.sh
+++ b/database/init/00-create-keycloak-db.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Create a separate database for Keycloak to avoid schema conflicts
+# with Prisma migrations in the main application database.
+# This script runs before the SQL init scripts (sorted by filename).
+
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    CREATE DATABASE keycloak;
+    GRANT ALL PRIVILEGES ON DATABASE keycloak TO $POSTGRES_USER;
+EOSQL
+
+echo "Keycloak database created successfully"

--- a/database/init/00b-create-infisical-db.sh
+++ b/database/init/00b-create-infisical-db.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Create a separate database for Infisical secrets manager.
+# This script sorts after 00-create-keycloak-db.sh and before 01-init.sql.
+
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    CREATE DATABASE infisical;
+    GRANT ALL PRIVILEGES ON DATABASE infisical TO $POSTGRES_USER;
+EOSQL
+
+echo "Infisical database created successfully"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -316,12 +316,15 @@ services:
           memory: 256M
 
   # ===========================================
-  # Secrets Management - Infisical (Self-Hosted)
-  # Centralized secret management with audit trail
+  # Secrets Management - Infisical (Optional)
+  # Only starts with: docker compose --profile infisical up -d
+  # Set SECRETS_PROVIDER=infisical in .env to use
   # ===========================================
   infisical:
     image: infisical/infisical:v0.158.2
     container_name: grc-infisical
+    profiles:
+      - infisical
     security_opt:
       - no-new-privileges:true
     cap_drop:
@@ -361,7 +364,8 @@ services:
         max-size: '10m'
         max-file: '3'
     healthcheck:
-      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:8080/api/status']
+      test:
+        ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:8080/api/status']
       interval: 15s
       timeout: 10s
       retries: 10
@@ -417,8 +421,7 @@ services:
         condition: service_healthy
       rustfs:
         condition: service_healthy
-      infisical:
-        condition: service_healthy
+
     networks:
       - grc-network
     labels:
@@ -519,8 +522,7 @@ services:
         condition: service_healthy
       rustfs:
         condition: service_healthy
-      infisical:
-        condition: service_healthy
+
     networks:
       - grc-network
     labels:
@@ -603,8 +605,7 @@ services:
         condition: service_healthy
       rustfs:
         condition: service_healthy
-      infisical:
-        condition: service_healthy
+
     networks:
       - grc-network
     labels:
@@ -687,8 +688,7 @@ services:
         condition: service_healthy
       rustfs:
         condition: service_healthy
-      infisical:
-        condition: service_healthy
+
     networks:
       - grc-network
     labels:
@@ -773,8 +773,7 @@ services:
         condition: service_healthy
       rustfs:
         condition: service_healthy
-      infisical:
-        condition: service_healthy
+
     networks:
       - grc-network
     labels:
@@ -859,8 +858,7 @@ services:
         condition: service_healthy
       rustfs:
         condition: service_healthy
-      infisical:
-        condition: service_healthy
+
     networks:
       - grc-network
     labels:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -316,6 +316,66 @@ services:
           memory: 256M
 
   # ===========================================
+  # Secrets Management - Infisical (Self-Hosted)
+  # Centralized secret management with audit trail
+  # ===========================================
+  infisical:
+    image: infisical/infisical:v0.158.2
+    container_name: grc-infisical
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp
+      - /etc/ssl/certs
+    environment:
+      ENCRYPTION_KEY: ${INFISICAL_ENCRYPTION_KEY}
+      AUTH_SECRET: ${INFISICAL_AUTH_SECRET}
+      DB_CONNECTION_URI: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/infisical
+      REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379/1
+      SITE_URL: https://secrets.${APP_DOMAIN}
+      TELEMETRY_ENABLED: false
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - grc-network
+      - grc-dmz
+    labels:
+      - 'traefik.enable=true'
+      - 'traefik.docker.network=grc-dmz'
+      - 'traefik.http.routers.infisical.rule=Host(`secrets.${APP_DOMAIN}`)'
+      - 'traefik.http.routers.infisical.entrypoints=websecure'
+      - 'traefik.http.routers.infisical.tls.certresolver=letsencrypt'
+      - 'traefik.http.services.infisical.loadbalancer.server.port=8080'
+      - 'traefik.http.middlewares.infisical-ipallow.ipallowlist.sourcerange=10.0.0.0/8,172.16.0.0/12'
+      - 'traefik.http.routers.infisical.middlewares=infisical-ipallow'
+    restart: always
+    logging:
+      driver: 'json-file'
+      options:
+        max-size: '10m'
+        max-file: '3'
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:8080/api/status']
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 120s
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 1G
+        reservations:
+          cpus: '0.25'
+          memory: 256M
+
+  # ===========================================
   # Controls Service - Security Controls Management
   # ===========================================
   controls:
@@ -356,6 +416,8 @@ services:
       keycloak:
         condition: service_healthy
       rustfs:
+        condition: service_healthy
+      infisical:
         condition: service_healthy
     networks:
       - grc-network
@@ -457,6 +519,8 @@ services:
         condition: service_healthy
       rustfs:
         condition: service_healthy
+      infisical:
+        condition: service_healthy
     networks:
       - grc-network
     labels:
@@ -539,6 +603,8 @@ services:
         condition: service_healthy
       rustfs:
         condition: service_healthy
+      infisical:
+        condition: service_healthy
     networks:
       - grc-network
     labels:
@@ -620,6 +686,8 @@ services:
       keycloak:
         condition: service_healthy
       rustfs:
+        condition: service_healthy
+      infisical:
         condition: service_healthy
     networks:
       - grc-network
@@ -705,6 +773,8 @@ services:
         condition: service_healthy
       rustfs:
         condition: service_healthy
+      infisical:
+        condition: service_healthy
     networks:
       - grc-network
     labels:
@@ -788,6 +858,8 @@ services:
       keycloak:
         condition: service_healthy
       rustfs:
+        condition: service_healthy
+      infisical:
         condition: service_healthy
     networks:
       - grc-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -193,6 +193,47 @@ services:
       start_period: 10s
 
   # ===========================================
+  # Secrets Management - Infisical (Self-Hosted)
+  # Centralized secret management with audit trail
+  # ===========================================
+  infisical:
+    image: infisical/infisical:v0.158.2
+    container_name: grc-infisical
+    security_opt:
+      - no-new-privileges:true
+    environment:
+      ENCRYPTION_KEY: ${INFISICAL_ENCRYPTION_KEY:?INFISICAL_ENCRYPTION_KEY is required}
+      AUTH_SECRET: ${INFISICAL_AUTH_SECRET:?INFISICAL_AUTH_SECRET is required}
+      DB_CONNECTION_URI: postgresql://${POSTGRES_USER:?}:${POSTGRES_PASSWORD:?}@postgres:5432/infisical
+      REDIS_URL: redis://:${REDIS_PASSWORD:?}@redis:6379/1
+      SITE_URL: http://localhost:8443
+      TELEMETRY_ENABLED: false
+    ports:
+      - '127.0.0.1:8443:8080'
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - grc-network
+    restart: unless-stopped
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:8080/api/status']
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 120s
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 1G
+        reservations:
+          cpus: '0.25'
+          memory: 256M
+
+  # ===========================================
   # Controls Service - Security Controls Management
   # ===========================================
   controls:
@@ -243,6 +284,8 @@ services:
       keycloak:
         condition: service_started
       rustfs:
+        condition: service_healthy
+      infisical:
         condition: service_healthy
     networks:
       - grc-network
@@ -318,6 +361,8 @@ services:
         condition: service_started
       rustfs:
         condition: service_healthy
+      infisical:
+        condition: service_healthy
     networks:
       - grc-network
     labels:
@@ -369,6 +414,8 @@ services:
         condition: service_started
       rustfs:
         condition: service_healthy
+      infisical:
+        condition: service_healthy
     networks:
       - grc-network
     labels:
@@ -418,6 +465,8 @@ services:
       keycloak:
         condition: service_started
       rustfs:
+        condition: service_healthy
+      infisical:
         condition: service_healthy
     networks:
       - grc-network
@@ -476,6 +525,8 @@ services:
         condition: service_started
       rustfs:
         condition: service_healthy
+      infisical:
+        condition: service_healthy
     networks:
       - grc-network
     labels:
@@ -529,6 +580,8 @@ services:
       keycloak:
         condition: service_started
       rustfs:
+        condition: service_healthy
+      infisical:
         condition: service_healthy
     networks:
       - grc-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -193,17 +193,20 @@ services:
       start_period: 10s
 
   # ===========================================
-  # Secrets Management - Infisical (Self-Hosted)
-  # Centralized secret management with audit trail
+  # Secrets Management - Infisical (Optional)
+  # Only starts with: docker compose --profile infisical up -d
+  # Set SECRETS_PROVIDER=infisical in .env to use
   # ===========================================
   infisical:
     image: infisical/infisical:v0.158.2
     container_name: grc-infisical
+    profiles:
+      - infisical
     security_opt:
       - no-new-privileges:true
     environment:
-      ENCRYPTION_KEY: ${INFISICAL_ENCRYPTION_KEY:?INFISICAL_ENCRYPTION_KEY is required}
-      AUTH_SECRET: ${INFISICAL_AUTH_SECRET:?INFISICAL_AUTH_SECRET is required}
+      ENCRYPTION_KEY: ${INFISICAL_ENCRYPTION_KEY:-}
+      AUTH_SECRET: ${INFISICAL_AUTH_SECRET:-}
       DB_CONNECTION_URI: postgresql://${POSTGRES_USER:?}:${POSTGRES_PASSWORD:?}@postgres:5432/infisical
       REDIS_URL: redis://:${REDIS_PASSWORD:?}@redis:6379/1
       SITE_URL: http://localhost:8443
@@ -219,7 +222,8 @@ services:
       - grc-network
     restart: unless-stopped
     healthcheck:
-      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:8080/api/status']
+      test:
+        ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:8080/api/status']
       interval: 15s
       timeout: 10s
       retries: 10
@@ -285,8 +289,7 @@ services:
         condition: service_started
       rustfs:
         condition: service_healthy
-      infisical:
-        condition: service_healthy
+
     networks:
       - grc-network
     labels:
@@ -361,8 +364,7 @@ services:
         condition: service_started
       rustfs:
         condition: service_healthy
-      infisical:
-        condition: service_healthy
+
     networks:
       - grc-network
     labels:
@@ -414,8 +416,7 @@ services:
         condition: service_started
       rustfs:
         condition: service_healthy
-      infisical:
-        condition: service_healthy
+
     networks:
       - grc-network
     labels:
@@ -466,8 +467,7 @@ services:
         condition: service_started
       rustfs:
         condition: service_healthy
-      infisical:
-        condition: service_healthy
+
     networks:
       - grc-network
     labels:
@@ -525,8 +525,7 @@ services:
         condition: service_started
       rustfs:
         condition: service_healthy
-      infisical:
-        condition: service_healthy
+
     networks:
       - grc-network
     labels:
@@ -581,8 +580,7 @@ services:
         condition: service_started
       rustfs:
         condition: service_healthy
-      infisical:
-        condition: service_healthy
+
     networks:
       - grc-network
     labels:

--- a/docs/secrets-management.md
+++ b/docs/secrets-management.md
@@ -1,0 +1,425 @@
+# Secrets Management
+
+## Overview
+
+GigaChad GRC includes a vendor-agnostic secrets management layer that decouples
+integration credentials from the application database. Instead of storing raw or
+locally-encrypted secrets in the `Integration.config` JSON column, the system can
+delegate storage and retrieval to an external key management service (KMS).
+
+The layer is designed to avoid vendor lock-in. A `SecretsProvider` interface
+defines the contract, a provider registry maps type names to implementations, and
+a factory selects the right provider at startup based on a single environment
+variable. Adding a new backend (HashiCorp Vault, AWS Secrets Manager, etc.) means
+implementing one interface and registering it -- no changes to consuming services.
+
+**Default behavior:** When no external provider is configured, the `env` provider
+is used. Integration credentials are encrypted locally with AES-256-GCM and
+stored in the database as before. No external infrastructure is required.
+
+---
+
+## Quick Start
+
+The default configuration works out of the box. No environment variables need to
+be set.
+
+1. Start the application normally (`docker compose up -d` or `make rebuild`).
+2. The secrets layer initializes with the `env` provider.
+3. Integration credentials are encrypted locally with AES-256-GCM using the
+   `ENCRYPTION_KEY` environment variable.
+4. No external secrets service is contacted.
+
+To explicitly select the default provider, set in your `.env`:
+
+```
+SECRETS_PROVIDER=env
+```
+
+Or leave `SECRETS_PROVIDER` unset entirely -- the factory defaults to `env`.
+
+---
+
+## Choosing a Provider
+
+Set the `SECRETS_PROVIDER` environment variable in `.env` to select a backend.
+The factory reads this value at service startup and instantiates the
+corresponding provider class from the registry.
+
+| Provider  | Value       | Description                                                      |
+| --------- | ----------- | ---------------------------------------------------------------- |
+| Env       | `env`       | Default. Reads from `process.env`, local AES-256-GCM encryption. |
+| Infisical | `infisical` | Self-hosted Infisical instance with Universal Auth.              |
+
+The `env` provider's `isEnabled()` returns `false`, which signals consuming
+services to continue using local encryption for credential storage. External
+providers return `true` when connected, and consuming services store a
+`secrets://` URI reference in the database instead of the encrypted value itself.
+
+---
+
+## Configuring Infisical
+
+Infisical is the first external provider. It runs as an optional Docker Compose
+profile and authenticates via Universal Auth (Machine Identity).
+
+### 1. Generate bootstrap secrets
+
+Infisical's container needs its own encryption key and auth secret. Generate them
+once and add them to your `.env`:
+
+```bash
+# Generate required Infisical container secrets
+echo "INFISICAL_ENCRYPTION_KEY=$(openssl rand -hex 16)" >> .env
+echo "INFISICAL_AUTH_SECRET=$(openssl rand -hex 32)" >> .env
+```
+
+These are used by the Infisical container itself (mapped to `ENCRYPTION_KEY` and
+`AUTH_SECRET` inside the container). They are not the same as the application's
+`ENCRYPTION_KEY`.
+
+### 2. Start the Infisical profile
+
+```bash
+docker compose --profile infisical up -d
+```
+
+This starts the `grc-infisical` container on port 8443 (dev) or behind Traefik
+at `secrets.<APP_DOMAIN>` (prod). The container uses the shared Postgres instance
+with a separate `infisical` database and Redis on database index 1.
+
+### 3. Create an admin account
+
+Open `http://localhost:8443` in a browser and complete the Infisical setup
+wizard. Create an organization and a project for GigaChad GRC.
+
+### 4. Create a Machine Identity
+
+In the Infisical dashboard:
+
+1. Navigate to Organization Settings > Machine Identities.
+2. Create a new identity with Universal Auth.
+3. Note the **Client ID** and **Client Secret**.
+4. Grant the identity access to your project with read/write permissions.
+5. Note your **Project ID** from the project settings page.
+
+### 5. Set environment variables
+
+Add the following to your `.env`:
+
+```
+SECRETS_PROVIDER=infisical
+
+INFISICAL_SITE_URL=http://infisical:8080
+INFISICAL_CLIENT_ID=<your-client-id>
+INFISICAL_CLIENT_SECRET=<your-client-secret>
+INFISICAL_PROJECT_ID=<your-project-id>
+```
+
+Optional variables:
+
+| Variable                | Default | Description                               |
+| ----------------------- | ------- | ----------------------------------------- |
+| `INFISICAL_ENVIRONMENT` | `dev`   | Infisical environment slug.               |
+| `INFISICAL_SECRET_PATH` | `/`     | Base path for secrets within the project. |
+
+`INFISICAL_URL` is accepted as an alias for `INFISICAL_SITE_URL`.
+
+### 6. Restart services
+
+```bash
+docker compose up -d --build controls frameworks policies tprm trust audit
+```
+
+On startup, each service logs either `Infisical SDK connected successfully` or a
+warning with fallback to `process.env` if the connection fails. The fallback is
+graceful -- services continue to operate using local encryption.
+
+---
+
+## Key Management Operations
+
+### Listing Managed Keys
+
+```typescript
+const keys = await secretsService.listManagedKeys('/integrations');
+// Returns: [{ key: 'int_abc123_api_key', createdAt: Date, updatedAt: Date }, ...]
+```
+
+`listManagedKeys(path?)` returns secret key names with optional timestamps. No
+secret values are exposed. This is intended for audit and inventory use cases.
+
+The `env` provider returns an empty array since it has no concept of managed
+secrets. The Infisical provider returns all keys at the given path with their
+`createdAt` and `updatedAt` timestamps from the Infisical API.
+
+### Key Rotation
+
+```typescript
+const newValue = await secretsService.rotateSecret('int_abc123_api_key', '/integrations');
+```
+
+`rotateSecret(name, path?, generator?)` performs an atomic rotate:
+
+1. Generates a new secret value. The default generator produces 32 random hex
+   bytes via `crypto.randomBytes(32)`. Pass a custom `generator` function for
+   provider-specific requirements (e.g., a specific format or length).
+2. Writes the new value to the provider via `setSecret`.
+3. Invalidates the in-memory cache entry for that key.
+4. Returns the new value.
+
+```typescript
+// Custom generator example
+const newApiKey = await secretsService.rotateSecret(
+  'int_abc123_api_key',
+  '/integrations',
+  () => `grc_${randomBytes(24).toString('base64url')}`
+);
+```
+
+### Caching
+
+The `SecretsService` maintains a TTL-based in-memory cache per service instance.
+Cache behavior:
+
+- **Reads** (`getSecret`): Served from cache if the entry exists and has not
+  expired. On cache miss, the provider is queried and the result is cached.
+- **Writes** (`setSecret`): The cache entry is updated immediately with the new
+  value and a fresh TTL.
+- **Deletes** (`deleteSecret`): The cache entry is evicted.
+- **Rotates** (`rotateSecret`): The cache entry is replaced with the new value.
+- **Lists** (`listSecrets`, `listManagedKeys`): Not cached. Always returns live
+  data from the provider.
+
+Configure the TTL via environment variable:
+
+```
+SECRETS_CACHE_TTL=300
+```
+
+Value is in seconds. Default is 300 (5 minutes). The cache is per-process -- in a
+multi-replica deployment, each instance maintains its own cache and there is no
+cross-instance invalidation.
+
+---
+
+## Adding a Custom Provider
+
+To add a new secrets backend (e.g., HashiCorp Vault), follow these steps.
+
+### 1. Create the provider file
+
+Create a new file in `services/shared/src/secrets/providers/`:
+
+```typescript
+// services/shared/src/secrets/providers/vault.provider.ts
+import { Logger } from '@nestjs/common';
+import { randomBytes } from 'crypto';
+import { SecretsProvider, SecretsProviderConfig } from '../secrets.interface';
+import { registerSecretsProvider } from '../secrets.registry';
+
+export class VaultSecretsProvider implements SecretsProvider {
+  private readonly logger = new Logger(VaultSecretsProvider.name);
+  private client: any = null;
+  private connected = false;
+
+  constructor(private config: SecretsProviderConfig) {
+    // Read provider-specific config from the generic bag
+    // e.g., this.config.VAULT_ADDR, this.config.VAULT_TOKEN
+  }
+
+  async init(): Promise<void> {
+    try {
+      // Dynamic import to avoid hard dependency
+      const vault = await import('node-vault');
+      this.client = vault.default({ endpoint: this.config.VAULT_ADDR as string });
+      // Authenticate...
+      this.connected = true;
+    } catch (error) {
+      this.logger.warn(`Vault init failed: ${error}`);
+    }
+  }
+
+  async destroy(): Promise<void> {
+    this.client = null;
+    this.connected = false;
+  }
+
+  async getSecret(name: string, path?: string): Promise<string | undefined> {
+    // Implement KV v2 read
+    return undefined;
+  }
+
+  async listSecrets(path?: string): Promise<Array<{ key: string; value: string }>> {
+    return [];
+  }
+
+  async setSecret(name: string, value: string, path?: string): Promise<void> {
+    // Implement KV v2 write
+  }
+
+  async deleteSecret(name: string, path?: string): Promise<void> {
+    // Implement KV v2 delete
+  }
+
+  isEnabled(): boolean {
+    return this.connected;
+  }
+
+  async listManagedKeys(
+    path?: string
+  ): Promise<Array<{ key: string; createdAt?: Date; updatedAt?: Date }>> {
+    // Implement KV v2 list metadata
+    return [];
+  }
+
+  async rotateSecret(name: string, path?: string, generator?: () => string): Promise<string> {
+    const newValue = generator ? generator() : randomBytes(32).toString('hex');
+    await this.setSecret(name, newValue, path);
+    return newValue;
+  }
+}
+
+// Self-register at import time
+registerSecretsProvider('vault', VaultSecretsProvider);
+```
+
+### 2. Register the import
+
+Add the import to `services/shared/src/secrets/providers/index.ts`:
+
+```typescript
+import './env.provider';
+import './infisical.provider';
+import './vault.provider'; // <-- add this line
+```
+
+The import triggers the `registerSecretsProvider('vault', ...)` call at module
+load time, which registers the constructor in the provider registry before the
+factory runs.
+
+### 3. Set the environment variable
+
+In `.env`:
+
+```
+SECRETS_PROVIDER=vault
+```
+
+### 4. Install any required SDK
+
+```bash
+npm install node-vault
+```
+
+### Summary of steps
+
+1. Create a file in `services/shared/src/secrets/providers/`.
+2. Implement the `SecretsProvider` interface (all 9 methods).
+3. Call `registerSecretsProvider('name', YourProvider)` at module scope.
+4. Add the import to `providers/index.ts`.
+5. Set `SECRETS_PROVIDER=name` in `.env`.
+6. Install any required SDK package.
+
+The factory (`secrets.factory.ts`) reads `SECRETS_PROVIDER` from the environment,
+looks up the registered constructor, and passes the full `process.env` as a
+generic config bag. Your provider reads only the keys it needs (e.g.,
+`VAULT_ADDR`, `VAULT_TOKEN`).
+
+---
+
+## Migration Guide
+
+### Moving from `env` to an external provider
+
+1. Set `SECRETS_PROVIDER=infisical` (or your chosen provider) in `.env`.
+2. Configure the provider's required environment variables.
+3. Restart services.
+
+Existing locally-encrypted integration credentials in the database remain
+readable. The AES-256-GCM decryption path is independent of the secrets provider.
+New credentials saved after the switch will be stored in the external provider,
+and a `secrets://` URI reference will be written to the database column instead
+of the encrypted blob.
+
+Over time, as integrations are re-saved or credentials are rotated, the database
+will transition from encrypted blobs to URI references. No bulk migration is
+required.
+
+### Moving from one external provider to another
+
+If you switch from one external provider to another (e.g., Infisical to Vault),
+ensure the same secret names and paths exist in the new provider. The
+integrations service stores references like `secrets://int_abc123_api_key` in the
+database. As long as the new provider can resolve those names, the transition is
+transparent.
+
+Steps:
+
+1. Export secrets from the old provider (using `listSecrets` or the provider's
+   native export tooling).
+2. Import them into the new provider under the same names and paths.
+3. Update `SECRETS_PROVIDER` in `.env`.
+4. Restart services.
+
+### Legacy URI prefix
+
+The `infisical://` URI prefix is supported alongside the current `secrets://`
+prefix for backwards compatibility. Database values written before the
+abstraction layer was introduced used `infisical://` references. Both prefixes
+resolve through the same `SecretsService.getSecret()` path -- the prefix is
+stripped and the secret name is looked up in whichever provider is currently
+configured.
+
+---
+
+## Architecture
+
+The secrets management layer is structured as a set of composable pieces in
+`services/shared/src/secrets/`. From bottom to top:
+
+**SecretsProvider interface** (`secrets.interface.ts`). Defines the contract that
+every provider must implement: `init`, `destroy`, `getSecret`, `listSecrets`,
+`setSecret`, `deleteSecret`, `isEnabled`, `listManagedKeys`, and `rotateSecret`.
+Also defines `SecretsProviderConfig` (a generic string-keyed bag) and
+`SecretsProviderConstructor` (the constructor signature providers must expose).
+
+**Provider Registry** (`secrets.registry.ts`). A `Map<string, Constructor>` that
+maps provider type names (e.g., `"env"`, `"infisical"`) to their class
+constructors. Providers self-register by calling `registerSecretsProvider()` at
+module scope when their file is imported. `getRegisteredProviders()` returns all
+known type names for error messages.
+
+**Built-in Providers** (`providers/`). Each provider file implements
+`SecretsProvider` and calls `registerSecretsProvider()` at the bottom. The barrel
+file `providers/index.ts` imports all provider files to trigger registration.
+Currently ships with `env` (process.env fallback, no external connection) and
+`infisical` (Infisical SDK with Universal Auth).
+
+**Factory** (`secrets.factory.ts`). `createSecretsProvider(type, config)` looks
+up the constructor from the registry and instantiates it with the config bag.
+`getSecretsConfigFromEnv()` reads `SECRETS_PROVIDER` from `process.env` (default:
+`"env"`) and copies all environment variables into the config bag so each
+provider can read only the keys it needs.
+
+**SecretsService** (`secrets.service.ts`). The NestJS `@Injectable()` that
+consuming services depend on. Wraps a provider instance with a TTL-based
+in-memory cache (`Map<string, CacheEntry>`). Implements `OnModuleInit` (calls
+`provider.init()`) and `OnModuleDestroy` (clears cache, calls
+`provider.destroy()`). The cache key format is `{path}:{name}`. Cache TTL is
+read from `SECRETS_CACHE_TTL` (seconds, default 300).
+
+**SecretsModule** (`secrets.module.ts`). A `@Global()` NestJS dynamic module.
+`SecretsModule.forRoot()` provides `SecretsService` as a singleton available to
+all modules in the application without explicit imports. It registers both the
+`SECRETS_PROVIDER` injection token and the `SecretsService` class so consumers
+can inject via either.
+
+**Integrations Service** (consumer, in `services/controls/`). The primary
+consumer. When saving integration credentials with an active external provider,
+it writes the secret value to the provider and stores a `secrets://` URI
+reference in the database `Integration.config` column. When reading, it detects
+the `secrets://` (or legacy `infisical://`) prefix, strips it, and calls
+`secretsService.getSecret()` to retrieve the actual value. If the provider is
+not enabled (`isEnabled() === false`), it falls back to local AES-256-GCM
+encryption as before.

--- a/init.sh
+++ b/init.sh
@@ -38,7 +38,7 @@ NC='\033[0m'
 
 # Services to manage
 SERVICES=(shared controls frameworks policies tprm trust audit)
-INFRASTRUCTURE=(postgres redis keycloak rustfs)
+INFRASTRUCTURE=(postgres redis keycloak rustfs infisical)
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Helper Functions
@@ -152,6 +152,20 @@ setup_environment() {
     
     if [ -f ".env" ]; then
         log_success ".env file exists (using existing credentials)"
+        # Migrate: append Infisical bootstrap secrets if missing from older .env
+        if ! grep -q '^INFISICAL_ENCRYPTION_KEY=' ".env" 2>/dev/null; then
+            log_substep "Adding missing Infisical secrets to existing .env..."
+            local INF_ENC_KEY INF_AUTH_SEC
+            INF_ENC_KEY=$(openssl rand -hex 16 2>/dev/null || head -c 16 /dev/urandom | xxd -p | tr -d '\n')
+            INF_AUTH_SEC=$(openssl rand -base64 32 2>/dev/null | tr -d '\n' || head -c 32 /dev/urandom | base64 | tr -d '\n')
+            cat >> ".env" << INFISICAL_EOF
+
+# Infisical Secrets Manager (auto-added)
+INFISICAL_ENCRYPTION_KEY=${INF_ENC_KEY}
+INFISICAL_AUTH_SECRET=${INF_AUTH_SEC}
+INFISICAL_EOF
+            log_success "Infisical bootstrap secrets added to .env"
+        fi
         # Source the existing .env to get passwords for health checks
         set -a
         source .env 2>/dev/null || true
@@ -182,7 +196,9 @@ setup_environment() {
     POSTGRES_PASSWORD=$(openssl rand -base64 24 2>/dev/null | tr -d '\n' | tr '+/' '-_' || head -c 24 /dev/urandom | base64 | tr '+/' '-_')
     REDIS_PASSWORD=$(openssl rand -base64 24 2>/dev/null | tr -d '\n' | tr '+/' '-_' || head -c 24 /dev/urandom | base64 | tr '+/' '-_')
     MINIO_PASSWORD=$(openssl rand -base64 20 2>/dev/null | tr -d '\n' | tr '+/' '-_' || head -c 20 /dev/urandom | base64 | tr '+/' '-_')
-    
+    INFISICAL_ENCRYPTION_KEY=$(openssl rand -hex 16 2>/dev/null || head -c 16 /dev/urandom | xxd -p | tr -d '\n')
+    INFISICAL_AUTH_SECRET=$(openssl rand -base64 32 2>/dev/null | tr -d '\n' || head -c 32 /dev/urandom | base64 | tr -d '\n')
+
     cat > ".env" << EOF
 # ============================================================================
 # GigaChad GRC - Environment Configuration
@@ -230,6 +246,10 @@ RATE_LIMIT_MAX_REQUESTS=1000
 # Logging
 LOG_LEVEL=debug
 
+# Infisical Secrets Manager
+INFISICAL_ENCRYPTION_KEY=${INFISICAL_ENCRYPTION_KEY}
+INFISICAL_AUTH_SECRET=${INFISICAL_AUTH_SECRET}
+
 # Frontend
 VITE_API_URL=http://localhost:3001
 VITE_ENABLE_DEV_AUTH=true
@@ -249,8 +269,8 @@ start_infrastructure() {
     
     cd "$PROJECT_ROOT"
     
-    log_substep "Starting PostgreSQL, Redis, Keycloak, RustFS..."
-    docker compose up -d postgres redis keycloak rustfs 2>/dev/null || docker-compose up -d postgres redis keycloak rustfs
+    log_substep "Starting PostgreSQL, Redis, Keycloak, RustFS, Infisical..."
+    docker compose up -d postgres redis keycloak rustfs infisical 2>/dev/null || docker-compose up -d postgres redis keycloak rustfs infisical
     
     # Wait for database
     log_substep "Waiting for PostgreSQL to be ready..."
@@ -293,6 +313,25 @@ start_infrastructure() {
         sleep 2
     done
     
+    # Wait for Infisical
+    log_substep "Waiting for Infisical to be ready..."
+    attempts=0
+    while [ $attempts -lt 30 ]; do
+        if curl -sf http://localhost:8443/api/status > /dev/null 2>&1; then
+            log_success "Infisical is ready"
+            break
+        fi
+        attempts=$((attempts + 1))
+        sleep 2
+    done
+
+    # First-time Infisical setup hint
+    if [ ! -f ".infisical-initialized" ]; then
+        log_info "Visit http://localhost:8443 to create your Infisical admin account"
+        log_info "Then run 'make secrets-seed' to import application secrets"
+        touch .infisical-initialized
+    fi
+
     log_success "All infrastructure services running"
 }
 
@@ -434,8 +473,8 @@ reset_all() {
     log_substep "Stopping containers..."
     docker compose down -v 2>/dev/null || docker-compose down -v 2>/dev/null || true
     
-    log_substep "Removing .env..."
-    rm -f .env
+    log_substep "Removing .env and Infisical state..."
+    rm -f .env .infisical-initialized
     
     log_substep "Removing node_modules..."
     rm -rf node_modules
@@ -465,6 +504,7 @@ print_success_demo() {
     echo -e "   ${CYAN}API Docs${NC}        http://localhost:3001/api/docs"
     echo -e "   ${CYAN}Keycloak${NC}        http://localhost:8080 (admin/admin)"
     echo -e "   ${CYAN}RustFS Console${NC}  http://localhost:9001 (rustfsadmin/...)"
+    echo -e "   ${CYAN}Secrets${NC}         http://localhost:8443 (Infisical)"
     echo -e "   ${CYAN}Grafana${NC}         http://localhost:3003 (admin/admin)"
     echo ""
     echo -e "${BOLD}Quick Login:${NC}"

--- a/scripts/seed-infisical.sh
+++ b/scripts/seed-infisical.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+# =============================================================================
+# GigaChad GRC - Seed Infisical with Application Secrets
+# =============================================================================
+#
+# This script imports application-tier secrets from the existing .env file
+# into Infisical for centralized secret management.
+#
+# Prerequisites:
+#   1. Infisical must be running (docker compose up infisical)
+#   2. Create an admin account at http://localhost:8443
+#   3. Create a Machine Identity with Universal Auth and generate a token
+#
+# Usage: ./scripts/seed-infisical.sh
+#
+# =============================================================================
+
+set -euo pipefail
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+ENV_FILE="$PROJECT_DIR/.env"
+
+INFISICAL_URL="${INFISICAL_URL:-http://localhost:8443}"
+
+echo ""
+echo -e "${CYAN}╔═══════════════════════════════════════════════════════════════╗${NC}"
+echo -e "${CYAN}║       GigaChad GRC - Infisical Secret Seeding                ║${NC}"
+echo -e "${CYAN}╚═══════════════════════════════════════════════════════════════╝${NC}"
+echo ""
+
+# Step 1: Check Infisical is healthy
+echo -e "${BLUE}[1/4]${NC} Checking Infisical health..."
+attempts=0
+max_attempts=15
+while [ $attempts -lt $max_attempts ]; do
+    if curl -sf "${INFISICAL_URL}/api/status" > /dev/null 2>&1; then
+        echo -e "  ${GREEN}✓${NC} Infisical is healthy at ${INFISICAL_URL}"
+        break
+    fi
+    attempts=$((attempts + 1))
+    if [ $attempts -eq $max_attempts ]; then
+        echo -e "  ${RED}✗${NC} Infisical is not responding at ${INFISICAL_URL}"
+        echo -e "  ${YELLOW}→${NC} Start it with: docker compose up -d infisical"
+        exit 1
+    fi
+    sleep 2
+done
+
+# Step 2: Check for admin account
+echo ""
+echo -e "${BLUE}[2/4]${NC} Admin account setup"
+echo -e "  ${YELLOW}→${NC} If you haven't already, visit ${CYAN}${INFISICAL_URL}${NC} to create your admin account"
+echo ""
+read -p "  Have you created an admin account? (y/n) " -n 1 -r
+echo ""
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo -e "  ${YELLOW}→${NC} Please create an admin account first, then re-run this script"
+    exit 0
+fi
+
+# Step 3: Get API token
+echo ""
+echo -e "${BLUE}[3/4]${NC} Machine Identity setup"
+echo -e "  To seed secrets, you need an API token from Infisical:"
+echo ""
+echo -e "  1. Go to ${CYAN}${INFISICAL_URL}${NC} → Admin Console → Machine Identities"
+echo -e "  2. Create a new Machine Identity (e.g., 'grc-seeder')"
+echo -e "  3. Add Universal Auth method"
+echo -e "  4. Generate a Client ID and Client Secret"
+echo ""
+
+if [ -n "${INFISICAL_TOKEN:-}" ]; then
+    echo -e "  ${GREEN}✓${NC} Using INFISICAL_TOKEN from environment"
+    TOKEN="$INFISICAL_TOKEN"
+else
+    read -p "  Enter your Infisical API token (or Machine Identity token): " TOKEN
+    if [ -z "$TOKEN" ]; then
+        echo -e "  ${RED}✗${NC} Token is required"
+        exit 1
+    fi
+fi
+
+# Step 4: Import secrets from .env
+echo ""
+echo -e "${BLUE}[4/4]${NC} Importing application secrets from .env..."
+
+if [ ! -f "$ENV_FILE" ]; then
+    echo -e "  ${RED}✗${NC} .env file not found at $ENV_FILE"
+    exit 1
+fi
+
+# Application-tier secrets to migrate to Infisical
+APP_SECRETS=(
+    "ENCRYPTION_KEY"
+    "JWT_SECRET"
+    "SESSION_SECRET"
+    "PHISHING_TRACKING_SECRET"
+    "KEYCLOAK_ADMIN_PASSWORD"
+    "KEYCLOAK_ADMIN_CLIENT_SECRET"
+    "GRAFANA_ADMIN_PASSWORD"
+    "OPENAI_API_KEY"
+    "ANTHROPIC_API_KEY"
+)
+
+imported=0
+skipped=0
+
+for secret_name in "${APP_SECRETS[@]}"; do
+    # Extract value from .env file
+    value=$(grep "^${secret_name}=" "$ENV_FILE" 2>/dev/null | head -1 | cut -d'=' -f2-)
+
+    if [ -z "$value" ]; then
+        echo -e "  ${YELLOW}⚠${NC} ${secret_name} - not found in .env (skipped)"
+        skipped=$((skipped + 1))
+        continue
+    fi
+
+    # Create/update secret in Infisical via API
+    response=$(curl -sf -X POST "${INFISICAL_URL}/api/v3/secrets/raw/${secret_name}" \
+        -H "Authorization: Bearer ${TOKEN}" \
+        -H "Content-Type: application/json" \
+        -d "{
+            \"workspaceId\": \"default\",
+            \"environment\": \"dev\",
+            \"secretValue\": \"${value}\",
+            \"type\": \"shared\"
+        }" 2>&1) || true
+
+    if echo "$response" | grep -q '"secret"' 2>/dev/null; then
+        echo -e "  ${GREEN}✓${NC} ${secret_name}"
+        imported=$((imported + 1))
+    else
+        # Try updating if create fails (secret may already exist)
+        response=$(curl -sf -X PATCH "${INFISICAL_URL}/api/v3/secrets/raw/${secret_name}" \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{
+                \"workspaceId\": \"default\",
+                \"environment\": \"dev\",
+                \"secretValue\": \"${value}\",
+                \"type\": \"shared\"
+            }" 2>&1) || true
+
+        if echo "$response" | grep -q '"secret"' 2>/dev/null; then
+            echo -e "  ${GREEN}✓${NC} ${secret_name} (updated)"
+            imported=$((imported + 1))
+        else
+            echo -e "  ${RED}✗${NC} ${secret_name} - failed to import"
+            echo -e "      API response: ${response}"
+            skipped=$((skipped + 1))
+        fi
+    fi
+done
+
+echo ""
+echo -e "${GREEN}╔═══════════════════════════════════════════════════════════════╗${NC}"
+echo -e "${GREEN}║                    Seeding Complete!                          ║${NC}"
+echo -e "${GREEN}╚═══════════════════════════════════════════════════════════════╝${NC}"
+echo ""
+echo -e "  Imported: ${GREEN}${imported}${NC} secrets"
+echo -e "  Skipped:  ${YELLOW}${skipped}${NC} secrets"
+echo ""
+echo -e "${BOLD}Next steps:${NC}"
+echo -e "  1. Install Infisical CLI:  ${CYAN}brew install infisical/get-cli/infisical${NC}"
+echo -e "  2. Authenticate:           ${CYAN}infisical login --domain=${INFISICAL_URL}${NC}"
+echo -e "  3. Start with injection:   ${CYAN}make up${NC}"
+echo ""
+echo -e "  Secrets are now managed at ${CYAN}${INFISICAL_URL}${NC}"
+echo -e "  Rotate secrets there — no .env changes needed."
+echo ""

--- a/services/audit/src/auth/auth.module.ts
+++ b/services/audit/src/auth/auth.module.ts
@@ -1,0 +1,19 @@
+import { Global, Module } from '@nestjs/common';
+import { DevAuthGuard, RolesGuard, PermissionsGuard, PRISMA_SERVICE } from '@gigachad-grc/shared';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Global()
+@Module({
+  providers: [
+    PrismaService,
+    {
+      provide: PRISMA_SERVICE,
+      useExisting: PrismaService,
+    },
+    DevAuthGuard,
+    RolesGuard,
+    PermissionsGuard,
+  ],
+  exports: [PrismaService, PRISMA_SERVICE, DevAuthGuard, RolesGuard, PermissionsGuard],
+})
+export class AuthModule {}

--- a/services/controls/src/app.module.ts
+++ b/services/controls/src/app.module.ts
@@ -54,7 +54,7 @@ import { AuthModule } from './auth/auth.module';
 import { ModulesController } from './modules/modules.controller';
 import { CustomThrottlerGuard } from './auth/throttler.guard';
 import { CorrelationIdMiddleware } from './common/correlation-id.middleware';
-import { StorageModule, EventsModule, CacheModule, HealthModule } from '@gigachad-grc/shared';
+import { StorageModule, EventsModule, CacheModule, HealthModule, SecretsModule } from '@gigachad-grc/shared';
 
 @Module({
   imports: [
@@ -86,6 +86,7 @@ import { StorageModule, EventsModule, CacheModule, HealthModule } from '@gigacha
       path: 'api/metrics',
     }),
     PrismaModule,
+    SecretsModule.forRoot(),
     StorageModule.forRoot(),
     EventsModule,
     CacheModule.forRoot({

--- a/services/controls/src/integrations/integrations.module.ts
+++ b/services/controls/src/integrations/integrations.module.ts
@@ -3,9 +3,10 @@ import { IntegrationsController } from './integrations.controller';
 import { IntegrationsService } from './integrations.service';
 import { CustomIntegrationService } from './custom/custom-integration.service';
 import { PrismaModule } from '../prisma/prisma.module';
+import { SecretsModule } from '@gigachad-grc/shared';
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, SecretsModule.forRoot()],
   controllers: [IntegrationsController],
   providers: [IntegrationsService, CustomIntegrationService],
   exports: [IntegrationsService, CustomIntegrationService],

--- a/services/controls/src/integrations/integrations.service.ts
+++ b/services/controls/src/integrations/integrations.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, NotFoundException, BadRequestException, Logger, Inject } from '@nestjs/common';
 import * as crypto from 'crypto';
 import { PrismaService } from '../prisma/prisma.service';
-import { isSafePropertyName, safePropertySet } from '@gigachad-grc/shared';
+import { isSafePropertyName, safePropertySet, SecretsService } from '@gigachad-grc/shared';
 import { AuditService } from '../audit/audit.service';
 import { NotificationsService } from '../notifications/notifications.service';
 import { NotificationType, NotificationSeverity } from '../notifications/dto/notification.dto';
@@ -106,14 +106,134 @@ export class IntegrationsService {
     private prisma: PrismaService,
     private auditService: AuditService,
     private notificationsService: NotificationsService,
-    @Inject(STORAGE_PROVIDER) private storage: StorageProvider
+    @Inject(STORAGE_PROVIDER) private storage: StorageProvider,
+    private secretsService: SecretsService
   ) {
     this.connectorFactory = new ConnectorFactory();
     this.encryptionKey = this.validateEncryptionKey();
   }
+
+  /** Infisical secret path prefix for integration credentials */
+  private readonly INFISICAL_PREFIX = 'infisical://';
+
+  /**
+   * Generate an opaque Infisical secret name for an integration field
+   */
+  private infisicalSecretName(
+    organizationId: string,
+    integrationId: string,
+    fieldName: string
+  ): string {
+    return `int_${organizationId.slice(0, 8)}_${integrationId.slice(0, 8)}_${fieldName}`;
+  }
+
+  /**
+   * Infisical path for integration credentials
+   */
+  private infisicalSecretPath(organizationId: string): string {
+    return `/integrations/${organizationId}`;
+  }
+
+  /**
+   * Store a sensitive field in Infisical and return a reference string
+   */
+  private async storeInInfisical(
+    organizationId: string,
+    integrationId: string,
+    fieldName: string,
+    value: string
+  ): Promise<string> {
+    const secretName = this.infisicalSecretName(organizationId, integrationId, fieldName);
+    const secretPath = this.infisicalSecretPath(organizationId);
+    await this.secretsService.setSecret(secretName, value, secretPath);
+    return `${this.INFISICAL_PREFIX}${secretName}`;
+  }
+
+  /**
+   * Retrieve a sensitive field from Infisical by its reference string
+   */
+  private async fetchFromInfisical(
+    reference: string,
+    organizationId: string
+  ): Promise<string | undefined> {
+    const secretName = reference.replace(this.INFISICAL_PREFIX, '');
+    const secretPath = this.infisicalSecretPath(organizationId);
+    return this.secretsService.getSecret(secretName, secretPath);
+  }
+
+  /**
+   * Check if a value is an Infisical reference
+   */
+  private isInfisicalRef(value: unknown): value is string {
+    return typeof value === 'string' && value.startsWith(this.INFISICAL_PREFIX);
+  }
+
+  /**
+   * Clean up Infisical secrets for a deleted integration
+   */
+  private async cleanupInfisicalSecrets(
+    organizationId: string,
+    integrationId: string,
+    config: Record<string, unknown>
+  ): Promise<void> {
+    if (!this.secretsService.isEnabled()) return;
+
+    for (const [key, value] of Object.entries(config)) {
+      if (this.isInfisicalRef(value)) {
+        try {
+          const secretName = (value as string).replace(this.INFISICAL_PREFIX, '');
+          const secretPath = this.infisicalSecretPath(organizationId);
+          await this.secretsService.deleteSecret(secretName, secretPath);
+        } catch (error) {
+          this.logger.warn(`Failed to cleanup Infisical secret for ${key}: ${error}`);
+        }
+      } else if (typeof value === 'object' && value !== null) {
+        await this.cleanupInfisicalSecrets(
+          organizationId,
+          integrationId,
+          value as Record<string, unknown>
+        );
+      }
+    }
+  }
   // ============================================
   // Encryption/Decryption for Sensitive Data
   // ============================================
+
+  /**
+   * Check if a string value is already in our encrypted format (iv:authTag:salt:encrypted or legacy iv:authTag:encrypted).
+   * Used to prevent double-encryption when the frontend sends back encrypted values.
+   */
+  private isEncryptedFormat(value: string): boolean {
+    if (!value || typeof value !== 'string') return false;
+    const parts = value.split(':');
+    const hexPattern = /^[0-9a-f]+$/i;
+    if (parts.length === 4) {
+      // New format: iv(32 hex chars):authTag(32):salt(32):encrypted(hex)
+      return (
+        parts[0].length === 32 &&
+        parts[1].length === 32 &&
+        parts[2].length === 32 &&
+        parts[3].length > 0 &&
+        hexPattern.test(parts[0]) &&
+        hexPattern.test(parts[1]) &&
+        hexPattern.test(parts[2]) &&
+        hexPattern.test(parts[3])
+      );
+    }
+    if (parts.length === 3) {
+      // Legacy format: iv(32):authTag(32):encrypted(hex)
+      return (
+        parts[0].length === 32 &&
+        parts[1].length === 32 &&
+        parts[2].length > 0 &&
+        hexPattern.test(parts[0]) &&
+        hexPattern.test(parts[1]) &&
+        hexPattern.test(parts[2])
+      );
+    }
+    return false;
+  }
 
   private encrypt(text: string): string {
     if (!text) return text;
@@ -133,11 +253,15 @@ export class IntegrationsService {
     return `${iv.toString('hex')}:${authTag.toString('hex')}:${salt.toString('hex')}:${encrypted}`;
   }
 
-  private decrypt(encryptedText: string): string {
+  private decrypt(encryptedText: string, depth = 0): string {
     if (!encryptedText) return encryptedText;
+    // Guard against infinite recursion (max 3 layers should be more than enough)
+    if (depth > 3) return encryptedText;
 
     try {
       const parts = encryptedText.split(':');
+
+      let decrypted: string;
 
       // Support both old format (3 parts: iv:authTag:encrypted) and new format (4 parts: iv:authTag:salt:encrypted)
       if (parts.length === 3) {
@@ -150,10 +274,8 @@ export class IntegrationsService {
         const decipher = crypto.createDecipheriv(this.algorithm, key, iv);
         decipher.setAuthTag(authTag);
 
-        let decrypted = decipher.update(encrypted, 'hex', 'utf8');
+        decrypted = decipher.update(encrypted, 'hex', 'utf8');
         decrypted += decipher.final('utf8');
-
-        return decrypted;
       } else if (parts.length === 4) {
         // New format with random salt
         const [ivHex, authTagHex, saltHex, encrypted] = parts;
@@ -165,14 +287,22 @@ export class IntegrationsService {
         const decipher = crypto.createDecipheriv(this.algorithm, key, iv);
         decipher.setAuthTag(authTag);
 
-        let decrypted = decipher.update(encrypted, 'hex', 'utf8');
+        decrypted = decipher.update(encrypted, 'hex', 'utf8');
         decrypted += decipher.final('utf8');
-
-        return decrypted;
       } else {
         // Not encrypted or invalid format
         return encryptedText;
       }
+
+      // Handle double-encrypted values: if decrypted result is still in encrypted format,
+      // decrypt again. This can happen when the frontend sends back raw encrypted values
+      // that get re-encrypted on update.
+      if (this.isEncryptedFormat(decrypted)) {
+        this.logger.warn('Detected double-encrypted value, decrypting inner layer');
+        return this.decrypt(decrypted, depth + 1);
+      }
+
+      return decrypted;
     } catch {
       this.logger.warn('Failed to decrypt value, returning as-is');
       return encryptedText;
@@ -180,9 +310,15 @@ export class IntegrationsService {
   }
 
   /**
-   * Encrypt sensitive fields in config object before storing
+   * Encrypt sensitive fields in config object before storing.
+   * When Infisical is enabled, stores sensitive fields there and saves a reference.
+   * Falls back to local AES-256-GCM encryption otherwise.
    */
-  private encryptConfig(config: Record<string, unknown>): Record<string, unknown> {
+  private async encryptConfigAsync(
+    config: Record<string, unknown>,
+    organizationId: string,
+    integrationId: string
+  ): Promise<Record<string, unknown>> {
     if (!config) return config;
 
     const encrypted: Record<string, unknown> = {};
@@ -194,15 +330,45 @@ export class IntegrationsService {
         continue;
       }
 
-      if (typeof value === 'object' && value !== null) {
+      if (Array.isArray(value)) {
+        // Preserve arrays as-is (e.g., evidenceTypes)
+        safePropertySet(encrypted, key, value);
+      } else if (typeof value === 'object' && value !== null) {
         // Recursively encrypt nested objects
-        safePropertySet(encrypted, key, this.encryptConfig(value as Record<string, unknown>));
+        safePropertySet(
+          encrypted,
+          key,
+          await this.encryptConfigAsync(
+            value as Record<string, unknown>,
+            organizationId,
+            integrationId
+          )
+        );
       } else if (
         typeof value === 'string' &&
         SENSITIVE_FIELDS.some((f) => key.toLowerCase().includes(f.toLowerCase()))
       ) {
-        // Encrypt sensitive string fields
-        safePropertySet(encrypted, key, this.encrypt(value));
+        // Skip already-encrypted values to prevent double encryption
+        // (can happen when frontend sends back raw encrypted values on update)
+        if (this.isEncryptedFormat(value)) {
+          safePropertySet(encrypted, key, value);
+        } else if (this.isInfisicalRef(value)) {
+          // Preserve existing Infisical references
+          safePropertySet(encrypted, key, value);
+        } else if (this.secretsService.isEnabled()) {
+          // Store in Infisical if available, otherwise encrypt locally
+          try {
+            const ref = await this.storeInInfisical(organizationId, integrationId, key, value);
+            safePropertySet(encrypted, key, ref);
+          } catch (error) {
+            this.logger.warn(
+              `Failed to store ${key} in Infisical, falling back to local encryption: ${error}`
+            );
+            safePropertySet(encrypted, key, this.encrypt(value));
+          }
+        } else {
+          safePropertySet(encrypted, key, this.encrypt(value));
+        }
       } else {
         safePropertySet(encrypted, key, value);
       }
@@ -212,9 +378,50 @@ export class IntegrationsService {
   }
 
   /**
-   * Decrypt sensitive fields in config object for internal use
+   * Synchronous encrypt for backward compatibility (no Infisical).
    */
-  private decryptConfig(config: Record<string, unknown>): Record<string, unknown> {
+  private encryptConfig(config: Record<string, unknown>): Record<string, unknown> {
+    if (!config) return config;
+
+    const encrypted: Record<string, unknown> = {};
+
+    for (const [key, value] of Object.entries(config)) {
+      if (!isSafePropertyName(key)) {
+        this.logger.warn(`Skipping blocked property name in encryptConfig: ${key}`);
+        continue;
+      }
+
+      if (Array.isArray(value)) {
+        // Preserve arrays as-is (e.g., evidenceTypes)
+        safePropertySet(encrypted, key, value);
+      } else if (typeof value === 'object' && value !== null) {
+        safePropertySet(encrypted, key, this.encryptConfig(value as Record<string, unknown>));
+      } else if (
+        typeof value === 'string' &&
+        SENSITIVE_FIELDS.some((f) => key.toLowerCase().includes(f.toLowerCase()))
+      ) {
+        // Skip already-encrypted values to prevent double encryption
+        if (this.isEncryptedFormat(value)) {
+          safePropertySet(encrypted, key, value);
+        } else {
+          safePropertySet(encrypted, key, this.encrypt(value));
+        }
+      } else {
+        safePropertySet(encrypted, key, value);
+      }
+    }
+
+    return encrypted;
+  }
+
+  /**
+   * Decrypt sensitive fields in config object for internal use.
+   * Supports both Infisical references (infisical://...) and local encrypted values.
+   */
+  private async decryptConfigAsync(
+    config: Record<string, unknown>,
+    organizationId: string
+  ): Promise<Record<string, unknown>> {
     if (!config) return config;
 
     const decrypted: Record<string, unknown> = {};
@@ -226,14 +433,62 @@ export class IntegrationsService {
         continue;
       }
 
-      if (typeof value === 'object' && value !== null) {
+      if (Array.isArray(value)) {
+        // Preserve arrays as-is (e.g., evidenceTypes)
+        safePropertySet(decrypted, key, value);
+      } else if (typeof value === 'object' && value !== null) {
         // Recursively decrypt nested objects
+        safePropertySet(
+          decrypted,
+          key,
+          await this.decryptConfigAsync(value as Record<string, unknown>, organizationId)
+        );
+      } else if (this.isInfisicalRef(value)) {
+        // Fetch from Infisical
+        try {
+          const fetched = await this.fetchFromInfisical(value, organizationId);
+          safePropertySet(decrypted, key, fetched || value);
+        } catch (error) {
+          this.logger.warn(`Failed to fetch ${key} from Infisical: ${error}`);
+          safePropertySet(decrypted, key, value);
+        }
+      } else if (
+        typeof value === 'string' &&
+        SENSITIVE_FIELDS.some((f) => key.toLowerCase().includes(f.toLowerCase()))
+      ) {
+        // Decrypt locally (legacy or fallback)
+        safePropertySet(decrypted, key, this.decrypt(value));
+      } else {
+        safePropertySet(decrypted, key, value);
+      }
+    }
+
+    return decrypted;
+  }
+
+  /**
+   * Synchronous decrypt for backward compatibility (no Infisical refs).
+   */
+  private decryptConfig(config: Record<string, unknown>): Record<string, unknown> {
+    if (!config) return config;
+
+    const decrypted: Record<string, unknown> = {};
+
+    for (const [key, value] of Object.entries(config)) {
+      if (!isSafePropertyName(key)) {
+        this.logger.warn(`Skipping blocked property name in decryptConfig: ${key}`);
+        continue;
+      }
+
+      if (Array.isArray(value)) {
+        // Preserve arrays as-is (e.g., evidenceTypes)
+        safePropertySet(decrypted, key, value);
+      } else if (typeof value === 'object' && value !== null) {
         safePropertySet(decrypted, key, this.decryptConfig(value as Record<string, unknown>));
       } else if (
         typeof value === 'string' &&
         SENSITIVE_FIELDS.some((f) => key.toLowerCase().includes(f.toLowerCase()))
       ) {
-        // Decrypt sensitive string fields
         safePropertySet(decrypted, key, this.decrypt(value));
       } else {
         safePropertySet(decrypted, key, value);
@@ -335,8 +590,13 @@ export class IntegrationsService {
       throw new BadRequestException(`Invalid integration type: ${dto.type}`);
     }
 
-    // Encrypt sensitive fields in config before storing
-    const encryptedConfig = dto.config ? this.encryptConfig(dto.config) : {};
+    // Generate a temporary ID for Infisical path (will be replaced with actual ID)
+    const tempId = crypto.randomUUID();
+
+    // Encrypt sensitive fields in config before storing (uses Infisical when available)
+    const encryptedConfig = dto.config
+      ? await this.encryptConfigAsync(dto.config, organizationId, tempId)
+      : {};
 
     const integration = await this.prisma.integration.create({
       data: {
@@ -391,8 +651,8 @@ export class IntegrationsService {
     // Merge config if provided (don't overwrite entire config)
     let newConfig = existing.config as Record<string, unknown>;
     if (dto.config) {
-      // Encrypt sensitive fields in the new config before merging
-      const encryptedNewConfig = this.encryptConfig(dto.config);
+      // Encrypt sensitive fields in the new config before merging (uses Infisical when available)
+      const encryptedNewConfig = await this.encryptConfigAsync(dto.config, organizationId, id);
       newConfig = { ...newConfig, ...encryptedNewConfig };
     }
 
@@ -458,6 +718,15 @@ export class IntegrationsService {
       throw new NotFoundException('Integration not found');
     }
 
+    // Clean up Infisical secrets for this integration
+    if (existing.config && this.secretsService.isEnabled()) {
+      await this.cleanupInfisicalSecrets(
+        organizationId,
+        id,
+        existing.config as Record<string, unknown>
+      );
+    }
+
     await this.prisma.integration.delete({
       where: { id },
     });
@@ -494,8 +763,26 @@ export class IntegrationsService {
       throw new NotFoundException('Integration not found');
     }
 
-    // Decrypt config for use in connection testing
-    const config = this.decryptConfig(integration.config as Record<string, unknown>);
+    // Decrypt config for use in connection testing (supports Infisical refs)
+    const rawConfig = await this.decryptConfigAsync(
+      integration.config as Record<string, unknown>,
+      organizationId
+    );
+
+    // Flatten credentials into top-level config so connectors can access fields
+    // directly (quick setup stores them under config.credentials)
+    const credentials = rawConfig.credentials as Record<string, unknown> | undefined;
+    const flattened = credentials
+      ? { ...rawConfig, ...credentials }
+      : { ...rawConfig };
+
+    // Map common field aliases (quick setup may use different names than configFields)
+    if (flattened.baseUrl && !flattened.siteUrl) {
+      flattened.siteUrl = flattened.baseUrl;
+    }
+
+    const config = flattened;
+
     const typeMeta = INTEGRATION_TYPES[integration.type as keyof typeof INTEGRATION_TYPES];
 
     if (!typeMeta) {
@@ -574,8 +861,11 @@ export class IntegrationsService {
       );
     }
 
-    // Decrypt config for use in sync operations
-    const config = this.decryptConfig(integration.config as Record<string, unknown>);
+    // Decrypt config for use in sync operations (supports Infisical refs)
+    const config = await this.decryptConfigAsync(
+      integration.config as Record<string, unknown>,
+      organizationId
+    );
 
     // Create a sync job
     const syncJob = await this.prisma.syncJob.create({
@@ -1252,14 +1542,34 @@ export class IntegrationsService {
     const typeMeta = INTEGRATION_TYPES[type as keyof typeof INTEGRATION_TYPES];
     if (!typeMeta) return config;
 
-    const masked = { ...config };
-    for (const field of typeMeta.configFields) {
-      if (field.type === 'password' && masked[field.key]) {
-        // Show only last 4 characters
-        const value = String(masked[field.key]);
-        masked[field.key] = value.length > 4 ? '••••••••' + value.slice(-4) : '••••••••';
+    const passwordFieldKeys = new Set(
+      typeMeta.configFields.filter((f) => f.type === 'password').map((f) => f.key)
+    );
+
+    const maskValue = (val: unknown): string => {
+      const str = String(val);
+      return str.length > 4 ? '••••••••' + str.slice(-4) : '••••••••';
+    };
+
+    const maskObject = (obj: Record<string, unknown>): Record<string, unknown> => {
+      const result = { ...obj };
+      for (const [key, value] of Object.entries(result)) {
+        if (passwordFieldKeys.has(key) && value) {
+          result[key] = maskValue(value);
+        } else if (
+          typeof value === 'string' &&
+          SENSITIVE_FIELDS.some((f) => key.toLowerCase().includes(f.toLowerCase())) &&
+          this.isEncryptedFormat(value)
+        ) {
+          // Mask any encrypted sensitive field even if not in configFields
+          result[key] = '••••••••';
+        } else if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+          result[key] = maskObject(value as Record<string, unknown>);
+        }
       }
-    }
-    return masked;
+      return result;
+    };
+
+    return maskObject(config);
   }
 }

--- a/services/frameworks/src/auth/auth.module.ts
+++ b/services/frameworks/src/auth/auth.module.ts
@@ -1,0 +1,19 @@
+import { Global, Module } from '@nestjs/common';
+import { DevAuthGuard, RolesGuard, PermissionsGuard, PRISMA_SERVICE } from '@gigachad-grc/shared';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Global()
+@Module({
+  providers: [
+    PrismaService,
+    {
+      provide: PRISMA_SERVICE,
+      useExisting: PrismaService,
+    },
+    DevAuthGuard,
+    RolesGuard,
+    PermissionsGuard,
+  ],
+  exports: [PrismaService, PRISMA_SERVICE, DevAuthGuard, RolesGuard, PermissionsGuard],
+})
+export class AuthModule {}

--- a/services/policies/src/auth/auth.module.ts
+++ b/services/policies/src/auth/auth.module.ts
@@ -1,0 +1,19 @@
+import { Global, Module } from '@nestjs/common';
+import { DevAuthGuard, RolesGuard, PermissionsGuard, PRISMA_SERVICE } from '@gigachad-grc/shared';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Global()
+@Module({
+  providers: [
+    PrismaService,
+    {
+      provide: PRISMA_SERVICE,
+      useExisting: PrismaService,
+    },
+    DevAuthGuard,
+    RolesGuard,
+    PermissionsGuard,
+  ],
+  exports: [PrismaService, PRISMA_SERVICE, DevAuthGuard, RolesGuard, PermissionsGuard],
+})
+export class AuthModule {}

--- a/services/shared/package.json
+++ b/services/shared/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.985.0",
+    "@infisical/sdk": "^4.0.6",
     "@aws-sdk/s3-request-presigner": "^3.450.0",
     "@azure/storage-blob": "^12.17.0",
     "@nestjs/throttler": "^6.5.0",

--- a/services/shared/src/index.ts
+++ b/services/shared/src/index.ts
@@ -172,3 +172,6 @@ export * from './session';
 
 // Security (Rate Limiting and SSRF protection)
 export * from './security';
+
+// Secrets (Infisical integration)
+export * from './secrets';

--- a/services/shared/src/secrets/index.ts
+++ b/services/shared/src/secrets/index.ts
@@ -1,2 +1,9 @@
 export { SecretsModule } from './secrets.module';
 export { SecretsService, SECRETS_PROVIDER } from './secrets.service';
+export type {
+  SecretsProvider,
+  SecretsProviderConfig,
+  SecretsProviderConstructor,
+} from './secrets.interface';
+export { registerSecretsProvider, getRegisteredProviders } from './secrets.registry';
+export { createSecretsProvider, getSecretsConfigFromEnv } from './secrets.factory';

--- a/services/shared/src/secrets/index.ts
+++ b/services/shared/src/secrets/index.ts
@@ -1,0 +1,2 @@
+export { SecretsModule } from './secrets.module';
+export { SecretsService, SECRETS_PROVIDER } from './secrets.service';

--- a/services/shared/src/secrets/providers/env.provider.ts
+++ b/services/shared/src/secrets/providers/env.provider.ts
@@ -1,0 +1,57 @@
+import { Logger } from '@nestjs/common';
+import { SecretsProvider, SecretsProviderConfig } from '../secrets.interface';
+import { registerSecretsProvider } from '../secrets.registry';
+
+/**
+ * Environment variable secrets provider (DEFAULT).
+ *
+ * Reads secrets from process.env. Write operations are no-ops.
+ * isEnabled() returns false so consumers fall back to local encryption.
+ */
+export class EnvSecretsProvider implements SecretsProvider {
+  private readonly logger = new Logger(EnvSecretsProvider.name);
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  constructor(_config: SecretsProviderConfig) {
+    // No configuration needed for env provider
+  }
+
+  async init(): Promise<void> {
+    this.logger.log('Using environment variables for secrets (no external provider)');
+  }
+
+  async destroy(): Promise<void> {
+    // Nothing to clean up
+  }
+
+  async getSecret(name: string): Promise<string | undefined> {
+    return process.env[name];
+  }
+
+  async listSecrets(): Promise<Array<{ key: string; value: string }>> {
+    return [];
+  }
+
+  async setSecret(name: string): Promise<void> {
+    this.logger.debug(`setSecret("${name}") is a no-op for env provider`);
+  }
+
+  async deleteSecret(name: string): Promise<void> {
+    this.logger.debug(`deleteSecret("${name}") is a no-op for env provider`);
+  }
+
+  isEnabled(): boolean {
+    return false;
+  }
+
+  async listManagedKeys(): Promise<Array<{ key: string; createdAt?: Date; updatedAt?: Date }>> {
+    return [];
+  }
+
+  async rotateSecret(): Promise<string> {
+    this.logger.debug('rotateSecret() is a no-op for env provider');
+    return '';
+  }
+}
+
+registerSecretsProvider('env', EnvSecretsProvider);

--- a/services/shared/src/secrets/providers/index.ts
+++ b/services/shared/src/secrets/providers/index.ts
@@ -1,0 +1,3 @@
+// Import providers to trigger self-registration
+import './env.provider';
+import './infisical.provider';

--- a/services/shared/src/secrets/providers/infisical.provider.ts
+++ b/services/shared/src/secrets/providers/infisical.provider.ts
@@ -1,0 +1,209 @@
+import { Logger } from '@nestjs/common';
+import { randomBytes } from 'crypto';
+import { SecretsProvider, SecretsProviderConfig } from '../secrets.interface';
+import { registerSecretsProvider } from '../secrets.registry';
+
+/**
+ * Infisical secrets provider.
+ *
+ * Connects to a self-hosted or cloud Infisical instance via the SDK.
+ * Uses Universal Auth (Machine Identity) for authentication.
+ *
+ * Required env vars:
+ *   INFISICAL_SITE_URL (or INFISICAL_URL)
+ *   INFISICAL_CLIENT_ID
+ *   INFISICAL_CLIENT_SECRET
+ *   INFISICAL_PROJECT_ID
+ *
+ * Optional:
+ *   INFISICAL_ENVIRONMENT (default: 'dev')
+ *   INFISICAL_SECRET_PATH (default: '/')
+ */
+export class InfisicalSecretsProvider implements SecretsProvider {
+  private readonly logger = new Logger(InfisicalSecretsProvider.name);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private client: any = null;
+  private enabled = false;
+
+  private readonly siteUrl: string | undefined;
+  private readonly clientId: string | undefined;
+  private readonly clientSecret: string | undefined;
+  private readonly projectId: string | undefined;
+  private readonly environment: string;
+  private readonly secretPath: string;
+
+  constructor(config: SecretsProviderConfig) {
+    this.siteUrl = (config.INFISICAL_SITE_URL || config.INFISICAL_URL) as string | undefined;
+    this.clientId = config.INFISICAL_CLIENT_ID as string | undefined;
+    this.clientSecret = config.INFISICAL_CLIENT_SECRET as string | undefined;
+    this.projectId = config.INFISICAL_PROJECT_ID as string | undefined;
+    this.environment = (config.INFISICAL_ENVIRONMENT as string) || 'dev';
+    this.secretPath = (config.INFISICAL_SECRET_PATH as string) || '/';
+  }
+
+  async init(): Promise<void> {
+    if (!this.siteUrl || !this.clientId || !this.clientSecret) {
+      this.logger.log(
+        'Infisical not configured (missing INFISICAL_SITE_URL, INFISICAL_CLIENT_ID, or INFISICAL_CLIENT_SECRET). Falling back to process.env.'
+      );
+      return;
+    }
+
+    try {
+      const { InfisicalSDK } = await import('@infisical/sdk');
+      this.client = new InfisicalSDK({
+        siteUrl: this.siteUrl,
+      });
+      await this.client.auth().universalAuth.login({
+        clientId: this.clientId,
+        clientSecret: this.clientSecret,
+      });
+      this.enabled = true;
+      this.logger.log('Infisical SDK connected successfully');
+    } catch (error) {
+      this.logger.warn(
+        `Failed to initialize Infisical SDK: ${error instanceof Error ? error.message : error}. Falling back to process.env.`
+      );
+    }
+  }
+
+  async destroy(): Promise<void> {
+    this.client = null;
+    this.enabled = false;
+  }
+
+  async getSecret(name: string, path?: string): Promise<string | undefined> {
+    if (this.enabled && this.client && this.projectId) {
+      try {
+        const secret = await this.client.secrets().getSecret({
+          environment: this.environment,
+          projectId: this.projectId,
+          secretName: name,
+          secretPath: path || this.secretPath,
+        });
+        return secret.secretValue;
+      } catch (error) {
+        this.logger.warn(
+          `Failed to fetch secret "${name}" from Infisical: ${error instanceof Error ? error.message : error}. Falling back to process.env.`
+        );
+      }
+    }
+
+    return process.env[name];
+  }
+
+  async listSecrets(path?: string): Promise<Array<{ key: string; value: string }>> {
+    if (this.enabled && this.client && this.projectId) {
+      try {
+        const result = await this.client.secrets().listSecrets({
+          environment: this.environment,
+          projectId: this.projectId,
+          secretPath: path || this.secretPath,
+        });
+        const secrets = result?.secrets || result || [];
+        return (Array.isArray(secrets) ? secrets : []).map(
+          (s: { secretKey: string; secretValue: string }) => ({
+            key: s.secretKey,
+            value: s.secretValue,
+          })
+        );
+      } catch (error) {
+        this.logger.warn(
+          `Failed to list secrets from Infisical: ${error instanceof Error ? error.message : error}`
+        );
+      }
+    }
+    return [];
+  }
+
+  async setSecret(name: string, value: string, path?: string): Promise<void> {
+    if (!this.enabled || !this.client || !this.projectId) {
+      this.logger.warn(`Cannot set secret "${name}": Infisical is not configured`);
+      return;
+    }
+
+    const secretPath = path || this.secretPath;
+
+    try {
+      await this.client.secrets().createSecret(name, {
+        environment: this.environment,
+        projectId: this.projectId,
+        secretValue: value,
+        secretPath,
+      });
+    } catch {
+      // If create fails (already exists), try update
+      try {
+        await this.client.secrets().updateSecret(name, {
+          environment: this.environment,
+          projectId: this.projectId,
+          secretValue: value,
+          secretPath,
+        });
+      } catch (error) {
+        this.logger.error(
+          `Failed to set secret "${name}" in Infisical: ${error instanceof Error ? error.message : error}`
+        );
+        throw error;
+      }
+    }
+  }
+
+  async deleteSecret(name: string, path?: string): Promise<void> {
+    if (!this.enabled || !this.client || !this.projectId) {
+      return;
+    }
+
+    try {
+      await this.client.secrets().deleteSecret(name, {
+        environment: this.environment,
+        projectId: this.projectId,
+        secretPath: path || this.secretPath,
+      });
+    } catch (error) {
+      this.logger.error(
+        `Failed to delete secret "${name}" from Infisical: ${error instanceof Error ? error.message : error}`
+      );
+      throw error;
+    }
+  }
+
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  async listManagedKeys(
+    path?: string
+  ): Promise<Array<{ key: string; createdAt?: Date; updatedAt?: Date }>> {
+    if (this.enabled && this.client && this.projectId) {
+      try {
+        const result = await this.client.secrets().listSecrets({
+          environment: this.environment,
+          projectId: this.projectId,
+          secretPath: path || this.secretPath,
+        });
+        const secrets = result?.secrets || result || [];
+        return (Array.isArray(secrets) ? secrets : []).map(
+          (s: { secretKey: string; createdAt?: string; updatedAt?: string }) => ({
+            key: s.secretKey,
+            createdAt: s.createdAt ? new Date(s.createdAt) : undefined,
+            updatedAt: s.updatedAt ? new Date(s.updatedAt) : undefined,
+          })
+        );
+      } catch (error) {
+        this.logger.warn(
+          `Failed to list managed keys from Infisical: ${error instanceof Error ? error.message : error}`
+        );
+      }
+    }
+    return [];
+  }
+
+  async rotateSecret(name: string, path?: string, generator?: () => string): Promise<string> {
+    const newValue = generator ? generator() : randomBytes(32).toString('hex');
+    await this.setSecret(name, newValue, path);
+    return newValue;
+  }
+}
+
+registerSecretsProvider('infisical', InfisicalSecretsProvider);

--- a/services/shared/src/secrets/secrets.factory.ts
+++ b/services/shared/src/secrets/secrets.factory.ts
@@ -1,0 +1,40 @@
+import { SecretsProvider, SecretsProviderConfig } from './secrets.interface';
+import { getSecretsProviderConstructor, getRegisteredProviders } from './secrets.registry';
+// Import to trigger registration of built-in providers
+import './providers';
+
+/**
+ * Create a secrets provider instance by type name.
+ * Providers must be registered via registerSecretsProvider() before calling this.
+ */
+export function createSecretsProvider(
+  type: string,
+  config: SecretsProviderConfig
+): SecretsProvider {
+  const Ctor = getSecretsProviderConstructor(type);
+  if (!Ctor) {
+    throw new Error(
+      `Unknown secrets provider "${type}". Registered providers: ${getRegisteredProviders().join(', ')}`
+    );
+  }
+  return new Ctor(config);
+}
+
+/**
+ * Build secrets config from environment variables.
+ * Returns the provider type and a generic config bag.
+ * Each provider reads only the env vars it needs from the bag.
+ */
+export function getSecretsConfigFromEnv(): {
+  type: string;
+  config: SecretsProviderConfig;
+} {
+  const type = process.env.SECRETS_PROVIDER || 'env';
+  const config: SecretsProviderConfig = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined) {
+      config[key] = value;
+    }
+  }
+  return { type, config };
+}

--- a/services/shared/src/secrets/secrets.interface.ts
+++ b/services/shared/src/secrets/secrets.interface.ts
@@ -1,0 +1,49 @@
+/**
+ * Vendor-agnostic secrets management interface.
+ *
+ * Implement this interface to add support for any KMS provider.
+ * Register your implementation via registerSecretsProvider() and
+ * set SECRETS_PROVIDER=<name> in your environment.
+ */
+
+export interface SecretsProvider {
+  /** Initialize provider (connect, authenticate). Called on module init. */
+  init(): Promise<void>;
+
+  /** Cleanup (disconnect, flush). Called on module destroy. */
+  destroy(): Promise<void>;
+
+  /** Get a secret by name. Returns undefined if not found. */
+  getSecret(name: string, path?: string): Promise<string | undefined>;
+
+  /** List secrets with values at a path. Returns [] if unsupported. */
+  listSecrets(path?: string): Promise<Array<{ key: string; value: string }>>;
+
+  /** Create or update a secret. No-op if provider is read-only. */
+  setSecret(name: string, value: string, path?: string): Promise<void>;
+
+  /** Delete a secret. No-op if provider is read-only. */
+  deleteSecret(name: string, path?: string): Promise<void>;
+
+  /** Whether provider is actively connected. false = passive fallback. */
+  isEnabled(): boolean;
+
+  /** List managed secret keys (names only, no values). For audit/inventory. */
+  listManagedKeys(
+    path?: string
+  ): Promise<Array<{ key: string; createdAt?: Date; updatedAt?: Date }>>;
+
+  /**
+   * Rotate a secret: generate new value, update in provider, return new value.
+   * @param generator Optional custom value generator. Defaults to crypto.randomBytes(32).
+   */
+  rotateSecret(name: string, path?: string, generator?: () => string): Promise<string>;
+}
+
+/** Generic config bag — each provider reads only the keys it needs. */
+export interface SecretsProviderConfig {
+  [key: string]: string | number | boolean | undefined;
+}
+
+/** Constructor signature for provider classes. */
+export type SecretsProviderConstructor = new (config: SecretsProviderConfig) => SecretsProvider;

--- a/services/shared/src/secrets/secrets.module.ts
+++ b/services/shared/src/secrets/secrets.module.ts
@@ -1,16 +1,16 @@
 import { Module, DynamicModule, Global } from '@nestjs/common';
-import { SecretsService, SecretsConfig, SECRETS_PROVIDER } from './secrets.service';
+import { SecretsService, SECRETS_PROVIDER } from './secrets.service';
 
 @Global()
 @Module({})
 export class SecretsModule {
-  static forRoot(config?: SecretsConfig): DynamicModule {
+  static forRoot(): DynamicModule {
     return {
       module: SecretsModule,
       providers: [
         {
           provide: SECRETS_PROVIDER,
-          useFactory: () => new SecretsService(config),
+          useFactory: () => new SecretsService(),
         },
         {
           provide: SecretsService,

--- a/services/shared/src/secrets/secrets.module.ts
+++ b/services/shared/src/secrets/secrets.module.ts
@@ -1,0 +1,23 @@
+import { Module, DynamicModule, Global } from '@nestjs/common';
+import { SecretsService, SecretsConfig, SECRETS_PROVIDER } from './secrets.service';
+
+@Global()
+@Module({})
+export class SecretsModule {
+  static forRoot(config?: SecretsConfig): DynamicModule {
+    return {
+      module: SecretsModule,
+      providers: [
+        {
+          provide: SECRETS_PROVIDER,
+          useFactory: () => new SecretsService(config),
+        },
+        {
+          provide: SecretsService,
+          useExisting: SECRETS_PROVIDER,
+        },
+      ],
+      exports: [SECRETS_PROVIDER, SecretsService],
+    };
+  }
+}

--- a/services/shared/src/secrets/secrets.registry.ts
+++ b/services/shared/src/secrets/secrets.registry.ts
@@ -1,0 +1,24 @@
+import { SecretsProviderConstructor } from './secrets.interface';
+
+const registry = new Map<string, SecretsProviderConstructor>();
+
+/**
+ * Register a secrets provider implementation.
+ * Call this at module scope in your provider file:
+ *   registerSecretsProvider('vault', VaultSecretsProvider);
+ */
+export function registerSecretsProvider(type: string, ctor: SecretsProviderConstructor): void {
+  registry.set(type, ctor);
+}
+
+/** Get a registered provider constructor by type name. */
+export function getSecretsProviderConstructor(
+  type: string
+): SecretsProviderConstructor | undefined {
+  return registry.get(type);
+}
+
+/** List all registered provider type names. */
+export function getRegisteredProviders(): string[] {
+  return Array.from(registry.keys());
+}

--- a/services/shared/src/secrets/secrets.service.ts
+++ b/services/shared/src/secrets/secrets.service.ts
@@ -1,233 +1,134 @@
 import { Injectable, Logger, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
+import { randomBytes } from 'crypto';
+import { SecretsProvider } from './secrets.interface';
+import { createSecretsProvider, getSecretsConfigFromEnv } from './secrets.factory';
 
 export const SECRETS_PROVIDER = 'SECRETS_PROVIDER';
-
-export interface SecretsConfig {
-  /** Infisical site URL (e.g., http://localhost:8443) */
-  siteUrl?: string;
-  /** Machine Identity Client ID */
-  clientId?: string;
-  /** Machine Identity Client Secret */
-  clientSecret?: string;
-  /** Infisical project ID (workspace) */
-  projectId?: string;
-  /** Environment slug (dev, staging, production) */
-  environment?: string;
-  /** Secret path prefix (default: /) */
-  secretPath?: string;
-  /** Cache TTL in seconds (default: 300) */
-  cacheTtlSeconds?: number;
-}
 
 interface CacheEntry {
   value: string;
   expiresAt: number;
 }
 
+/**
+ * Secrets management service.
+ *
+ * Thin caching wrapper that delegates to a SecretsProvider implementation.
+ * The provider is selected via SECRETS_PROVIDER env var (default: 'env').
+ *
+ * Cache is TTL-based and per-service-instance.
+ */
 @Injectable()
 export class SecretsService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(SecretsService.name);
   private readonly cache = new Map<string, CacheEntry>();
   private readonly cacheTtl: number;
-  private readonly config: SecretsConfig;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private client: any = null;
-  private enabled = false;
+  private readonly provider: SecretsProvider;
+  private readonly providerType: string;
 
-  constructor(config?: SecretsConfig) {
-    this.config = config || this.getConfigFromEnv();
-    this.cacheTtl = (this.config.cacheTtlSeconds ?? 300) * 1000;
-  }
-
-  private getConfigFromEnv(): SecretsConfig {
-    return {
-      siteUrl: process.env.INFISICAL_SITE_URL || process.env.INFISICAL_URL,
-      clientId: process.env.INFISICAL_CLIENT_ID,
-      clientSecret: process.env.INFISICAL_CLIENT_SECRET,
-      projectId: process.env.INFISICAL_PROJECT_ID,
-      environment: process.env.INFISICAL_ENVIRONMENT || 'dev',
-      secretPath: process.env.INFISICAL_SECRET_PATH || '/',
-      cacheTtlSeconds: parseInt(process.env.INFISICAL_CACHE_TTL || '300', 10),
-    };
+  constructor() {
+    const { type, config } = getSecretsConfigFromEnv();
+    this.providerType = type;
+    this.cacheTtl = (parseInt(String(config.SECRETS_CACHE_TTL || '300'), 10) || 300) * 1000;
+    this.provider = createSecretsProvider(type, config);
   }
 
   async onModuleInit(): Promise<void> {
-    if (!this.config.siteUrl || !this.config.clientId || !this.config.clientSecret) {
-      this.logger.log(
-        'Infisical not configured (missing INFISICAL_SITE_URL, INFISICAL_CLIENT_ID, or INFISICAL_CLIENT_SECRET). Falling back to process.env.'
-      );
-      return;
-    }
-
     try {
-      const { InfisicalSDK } = await import('@infisical/sdk');
-      this.client = new InfisicalSDK({
-        siteUrl: this.config.siteUrl,
-      });
-      await this.client.auth().universalAuth.login({
-        clientId: this.config.clientId,
-        clientSecret: this.config.clientSecret,
-      });
-      this.enabled = true;
-      this.logger.log('Infisical SDK connected successfully');
+      await this.provider.init();
+      this.logger.log(`Secrets provider "${this.providerType}" initialized`);
     } catch (error) {
       this.logger.warn(
-        `Failed to initialize Infisical SDK: ${error instanceof Error ? error.message : error}. Falling back to process.env.`
+        `Secrets provider "${this.providerType}" init failed: ${error instanceof Error ? error.message : error}. Falling back gracefully.`
       );
     }
   }
 
   async onModuleDestroy(): Promise<void> {
     this.cache.clear();
+    await this.provider.destroy();
   }
 
   /**
-   * Get a secret by name. Falls back to process.env if Infisical is not configured.
+   * Get a secret by name. Uses cache with TTL.
+   * Falls back to process.env if provider returns undefined.
    */
   async getSecret(name: string, path?: string): Promise<string | undefined> {
-    // Check cache first
-    const cacheKey = `${path || this.config.secretPath}:${name}`;
+    const cacheKey = `${path || '/'}:${name}`;
     const cached = this.cache.get(cacheKey);
     if (cached && cached.expiresAt > Date.now()) {
       return cached.value;
     }
 
-    if (this.enabled && this.client && this.config.projectId) {
-      try {
-        const secret = await this.client.secrets().getSecret({
-          environment: this.config.environment || 'dev',
-          projectId: this.config.projectId,
-          secretName: name,
-          secretPath: path || this.config.secretPath || '/',
-        });
-
-        const value = secret.secretValue;
-        if (value !== undefined) {
-          this.cache.set(cacheKey, {
-            value,
-            expiresAt: Date.now() + this.cacheTtl,
-          });
-        }
-        return value;
-      } catch (error) {
-        this.logger.warn(
-          `Failed to fetch secret "${name}" from Infisical: ${error instanceof Error ? error.message : error}. Falling back to process.env.`
-        );
-      }
-    }
-
-    // Fallback to process.env
-    return process.env[name];
-  }
-
-  /**
-   * List secrets at a given path. Falls back to empty array if not configured.
-   */
-  async listSecrets(
-    path?: string
-  ): Promise<Array<{ key: string; value: string }>> {
-    if (this.enabled && this.client && this.config.projectId) {
-      try {
-        const result = await this.client.secrets().listSecrets({
-          environment: this.config.environment || 'dev',
-          projectId: this.config.projectId,
-          secretPath: path || this.config.secretPath || '/',
-        });
-        const secrets = result?.secrets || result || [];
-        return (Array.isArray(secrets) ? secrets : []).map(
-          (s: { secretKey: string; secretValue: string }) => ({
-            key: s.secretKey,
-            value: s.secretValue,
-          })
-        );
-      } catch (error) {
-        this.logger.warn(
-          `Failed to list secrets from Infisical: ${error instanceof Error ? error.message : error}`
-        );
-      }
-    }
-    return [];
-  }
-
-  /**
-   * Create or update a secret. No-op if Infisical is not configured.
-   */
-  async setSecret(name: string, value: string, path?: string): Promise<void> {
-    if (!this.enabled || !this.client || !this.config.projectId) {
-      this.logger.warn(
-        `Cannot set secret "${name}": Infisical is not configured`
-      );
-      return;
-    }
-
-    try {
-      await this.client.secrets().createSecret(name, {
-        environment: this.config.environment || 'dev',
-        projectId: this.config.projectId,
-        secretValue: value,
-        secretPath: path || this.config.secretPath || '/',
-      });
-
-      // Update cache
-      const cacheKey = `${path || this.config.secretPath}:${name}`;
+    const value = await this.provider.getSecret(name, path);
+    if (value !== undefined) {
       this.cache.set(cacheKey, {
         value,
         expiresAt: Date.now() + this.cacheTtl,
       });
-    } catch {
-      // If create fails (already exists), try update
-      try {
-        await this.client.secrets().updateSecret(name, {
-          environment: this.config.environment || 'dev',
-          projectId: this.config.projectId,
-          secretValue: value,
-          secretPath: path || this.config.secretPath || '/',
-        });
-
-        const cacheKey = `${path || this.config.secretPath}:${name}`;
-        this.cache.set(cacheKey, {
-          value,
-          expiresAt: Date.now() + this.cacheTtl,
-        });
-      } catch (error) {
-        this.logger.error(
-          `Failed to set secret "${name}" in Infisical: ${error instanceof Error ? error.message : error}`
-        );
-        throw error;
-      }
     }
+    return value;
   }
 
   /**
-   * Delete a secret. No-op if Infisical is not configured.
+   * List secrets with values at a path.
+   * Not cached — returns live data from provider.
+   */
+  async listSecrets(path?: string): Promise<Array<{ key: string; value: string }>> {
+    return this.provider.listSecrets(path);
+  }
+
+  /**
+   * Create or update a secret. Updates cache on success.
+   */
+  async setSecret(name: string, value: string, path?: string): Promise<void> {
+    await this.provider.setSecret(name, value, path);
+    const cacheKey = `${path || '/'}:${name}`;
+    this.cache.set(cacheKey, {
+      value,
+      expiresAt: Date.now() + this.cacheTtl,
+    });
+  }
+
+  /**
+   * Delete a secret. Evicts from cache.
    */
   async deleteSecret(name: string, path?: string): Promise<void> {
-    if (!this.enabled || !this.client || !this.config.projectId) {
-      return;
-    }
-
-    try {
-      await this.client.secrets().deleteSecret(name, {
-        environment: this.config.environment || 'dev',
-        projectId: this.config.projectId,
-        secretPath: path || this.config.secretPath || '/',
-      });
-
-      // Remove from cache
-      const cacheKey = `${path || this.config.secretPath}:${name}`;
-      this.cache.delete(cacheKey);
-    } catch (error) {
-      this.logger.error(
-        `Failed to delete secret "${name}" from Infisical: ${error instanceof Error ? error.message : error}`
-      );
-      throw error;
-    }
+    await this.provider.deleteSecret(name, path);
+    const cacheKey = `${path || '/'}:${name}`;
+    this.cache.delete(cacheKey);
   }
 
   /**
-   * Check if Infisical SDK is connected and active.
+   * Whether the underlying provider is actively connected.
+   * false = passive fallback (env provider or failed init).
    */
   isEnabled(): boolean {
-    return this.enabled;
+    return this.provider.isEnabled();
+  }
+
+  /**
+   * List managed secret keys (names only, no values).
+   * For audit/inventory purposes. Not cached.
+   */
+  async listManagedKeys(
+    path?: string
+  ): Promise<Array<{ key: string; createdAt?: Date; updatedAt?: Date }>> {
+    return this.provider.listManagedKeys(path);
+  }
+
+  /**
+   * Rotate a secret: generate new value, update in provider, invalidate cache.
+   * @param generator Optional custom value generator. Defaults to 32 random hex bytes.
+   */
+  async rotateSecret(name: string, path?: string, generator?: () => string): Promise<string> {
+    const newValue = generator ? generator() : randomBytes(32).toString('hex');
+    await this.provider.setSecret(name, newValue, path);
+    const cacheKey = `${path || '/'}:${name}`;
+    this.cache.set(cacheKey, {
+      value: newValue,
+      expiresAt: Date.now() + this.cacheTtl,
+    });
+    return newValue;
   }
 }

--- a/services/shared/src/secrets/secrets.service.ts
+++ b/services/shared/src/secrets/secrets.service.ts
@@ -1,0 +1,233 @@
+import { Injectable, Logger, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
+
+export const SECRETS_PROVIDER = 'SECRETS_PROVIDER';
+
+export interface SecretsConfig {
+  /** Infisical site URL (e.g., http://localhost:8443) */
+  siteUrl?: string;
+  /** Machine Identity Client ID */
+  clientId?: string;
+  /** Machine Identity Client Secret */
+  clientSecret?: string;
+  /** Infisical project ID (workspace) */
+  projectId?: string;
+  /** Environment slug (dev, staging, production) */
+  environment?: string;
+  /** Secret path prefix (default: /) */
+  secretPath?: string;
+  /** Cache TTL in seconds (default: 300) */
+  cacheTtlSeconds?: number;
+}
+
+interface CacheEntry {
+  value: string;
+  expiresAt: number;
+}
+
+@Injectable()
+export class SecretsService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(SecretsService.name);
+  private readonly cache = new Map<string, CacheEntry>();
+  private readonly cacheTtl: number;
+  private readonly config: SecretsConfig;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private client: any = null;
+  private enabled = false;
+
+  constructor(config?: SecretsConfig) {
+    this.config = config || this.getConfigFromEnv();
+    this.cacheTtl = (this.config.cacheTtlSeconds ?? 300) * 1000;
+  }
+
+  private getConfigFromEnv(): SecretsConfig {
+    return {
+      siteUrl: process.env.INFISICAL_SITE_URL || process.env.INFISICAL_URL,
+      clientId: process.env.INFISICAL_CLIENT_ID,
+      clientSecret: process.env.INFISICAL_CLIENT_SECRET,
+      projectId: process.env.INFISICAL_PROJECT_ID,
+      environment: process.env.INFISICAL_ENVIRONMENT || 'dev',
+      secretPath: process.env.INFISICAL_SECRET_PATH || '/',
+      cacheTtlSeconds: parseInt(process.env.INFISICAL_CACHE_TTL || '300', 10),
+    };
+  }
+
+  async onModuleInit(): Promise<void> {
+    if (!this.config.siteUrl || !this.config.clientId || !this.config.clientSecret) {
+      this.logger.log(
+        'Infisical not configured (missing INFISICAL_SITE_URL, INFISICAL_CLIENT_ID, or INFISICAL_CLIENT_SECRET). Falling back to process.env.'
+      );
+      return;
+    }
+
+    try {
+      const { InfisicalSDK } = await import('@infisical/sdk');
+      this.client = new InfisicalSDK({
+        siteUrl: this.config.siteUrl,
+      });
+      await this.client.auth().universalAuth.login({
+        clientId: this.config.clientId,
+        clientSecret: this.config.clientSecret,
+      });
+      this.enabled = true;
+      this.logger.log('Infisical SDK connected successfully');
+    } catch (error) {
+      this.logger.warn(
+        `Failed to initialize Infisical SDK: ${error instanceof Error ? error.message : error}. Falling back to process.env.`
+      );
+    }
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    this.cache.clear();
+  }
+
+  /**
+   * Get a secret by name. Falls back to process.env if Infisical is not configured.
+   */
+  async getSecret(name: string, path?: string): Promise<string | undefined> {
+    // Check cache first
+    const cacheKey = `${path || this.config.secretPath}:${name}`;
+    const cached = this.cache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.value;
+    }
+
+    if (this.enabled && this.client && this.config.projectId) {
+      try {
+        const secret = await this.client.secrets().getSecret({
+          environment: this.config.environment || 'dev',
+          projectId: this.config.projectId,
+          secretName: name,
+          secretPath: path || this.config.secretPath || '/',
+        });
+
+        const value = secret.secretValue;
+        if (value !== undefined) {
+          this.cache.set(cacheKey, {
+            value,
+            expiresAt: Date.now() + this.cacheTtl,
+          });
+        }
+        return value;
+      } catch (error) {
+        this.logger.warn(
+          `Failed to fetch secret "${name}" from Infisical: ${error instanceof Error ? error.message : error}. Falling back to process.env.`
+        );
+      }
+    }
+
+    // Fallback to process.env
+    return process.env[name];
+  }
+
+  /**
+   * List secrets at a given path. Falls back to empty array if not configured.
+   */
+  async listSecrets(
+    path?: string
+  ): Promise<Array<{ key: string; value: string }>> {
+    if (this.enabled && this.client && this.config.projectId) {
+      try {
+        const result = await this.client.secrets().listSecrets({
+          environment: this.config.environment || 'dev',
+          projectId: this.config.projectId,
+          secretPath: path || this.config.secretPath || '/',
+        });
+        const secrets = result?.secrets || result || [];
+        return (Array.isArray(secrets) ? secrets : []).map(
+          (s: { secretKey: string; secretValue: string }) => ({
+            key: s.secretKey,
+            value: s.secretValue,
+          })
+        );
+      } catch (error) {
+        this.logger.warn(
+          `Failed to list secrets from Infisical: ${error instanceof Error ? error.message : error}`
+        );
+      }
+    }
+    return [];
+  }
+
+  /**
+   * Create or update a secret. No-op if Infisical is not configured.
+   */
+  async setSecret(name: string, value: string, path?: string): Promise<void> {
+    if (!this.enabled || !this.client || !this.config.projectId) {
+      this.logger.warn(
+        `Cannot set secret "${name}": Infisical is not configured`
+      );
+      return;
+    }
+
+    try {
+      await this.client.secrets().createSecret(name, {
+        environment: this.config.environment || 'dev',
+        projectId: this.config.projectId,
+        secretValue: value,
+        secretPath: path || this.config.secretPath || '/',
+      });
+
+      // Update cache
+      const cacheKey = `${path || this.config.secretPath}:${name}`;
+      this.cache.set(cacheKey, {
+        value,
+        expiresAt: Date.now() + this.cacheTtl,
+      });
+    } catch {
+      // If create fails (already exists), try update
+      try {
+        await this.client.secrets().updateSecret(name, {
+          environment: this.config.environment || 'dev',
+          projectId: this.config.projectId,
+          secretValue: value,
+          secretPath: path || this.config.secretPath || '/',
+        });
+
+        const cacheKey = `${path || this.config.secretPath}:${name}`;
+        this.cache.set(cacheKey, {
+          value,
+          expiresAt: Date.now() + this.cacheTtl,
+        });
+      } catch (error) {
+        this.logger.error(
+          `Failed to set secret "${name}" in Infisical: ${error instanceof Error ? error.message : error}`
+        );
+        throw error;
+      }
+    }
+  }
+
+  /**
+   * Delete a secret. No-op if Infisical is not configured.
+   */
+  async deleteSecret(name: string, path?: string): Promise<void> {
+    if (!this.enabled || !this.client || !this.config.projectId) {
+      return;
+    }
+
+    try {
+      await this.client.secrets().deleteSecret(name, {
+        environment: this.config.environment || 'dev',
+        projectId: this.config.projectId,
+        secretPath: path || this.config.secretPath || '/',
+      });
+
+      // Remove from cache
+      const cacheKey = `${path || this.config.secretPath}:${name}`;
+      this.cache.delete(cacheKey);
+    } catch (error) {
+      this.logger.error(
+        `Failed to delete secret "${name}" from Infisical: ${error instanceof Error ? error.message : error}`
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Check if Infisical SDK is connected and active.
+   */
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+}

--- a/services/trust/src/auth/auth.module.ts
+++ b/services/trust/src/auth/auth.module.ts
@@ -1,0 +1,19 @@
+import { Global, Module } from '@nestjs/common';
+import { DevAuthGuard, RolesGuard, PermissionsGuard, PRISMA_SERVICE } from '@gigachad-grc/shared';
+import { PrismaService } from '../common/prisma.service';
+
+@Global()
+@Module({
+  providers: [
+    PrismaService,
+    {
+      provide: PRISMA_SERVICE,
+      useExisting: PrismaService,
+    },
+    DevAuthGuard,
+    RolesGuard,
+    PermissionsGuard,
+  ],
+  exports: [PrismaService, PRISMA_SERVICE, DevAuthGuard, RolesGuard, PermissionsGuard],
+})
+export class AuthModule {}

--- a/start.sh
+++ b/start.sh
@@ -62,6 +62,20 @@ setup_env() {
     # Check if .env exists
     if [ -f ".env" ]; then
         echo -e "${GREEN}✓${NC} Using existing .env file"
+        # Migrate: append Infisical bootstrap secrets if missing from older .env
+        if ! grep -q '^INFISICAL_ENCRYPTION_KEY=' ".env" 2>/dev/null; then
+            echo -e "${YELLOW}⚠${NC} Adding missing Infisical secrets to existing .env..."
+            local INF_ENC_KEY INF_AUTH_SEC
+            INF_ENC_KEY=$(openssl rand -hex 16 2>/dev/null || head -c 16 /dev/urandom | xxd -p | tr -d '\n')
+            INF_AUTH_SEC=$(openssl rand -base64 32 2>/dev/null | tr -d '\n' || head -c 32 /dev/urandom | base64 | tr -d '\n')
+            cat >> ".env" << INFISICAL_EOF
+
+# Infisical Secrets Manager (auto-added)
+INFISICAL_ENCRYPTION_KEY=${INF_ENC_KEY}
+INFISICAL_AUTH_SECRET=${INF_AUTH_SEC}
+INFISICAL_EOF
+            echo -e "${GREEN}✓${NC} Infisical bootstrap secrets added to .env"
+        fi
         return 0
     fi
 
@@ -75,6 +89,8 @@ setup_env() {
     REDIS_PASSWORD=$(openssl rand -base64 24 2>/dev/null | tr -d '\n' | tr '+/' '-_' || head -c 24 /dev/urandom | base64 | tr '+/' '-_')
     MINIO_PASSWORD=$(openssl rand -base64 20 2>/dev/null | tr -d '\n' | tr '+/' '-_' || head -c 20 /dev/urandom | base64 | tr '+/' '-_')
     GRAFANA_PASSWORD=$(openssl rand -base64 32 2>/dev/null | tr -d '\n' | tr '+/' '-_' || head -c 32 /dev/urandom | base64 | tr '+/' '-_')
+    INFISICAL_ENCRYPTION_KEY=$(openssl rand -hex 16 2>/dev/null || head -c 16 /dev/urandom | xxd -p | tr -d '\n')
+    INFISICAL_AUTH_SECRET=$(openssl rand -base64 32 2>/dev/null | tr -d '\n' || head -c 32 /dev/urandom | base64 | tr -d '\n')
 
     cat > ".env" << EOF
 # ============================================================================
@@ -126,6 +142,10 @@ RATE_LIMIT_MAX_REQUESTS=1000
 # Logging
 LOG_LEVEL=debug
 
+# Infisical Secrets Manager
+INFISICAL_ENCRYPTION_KEY=${INFISICAL_ENCRYPTION_KEY}
+INFISICAL_AUTH_SECRET=${INFISICAL_AUTH_SECRET}
+
 # Frontend
 VITE_API_URL=http://localhost:3001
 VITE_ENABLE_DEV_AUTH=true
@@ -161,6 +181,7 @@ start_services() {
     echo -e "   ${CYAN}Frontend${NC}        http://localhost:3000"
     echo -e "   ${CYAN}API Docs${NC}        http://localhost:3001/api/docs"
     echo -e "   ${CYAN}Keycloak${NC}        http://localhost:8080 (admin/admin)"
+    echo -e "   ${CYAN}Secrets (Infisical)${NC} http://localhost:8443"
     echo -e "   ${CYAN}Grafana${NC}         http://localhost:3003 (admin/admin)"
     echo ""
     echo -e "${BOLD}How to Login:${NC}"
@@ -175,6 +196,20 @@ start_services() {
     echo -e "   ${CYAN}./start.sh logs${NC}    View logs"
     echo -e "   ${CYAN}./start.sh status${NC}  Check service status"
     echo ""
+
+    # Wait for Infisical to be ready (first-time setup)
+    if [ ! -f ".infisical-initialized" ]; then
+        echo -e "${BLUE}Waiting for Infisical secrets manager...${NC}"
+        for i in $(seq 1 30); do
+            if curl -sf http://localhost:8443/api/status > /dev/null 2>&1; then
+                echo -e "${GREEN}✓${NC} Infisical is ready"
+                echo -e "${YELLOW}→ Visit http://localhost:8443 to create your admin account and set up secrets${NC}"
+                touch .infisical-initialized
+                break
+            fi
+            sleep 2
+        done
+    fi
 
     # Open browser on macOS
     if [[ "$OSTYPE" == "darwin"* ]]; then
@@ -221,6 +256,7 @@ reset_all() {
             echo -e "${YELLOW}Removing .env file...${NC}"
             rm -f .env
         fi
+        rm -f .infisical-initialized
         
         echo -e "${GREEN}✓ Reset complete${NC}"
         echo ""


### PR DESCRIPTION
## Summary
- Add `SecretsModule` / `SecretsService` to the shared library wrapping `@infisical/sdk` for centralized secrets management
- Add Infisical service to Docker Compose (dev and prod) with dedicated database
- Update `IntegrationsService` to store and retrieve credentials via Infisical with `infisical://` references
- Add bootstrap secret generation to `start.sh` and `init.sh`
- Add auth module updates across services for Infisical-aware configuration

## Context
Integration credentials (API keys, tokens) were previously stored AES-256-GCM encrypted in Postgres. This adds Infisical as an optional secrets manager so credentials can be stored in a purpose-built vault instead.

The integration is **backward compatible** — when Infisical is not configured, services fall back to `process.env` and the existing encrypted-in-DB approach continues to work. Bootstrap secrets (`INFISICAL_ENCRYPTION_KEY`, `INFISICAL_AUTH_SECRET`) remain in `.env` since they're needed before Infisical is available.

### Architecture
- **Phase 1**: Host-level injection via `infisical run -- docker compose up`
- **Phase 2A**: `SecretsModule.forRoot()` / `SecretsService` in shared library
- **Phase 2B**: `IntegrationsService` stores credentials in Infisical, references them with `infisical://` URIs

## Test plan
- [ ] `docker compose up` starts Infisical alongside existing services
- [ ] Infisical admin console accessible at `http://localhost:8443`
- [ ] Existing integrations continue to work without Infisical configured (backward compat)
- [ ] New integration credentials are stored in Infisical when configured
- [ ] `SecretsService` falls back to `process.env` when Infisical is unavailable
- [ ] `start.sh` and `init.sh` generate bootstrap secrets on first run