### PR TITLE
fix(security): SSRF protection, async crypto, shell injection, and credential masking

### DIFF
--- a/services/controls/src/integrations/connectors/base-connector.ts
+++ b/services/controls/src/integrations/connectors/base-connector.ts
@@ -1,5 +1,7 @@
 import { Logger } from '@nestjs/common';
 import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
+import { URL } from 'url';
+import * as net from 'net';
 
 /**
  * HTTP request result type.
@@ -63,6 +65,65 @@ function getErrorMessage(error: unknown): string {
 }
 
 /**
+ * Validate a URL is safe for server-side requests (SSRF protection).
+ * Blocks private IPs, loopback, link-local, and cloud metadata endpoints.
+ */
+function validateUrlSafe(urlString: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(urlString);
+  } catch {
+    throw new Error(`Invalid URL: ${urlString}`);
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+
+  // Block localhost
+  if (hostname === 'localhost' || hostname === '[::1]') {
+    throw new Error('SSRF blocked: localhost URLs are not allowed');
+  }
+
+  // Block cloud metadata endpoints
+  if (hostname === '169.254.169.254' || hostname === 'metadata.google.internal') {
+    throw new Error('SSRF blocked: cloud metadata endpoints are not allowed');
+  }
+
+  // Check if hostname is an IP address
+  if (net.isIPv4(hostname)) {
+    const octets = hostname.split('.').map(Number);
+    // 10.0.0.0/8
+    if (octets[0] === 10) {
+      throw new Error('SSRF blocked: private IP range (10.x.x.x)');
+    }
+    // 172.16.0.0/12
+    if (octets[0] === 172 && octets[1] >= 16 && octets[1] <= 31) {
+      throw new Error('SSRF blocked: private IP range (172.16-31.x.x)');
+    }
+    // 192.168.0.0/16
+    if (octets[0] === 192 && octets[1] === 168) {
+      throw new Error('SSRF blocked: private IP range (192.168.x.x)');
+    }
+    // 127.0.0.0/8
+    if (octets[0] === 127) {
+      throw new Error('SSRF blocked: loopback address');
+    }
+    // 169.254.0.0/16 (link-local)
+    if (octets[0] === 169 && octets[1] === 254) {
+      throw new Error('SSRF blocked: link-local address');
+    }
+    // 0.0.0.0
+    if (octets.every((o) => o === 0)) {
+      throw new Error('SSRF blocked: unspecified address');
+    }
+  }
+
+  // Only allow http and https schemes
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`SSRF blocked: unsupported protocol ${parsed.protocol}`);
+  }
+}
+
+/**
  * Base connector class with common HTTP functionality.
  * All integration connectors should extend this for consistent behavior.
  * 
@@ -95,14 +156,48 @@ export abstract class BaseConnector {
   }
 
   /**
+   * Create a request-scoped HTTP client with the given base URL and headers.
+   * This returns a fresh AxiosInstance that is NOT shared, making it safe
+   * for concurrent use in singleton NestJS services.
+   *
+   * Includes SSRF validation on the base URL.
+   */
+  protected createClient(
+    baseURL: string,
+    headers?: Record<string, string>,
+    timeout?: number,
+  ): AxiosInstance {
+    validateUrlSafe(baseURL);
+    return axios.create({
+      timeout: timeout || 30000,
+      validateStatus: (status) => status < 500,
+      baseURL,
+      headers,
+    });
+  }
+
+  private getClient(config?: AxiosRequestConfig & { client?: AxiosInstance }): {
+    client: AxiosInstance;
+    axiosConfig?: AxiosRequestConfig;
+  } {
+    if (config?.client) {
+      const { client, ...rest } = config;
+      return { client, axiosConfig: Object.keys(rest).length > 0 ? rest : undefined };
+    }
+    return { client: this.axiosInstance, axiosConfig: config };
+  }
+
+  /**
    * Make an authenticated GET request.
+   * Pass { client } in config to use a request-scoped client.
    */
   protected async get<T = unknown>(
     url: string,
-    config?: AxiosRequestConfig,
+    config?: AxiosRequestConfig & { client?: AxiosInstance },
   ): Promise<HttpResult<T>> {
     try {
-      const response = await this.axiosInstance.get<T>(url, config);
+      const { client, axiosConfig } = this.getClient(config);
+      const response = await client.get<T>(url, axiosConfig);
       if (response.status >= 400) {
         return {
           error: `HTTP ${response.status}: ${response.statusText}`,
@@ -119,14 +214,16 @@ export abstract class BaseConnector {
 
   /**
    * Make an authenticated POST request.
+   * Pass { client } in config to use a request-scoped client.
    */
   protected async post<T = unknown, D = unknown>(
     url: string,
     data?: D,
-    config?: AxiosRequestConfig,
+    config?: AxiosRequestConfig & { client?: AxiosInstance },
   ): Promise<HttpResult<T>> {
     try {
-      const response = await this.axiosInstance.post<T>(url, data, config);
+      const { client, axiosConfig } = this.getClient(config);
+      const response = await client.post<T>(url, data, axiosConfig);
       if (response.status >= 400) {
         return {
           error: `HTTP ${response.status}: ${response.statusText}`,
@@ -143,14 +240,16 @@ export abstract class BaseConnector {
 
   /**
    * Make an authenticated PUT request.
+   * Pass { client } in config to use a request-scoped client.
    */
   protected async put<T = unknown, D = unknown>(
     url: string,
     data?: D,
-    config?: AxiosRequestConfig,
+    config?: AxiosRequestConfig & { client?: AxiosInstance },
   ): Promise<HttpResult<T>> {
     try {
-      const response = await this.axiosInstance.put<T>(url, data, config);
+      const { client, axiosConfig } = this.getClient(config);
+      const response = await client.put<T>(url, data, axiosConfig);
       if (response.status >= 400) {
         return {
           error: `HTTP ${response.status}: ${response.statusText}`,
@@ -167,13 +266,15 @@ export abstract class BaseConnector {
 
   /**
    * Make an authenticated DELETE request.
+   * Pass { client } in config to use a request-scoped client.
    */
   protected async delete<T = unknown>(
     url: string,
-    config?: AxiosRequestConfig,
+    config?: AxiosRequestConfig & { client?: AxiosInstance },
   ): Promise<HttpResult<T>> {
     try {
-      const response = await this.axiosInstance.delete<T>(url, config);
+      const { client, axiosConfig } = this.getClient(config);
+      const response = await client.delete<T>(url, axiosConfig);
       if (response.status >= 400) {
         return {
           error: `HTTP ${response.status}: ${response.statusText}`,
@@ -189,7 +290,9 @@ export abstract class BaseConnector {
   }
 
   /**
-   * Set default headers (Authorization, Content-Type, etc.).
+   * @deprecated Use createClient() for request-scoped clients to avoid
+   * shared mutable state in singleton services. This method mutates the
+   * shared axiosInstance defaults and is unsafe for concurrent use.
    */
   protected setHeaders(headers: Record<string, string>): void {
     this.axiosInstance.defaults.headers.common = {
@@ -199,9 +302,14 @@ export abstract class BaseConnector {
   }
 
   /**
-   * Set base URL for all requests.
+   * @deprecated Use createClient() for request-scoped clients to avoid
+   * shared mutable state in singleton services. This method mutates the
+   * shared axiosInstance defaults and is unsafe for concurrent use.
+   *
+   * Includes SSRF validation.
    */
   protected setBaseURL(baseURL: string): void {
+    validateUrlSafe(baseURL);
     this.axiosInstance.defaults.baseURL = baseURL;
   }
 


### PR DESCRIPTION
## Summary
- Add SSRF URL validation in `BaseConnector` blocking private IPs, loopback, link-local, and cloud metadata endpoints
- Add `createClient()` for request-scoped HTTP clients to prevent credential leakage between concurrent tenant syncs
- Replace blocking `crypto.scryptSync` with async `crypto.scrypt` to avoid event loop starvation under load, with cached legacy key derivation
- Fix shell injection in `seed-infisical.sh` by using `jq` for safe JSON construction instead of string interpolation
- Mask `infisical://` references in API responses alongside encrypted values
- Sanitize delete audit log to exclude encrypted config data

## Dependencies
> This PR depends on #139 (Infisical integration) — it modifies `seed-infisical.sh` and `integrations.service.ts` which were introduced/changed in that PR. Merge #139 first.

## Test plan
- [ ] SSRF: connector rejects requests to `169.254.169.254`, `127.0.0.1`, `10.x.x.x`, `::1`
- [ ] Async crypto: encrypt/decrypt operations don't block event loop (no `scryptSync` calls remain)
- [ ] Shell injection: `seed-infisical.sh` handles special characters in secrets safely via `jq`
- [ ] Credential masking: API responses show `[ENCRYPTED]` for encrypted values and `[INFISICAL]` for Infisical references
- [ ] Delete audit logs don't contain raw encrypted config