### PR TITLE
feat(integrations): Atlassian Assets connector with service account support

### DIFF
--- a/frontend/src/components/integrations/IntegrationConfigModal.tsx
+++ b/frontend/src/components/integrations/IntegrationConfigModal.tsx
@@ -57,10 +57,13 @@ export default function IntegrationConfigModal({
   });
 
   const createMutation = useMutation({
-    mutationFn: (data: any) => 
-      existingIntegration 
-        ? integrationsApi.update(existingIntegration.id, data)
-        : integrationsApi.create(data),
+    mutationFn: (data: any) => {
+      if (existingIntegration) {
+        const { type, ...updateData } = data;
+        return integrationsApi.update(existingIntegration.id, updateData);
+      }
+      return integrationsApi.create(data);
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['integrations'] });
       queryClient.invalidateQueries({ queryKey: ['integrations-stats'] });

--- a/frontend/src/lib/integrationTypes.ts
+++ b/frontend/src/lib/integrationTypes.ts
@@ -3791,19 +3791,20 @@ export const INTEGRATION_TYPES: Record<string, IntegrationType> = {
   },
   atlassian_assets: {
     name: 'Atlassian Assets',
-    description: 'Integrate Atlassian Assets for CMDB and asset tracking',
+    description: 'Integrate Atlassian Assets (JSM) for CMDB and asset tracking. Cloud ID and Workspace ID are auto-discovered from your site URL.',
     category: 'Asset Management',
     iconSlug: 'atlassian_assets',
     apiDocs: 'https://developer.atlassian.com/cloud/assets/rest/intro/',
     authType: 'basic',
     syncFrequencies: ['daily', 'weekly'],
     configFields: [
-      { key: 'baseUrl', label: 'Jira URL', type: 'url', required: true },
-      { key: 'email', label: 'Email', type: 'text', required: true },
-      { key: 'apiToken', label: 'API Token', type: 'password', required: true },
+      { key: 'siteUrl', label: 'Jira Site URL', type: 'url', required: true, placeholder: 'https://your-domain.atlassian.net', helpText: 'Your Atlassian Cloud site URL. Cloud ID and Workspace ID will be auto-discovered.' },
+      { key: 'email', label: 'Email', type: 'text', required: true, placeholder: 'you@company.com', helpText: 'The email address associated with your Atlassian account.' },
+      { key: 'apiToken', label: 'API Token', type: 'password', required: true, helpText: 'Generate at id.atlassian.com/manage/api-tokens' },
     ],
     evidenceTypes: [
-      { key: 'objects', label: 'Objects', description: 'Asset objects', defaultEnabled: true },
+      { key: 'objects', label: 'Asset Objects', description: 'CMDB objects and configuration items', defaultEnabled: true },
+      { key: 'schemas', label: 'Object Schemas', description: 'Asset object schema definitions', defaultEnabled: true },
     ],
   },
 

--- a/services/controls/src/integrations/dto/integration.dto.ts
+++ b/services/controls/src/integrations/dto/integration.dto.ts
@@ -2640,7 +2640,7 @@ export const INTEGRATION_TYPES = {
     category: 'Asset Management',
     apiDocs: 'https://developer.atlassian.com/cloud/assets/',
     configFields: [
-      { key: 'siteUrl', label: 'Site URL', type: 'text', required: true },
+      { key: 'siteUrl', label: 'Jira Site URL', type: 'text', required: true },
       { key: 'email', label: 'Email', type: 'text', required: true },
       { key: 'apiToken', label: 'API Token', type: 'password', required: true },
     ],

--- a/services/controls/src/workspace/workspace.controller.ts
+++ b/services/controls/src/workspace/workspace.controller.ts
@@ -50,6 +50,7 @@ export class WorkspaceController {
    * Check if multi-workspace mode is enabled for the organization
    */
   @Get('status')
+  @RequirePermission(Resource.WORKSPACES, Action.READ)
   async getMultiWorkspaceStatus(@Req() req: WorkspaceRequest) {
     const enabled = await this.workspaceService.isMultiWorkspaceEnabled(req.user.organizationId);
     return { enabled };
@@ -72,6 +73,7 @@ export class WorkspaceController {
    * List all workspaces (filtered by user access for non-admins)
    */
   @Get()
+  @RequirePermission(Resource.WORKSPACES, Action.READ)
   async findAll(@Req() req: WorkspaceRequest, @Query() filters: WorkspaceFilterDto) {
     return this.workspaceService.findAll(
       req.user.organizationId,
@@ -94,6 +96,7 @@ export class WorkspaceController {
    * Get a single workspace by ID
    */
   @Get(':id')
+  @RequirePermission(Resource.WORKSPACES, Action.READ)
   async findOne(@Param('id') id: string, @Req() req: WorkspaceRequest) {
     return this.workspaceService.findOne(id, req.user.organizationId, req.user.id || req.user.userId, req.user.role);
   }
@@ -102,6 +105,7 @@ export class WorkspaceController {
    * Get workspace dashboard
    */
   @Get(':id/dashboard')
+  @RequirePermission(Resource.WORKSPACES, Action.READ)
   async getDashboard(@Param('id') id: string, @Req() req: WorkspaceRequest) {
     return this.workspaceService.getDashboard(
       id,
@@ -143,6 +147,7 @@ export class WorkspaceController {
    * List workspace members
    */
   @Get(':id/members')
+  @RequirePermission(Resource.WORKSPACES, Action.READ)
   async listMembers(@Param('id') id: string, @Req() req: WorkspaceRequest) {
     const workspace = await this.workspaceService.findOne(
       id,


### PR DESCRIPTION
## Summary
- Add Atlassian Assets (CMDB) connector with service account authentication via API gateway
- Graceful fallback: when Assets/CMDB scopes are unavailable (common with service accounts), the connector syncs Jira project data instead
- Flatten nested `config.credentials` for quick-setup compatibility in `testConnection()` and `triggerSync()`
- Route service account requests through `api.atlassian.com/ex/jira/{cloudId}` gateway with Cloud ID auto-discovery via `_edge/tenant_info`
- Add Atlassian integration type to frontend config modal and type definitions

## Context
Atlassian service account API tokens cannot be granted CMDB/Assets scopes — this is a known platform limitation. Rather than failing, the connector treats auth + Jira access as success and reports Assets as an optional capability. When Assets is unavailable, sync pulls Jira projects (id, key, name, description, type, lead).

The quick-setup flow stores credentials under `config.credentials.{field}` but connectors expect flat top-level fields. Added credential flattening in the service layer before validation and connector invocation.

## Dependencies
> This PR depends on #139 (Infisical integration) — it modifies `integrations.service.ts` which was heavily changed in that PR. Merge #139 first.

## Test plan
- [ ] Atlassian integration type appears in frontend integration setup modal
- [ ] `testConnection()` succeeds with valid Atlassian service account credentials
- [ ] Connection test reports capabilities (Jira access, Assets availability)
- [ ] `triggerSync()` syncs Jira projects when Assets is unavailable
- [ ] Credentials stored via quick-setup (nested) work correctly
- [ ] Service accounts route through API gateway, not direct site URL