### PR TITLE
fix(security): harden SSRF protection and fix shell auth token bug

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,14 +24,17 @@ NODE_ENV=development
 
 # 64-character hex key for encrypting sensitive data
 # Generate: openssl rand -hex 32
+# NOTE: Managed by Infisical after initial setup (see Infisical section below)
 ENCRYPTION_KEY=generate-a-64-char-hex-key-using-openssl-rand-hex-32
 
 # Base64 secret for JWT token signing (64+ characters)
 # Generate: openssl rand -base64 64
+# NOTE: Managed by Infisical after initial setup
 JWT_SECRET=generate-a-secure-jwt-secret-using-openssl-rand-base64-64
 
 # Base64 secret for session encryption (64+ characters)
 # Generate: openssl rand -base64 64
+# NOTE: Managed by Infisical after initial setup
 SESSION_SECRET=generate-a-secure-session-secret-using-openssl-rand-base64-64
 
 # =============================================================================
@@ -122,6 +125,18 @@ VITE_ENABLE_DEV_AUTH=false
 VITE_ENABLE_AI_MODULE=true
 # Optional: CDN URL for training content (used for postMessage origin validation)
 # VITE_TRAINING_CDN_URL=https://training.example.com
+
+# =============================================================================
+# Infisical Secrets Manager (Bootstrap)
+# =============================================================================
+# These are bootstrap secrets needed before Infisical starts.
+# Application secrets (ENCRYPTION_KEY, JWT_SECRET, etc.) are managed in Infisical
+# after initial setup. See: make secrets-seed
+#
+# Generate encryption key: openssl rand -hex 16
+INFISICAL_ENCRYPTION_KEY=generate-a-32-char-hex-key
+# Generate auth secret: openssl rand -base64 32
+INFISICAL_AUTH_SECRET=generate-a-secure-auth-secret
 
 # =============================================================================
 # Optional: AI Integration

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@ services/policies/storage/
 *.key
 *.p12
 
+# Infisical
+.infisical.json
+.infisical-initialized
+
 # Storage directories - contain user data
 services/*/storage/
 **/storage/evidence/

--- a/database/init/00-create-keycloak-db.sh
+++ b/database/init/00-create-keycloak-db.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Create a separate database for Keycloak to avoid schema conflicts
+# with Prisma migrations in the main application database.
+# This script runs before the SQL init scripts (sorted by filename).
+
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    CREATE DATABASE keycloak;
+    GRANT ALL PRIVILEGES ON DATABASE keycloak TO $POSTGRES_USER;
+EOSQL
+
+echo "Keycloak database created successfully"

--- a/database/init/00b-create-infisical-db.sh
+++ b/database/init/00b-create-infisical-db.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Create a separate database for Infisical secrets manager.
+# This script sorts after 00-create-keycloak-db.sh and before 01-init.sql.
+
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    CREATE DATABASE infisical;
+    GRANT ALL PRIVILEGES ON DATABASE infisical TO $POSTGRES_USER;
+EOSQL
+
+echo "Infisical database created successfully"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -172,7 +172,7 @@ services:
     environment:
       # Database
       KC_DB: postgres
-      KC_DB_URL: jdbc:postgresql://postgres:5432/${POSTGRES_DB}
+      KC_DB_URL: jdbc:postgresql://postgres:5432/keycloak
       KC_DB_USERNAME: ${POSTGRES_USER}
       KC_DB_PASSWORD: ${POSTGRES_PASSWORD}
       KC_DB_POOL_INITIAL_SIZE: ${KC_DB_POOL_INITIAL_SIZE:-5}
@@ -316,6 +316,66 @@ services:
           memory: 256M
 
   # ===========================================
+  # Secrets Management - Infisical (Self-Hosted)
+  # Centralized secret management with audit trail
+  # ===========================================
+  infisical:
+    image: infisical/infisical:v0.158.2
+    container_name: grc-infisical
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp
+      - /etc/ssl/certs
+    environment:
+      ENCRYPTION_KEY: ${INFISICAL_ENCRYPTION_KEY}
+      AUTH_SECRET: ${INFISICAL_AUTH_SECRET}
+      DB_CONNECTION_URI: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/infisical
+      REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379/1
+      SITE_URL: https://secrets.${APP_DOMAIN}
+      TELEMETRY_ENABLED: false
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - grc-network
+      - grc-dmz
+    labels:
+      - 'traefik.enable=true'
+      - 'traefik.docker.network=grc-dmz'
+      - 'traefik.http.routers.infisical.rule=Host(`secrets.${APP_DOMAIN}`)'
+      - 'traefik.http.routers.infisical.entrypoints=websecure'
+      - 'traefik.http.routers.infisical.tls.certresolver=letsencrypt'
+      - 'traefik.http.services.infisical.loadbalancer.server.port=8080'
+      - 'traefik.http.middlewares.infisical-ipallow.ipallowlist.sourcerange=10.0.0.0/8,172.16.0.0/12'
+      - 'traefik.http.routers.infisical.middlewares=infisical-ipallow'
+    restart: always
+    logging:
+      driver: 'json-file'
+      options:
+        max-size: '10m'
+        max-file: '3'
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:8080/api/status']
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 120s
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 1G
+        reservations:
+          cpus: '0.25'
+          memory: 256M
+
+  # ===========================================
   # Controls Service - Security Controls Management
   # ===========================================
   controls:
@@ -356,6 +416,8 @@ services:
       keycloak:
         condition: service_healthy
       rustfs:
+        condition: service_healthy
+      infisical:
         condition: service_healthy
     networks:
       - grc-network
@@ -457,6 +519,8 @@ services:
         condition: service_healthy
       rustfs:
         condition: service_healthy
+      infisical:
+        condition: service_healthy
     networks:
       - grc-network
     labels:
@@ -539,6 +603,8 @@ services:
         condition: service_healthy
       rustfs:
         condition: service_healthy
+      infisical:
+        condition: service_healthy
     networks:
       - grc-network
     labels:
@@ -620,6 +686,8 @@ services:
       keycloak:
         condition: service_healthy
       rustfs:
+        condition: service_healthy
+      infisical:
         condition: service_healthy
     networks:
       - grc-network
@@ -705,6 +773,8 @@ services:
         condition: service_healthy
       rustfs:
         condition: service_healthy
+      infisical:
+        condition: service_healthy
     networks:
       - grc-network
     labels:
@@ -788,6 +858,8 @@ services:
       keycloak:
         condition: service_healthy
       rustfs:
+        condition: service_healthy
+      infisical:
         condition: service_healthy
     networks:
       - grc-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,7 @@ services:
     command: start-dev --import-realm
     environment:
       KC_DB: postgres
-      KC_DB_URL: jdbc:postgresql://postgres:5432/${POSTGRES_DB:-gigachad_grc}
+      KC_DB_URL: jdbc:postgresql://postgres:5432/keycloak
       KC_DB_USERNAME: ${POSTGRES_USER:-grc}
       KC_DB_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
       KC_HOSTNAME: ${KEYCLOAK_HOSTNAME:-localhost}
@@ -193,6 +193,47 @@ services:
       start_period: 10s
 
   # ===========================================
+  # Secrets Management - Infisical (Self-Hosted)
+  # Centralized secret management with audit trail
+  # ===========================================
+  infisical:
+    image: infisical/infisical:v0.158.2
+    container_name: grc-infisical
+    security_opt:
+      - no-new-privileges:true
+    environment:
+      ENCRYPTION_KEY: ${INFISICAL_ENCRYPTION_KEY:?INFISICAL_ENCRYPTION_KEY is required}
+      AUTH_SECRET: ${INFISICAL_AUTH_SECRET:?INFISICAL_AUTH_SECRET is required}
+      DB_CONNECTION_URI: postgresql://${POSTGRES_USER:?}:${POSTGRES_PASSWORD:?}@postgres:5432/infisical
+      REDIS_URL: redis://:${REDIS_PASSWORD:?}@redis:6379/1
+      SITE_URL: http://localhost:8443
+      TELEMETRY_ENABLED: false
+    ports:
+      - '127.0.0.1:8443:8080'
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - grc-network
+    restart: unless-stopped
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:8080/api/status']
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 120s
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 1G
+        reservations:
+          cpus: '0.25'
+          memory: 256M
+
+  # ===========================================
   # Controls Service - Security Controls Management
   # ===========================================
   controls:
@@ -243,6 +284,8 @@ services:
       keycloak:
         condition: service_started
       rustfs:
+        condition: service_healthy
+      infisical:
         condition: service_healthy
     networks:
       - grc-network
@@ -318,6 +361,8 @@ services:
         condition: service_started
       rustfs:
         condition: service_healthy
+      infisical:
+        condition: service_healthy
     networks:
       - grc-network
     labels:
@@ -369,6 +414,8 @@ services:
         condition: service_started
       rustfs:
         condition: service_healthy
+      infisical:
+        condition: service_healthy
     networks:
       - grc-network
     labels:
@@ -418,6 +465,8 @@ services:
       keycloak:
         condition: service_started
       rustfs:
+        condition: service_healthy
+      infisical:
         condition: service_healthy
     networks:
       - grc-network
@@ -476,6 +525,8 @@ services:
         condition: service_started
       rustfs:
         condition: service_healthy
+      infisical:
+        condition: service_healthy
     networks:
       - grc-network
     labels:
@@ -529,6 +580,8 @@ services:
       keycloak:
         condition: service_started
       rustfs:
+        condition: service_healthy
+      infisical:
         condition: service_healthy
     networks:
       - grc-network

--- a/init.sh
+++ b/init.sh
@@ -38,7 +38,7 @@ NC='\033[0m'
 
 # Services to manage
 SERVICES=(shared controls frameworks policies tprm trust audit)
-INFRASTRUCTURE=(postgres redis keycloak rustfs)
+INFRASTRUCTURE=(postgres redis keycloak rustfs infisical)
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Helper Functions
@@ -152,6 +152,20 @@ setup_environment() {
     
     if [ -f ".env" ]; then
         log_success ".env file exists (using existing credentials)"
+        # Migrate: append Infisical bootstrap secrets if missing from older .env
+        if ! grep -q '^INFISICAL_ENCRYPTION_KEY=' ".env" 2>/dev/null; then
+            log_substep "Adding missing Infisical secrets to existing .env..."
+            local INF_ENC_KEY INF_AUTH_SEC
+            INF_ENC_KEY=$(openssl rand -hex 16 2>/dev/null || head -c 16 /dev/urandom | xxd -p | tr -d '\n')
+            INF_AUTH_SEC=$(openssl rand -base64 32 2>/dev/null | tr -d '\n' || head -c 32 /dev/urandom | base64 | tr -d '\n')
+            cat >> ".env" << INFISICAL_EOF
+
+# Infisical Secrets Manager (auto-added)
+INFISICAL_ENCRYPTION_KEY=${INF_ENC_KEY}
+INFISICAL_AUTH_SECRET=${INF_AUTH_SEC}
+INFISICAL_EOF
+            log_success "Infisical bootstrap secrets added to .env"
+        fi
         # Source the existing .env to get passwords for health checks
         set -a
         source .env 2>/dev/null || true
@@ -182,7 +196,9 @@ setup_environment() {
     POSTGRES_PASSWORD=$(openssl rand -base64 24 2>/dev/null | tr -d '\n' | tr '+/' '-_' || head -c 24 /dev/urandom | base64 | tr '+/' '-_')
     REDIS_PASSWORD=$(openssl rand -base64 24 2>/dev/null | tr -d '\n' | tr '+/' '-_' || head -c 24 /dev/urandom | base64 | tr '+/' '-_')
     MINIO_PASSWORD=$(openssl rand -base64 20 2>/dev/null | tr -d '\n' | tr '+/' '-_' || head -c 20 /dev/urandom | base64 | tr '+/' '-_')
-    
+    INFISICAL_ENCRYPTION_KEY=$(openssl rand -hex 16 2>/dev/null || head -c 16 /dev/urandom | xxd -p | tr -d '\n')
+    INFISICAL_AUTH_SECRET=$(openssl rand -base64 32 2>/dev/null | tr -d '\n' || head -c 32 /dev/urandom | base64 | tr -d '\n')
+
     cat > ".env" << EOF
 # ============================================================================
 # GigaChad GRC - Environment Configuration
@@ -230,6 +246,10 @@ RATE_LIMIT_MAX_REQUESTS=1000
 # Logging
 LOG_LEVEL=debug
 
+# Infisical Secrets Manager
+INFISICAL_ENCRYPTION_KEY=${INFISICAL_ENCRYPTION_KEY}
+INFISICAL_AUTH_SECRET=${INFISICAL_AUTH_SECRET}
+
 # Frontend
 VITE_API_URL=http://localhost:3001
 VITE_ENABLE_DEV_AUTH=true
@@ -249,8 +269,8 @@ start_infrastructure() {
     
     cd "$PROJECT_ROOT"
     
-    log_substep "Starting PostgreSQL, Redis, Keycloak, RustFS..."
-    docker compose up -d postgres redis keycloak rustfs 2>/dev/null || docker-compose up -d postgres redis keycloak rustfs
+    log_substep "Starting PostgreSQL, Redis, Keycloak, RustFS, Infisical..."
+    docker compose up -d postgres redis keycloak rustfs infisical 2>/dev/null || docker-compose up -d postgres redis keycloak rustfs infisical
     
     # Wait for database
     log_substep "Waiting for PostgreSQL to be ready..."
@@ -293,6 +313,25 @@ start_infrastructure() {
         sleep 2
     done
     
+    # Wait for Infisical
+    log_substep "Waiting for Infisical to be ready..."
+    attempts=0
+    while [ $attempts -lt 30 ]; do
+        if curl -sf http://localhost:8443/api/status > /dev/null 2>&1; then
+            log_success "Infisical is ready"
+            break
+        fi
+        attempts=$((attempts + 1))
+        sleep 2
+    done
+
+    # First-time Infisical setup hint
+    if [ ! -f ".infisical-initialized" ]; then
+        log_info "Visit http://localhost:8443 to create your Infisical admin account"
+        log_info "Then run 'make secrets-seed' to import application secrets"
+        touch .infisical-initialized
+    fi
+
     log_success "All infrastructure services running"
 }
 
@@ -434,8 +473,8 @@ reset_all() {
     log_substep "Stopping containers..."
     docker compose down -v 2>/dev/null || docker-compose down -v 2>/dev/null || true
     
-    log_substep "Removing .env..."
-    rm -f .env
+    log_substep "Removing .env and Infisical state..."
+    rm -f .env .infisical-initialized
     
     log_substep "Removing node_modules..."
     rm -rf node_modules
@@ -465,6 +504,7 @@ print_success_demo() {
     echo -e "   ${CYAN}API Docs${NC}        http://localhost:3001/api/docs"
     echo -e "   ${CYAN}Keycloak${NC}        http://localhost:8080 (admin/admin)"
     echo -e "   ${CYAN}RustFS Console${NC}  http://localhost:9001 (rustfsadmin/...)"
+    echo -e "   ${CYAN}Secrets${NC}         http://localhost:8443 (Infisical)"
     echo -e "   ${CYAN}Grafana${NC}         http://localhost:3003 (admin/admin)"
     echo ""
     echo -e "${BOLD}Quick Login:${NC}"

--- a/scripts/seed-infisical.sh
+++ b/scripts/seed-infisical.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+# =============================================================================
+# GigaChad GRC - Seed Infisical with Application Secrets
+# =============================================================================
+#
+# This script imports application-tier secrets from the existing .env file
+# into Infisical for centralized secret management.
+#
+# Prerequisites:
+#   1. Infisical must be running (docker compose up infisical)
+#   2. Create an admin account at http://localhost:8443
+#   3. Create a Machine Identity with Universal Auth and generate a token
+#
+# Usage: ./scripts/seed-infisical.sh
+#
+# =============================================================================
+
+set -euo pipefail
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+ENV_FILE="$PROJECT_DIR/.env"
+
+INFISICAL_URL="${INFISICAL_URL:-http://localhost:8443}"
+
+echo ""
+echo -e "${CYAN}╔═══════════════════════════════════════════════════════════════╗${NC}"
+echo -e "${CYAN}║       GigaChad GRC - Infisical Secret Seeding                ║${NC}"
+echo -e "${CYAN}╚═══════════════════════════════════════════════════════════════╝${NC}"
+echo ""
+
+# Step 1: Check Infisical is healthy
+echo -e "${BLUE}[1/4]${NC} Checking Infisical health..."
+attempts=0
+max_attempts=15
+while [ $attempts -lt $max_attempts ]; do
+    if curl -sf "${INFISICAL_URL}/api/status" > /dev/null 2>&1; then
+        echo -e "  ${GREEN}✓${NC} Infisical is healthy at ${INFISICAL_URL}"
+        break
+    fi
+    attempts=$((attempts + 1))
+    if [ $attempts -eq $max_attempts ]; then
+        echo -e "  ${RED}✗${NC} Infisical is not responding at ${INFISICAL_URL}"
+        echo -e "  ${YELLOW}→${NC} Start it with: docker compose up -d infisical"
+        exit 1
+    fi
+    sleep 2
+done
+
+# Step 2: Check for admin account
+echo ""
+echo -e "${BLUE}[2/4]${NC} Admin account setup"
+echo -e "  ${YELLOW}→${NC} If you haven't already, visit ${CYAN}${INFISICAL_URL}${NC} to create your admin account"
+echo ""
+read -p "  Have you created an admin account? (y/n) " -n 1 -r
+echo ""
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo -e "  ${YELLOW}→${NC} Please create an admin account first, then re-run this script"
+    exit 0
+fi
+
+# Step 3: Get API token
+echo ""
+echo -e "${BLUE}[3/4]${NC} Machine Identity setup"
+echo -e "  To seed secrets, you need an API token from Infisical:"
+echo ""
+echo -e "  1. Go to ${CYAN}${INFISICAL_URL}${NC} → Admin Console → Machine Identities"
+echo -e "  2. Create a new Machine Identity (e.g., 'grc-seeder')"
+echo -e "  3. Add Universal Auth method"
+echo -e "  4. Generate a Client ID and Client Secret"
+echo ""
+
+if [ -n "${INFISICAL_TOKEN:-}" ]; then
+    echo -e "  ${GREEN}✓${NC} Using INFISICAL_TOKEN from environment"
+    TOKEN="$INFISICAL_TOKEN"
+else
+    read -p "  Enter your Infisical API token (or Machine Identity token): " TOKEN
+    if [ -z "$TOKEN" ]; then
+        echo -e "  ${RED}✗${NC} Token is required"
+        exit 1
+    fi
+fi
+
+# Step 4: Import secrets from .env
+echo ""
+echo -e "${BLUE}[4/4]${NC} Importing application secrets from .env..."
+
+if [ ! -f "$ENV_FILE" ]; then
+    echo -e "  ${RED}✗${NC} .env file not found at $ENV_FILE"
+    exit 1
+fi
+
+# Application-tier secrets to migrate to Infisical
+APP_SECRETS=(
+    "ENCRYPTION_KEY"
+    "JWT_SECRET"
+    "SESSION_SECRET"
+    "PHISHING_TRACKING_SECRET"
+    "KEYCLOAK_ADMIN_PASSWORD"
+    "KEYCLOAK_ADMIN_CLIENT_SECRET"
+    "GRAFANA_ADMIN_PASSWORD"
+    "OPENAI_API_KEY"
+    "ANTHROPIC_API_KEY"
+)
+
+imported=0
+skipped=0
+
+for secret_name in "${APP_SECRETS[@]}"; do
+    # Extract value from .env file
+    value=$(grep "^${secret_name}=" "$ENV_FILE" 2>/dev/null | head -1 | cut -d'=' -f2-)
+
+    if [ -z "$value" ]; then
+        echo -e "  ${YELLOW}⚠${NC} ${secret_name} - not found in .env (skipped)"
+        skipped=$((skipped + 1))
+        continue
+    fi
+
+    # Create/update secret in Infisical via API
+    response=$(curl -sf -X POST "${INFISICAL_URL}/api/v3/secrets/raw/${secret_name}" \
+        -H "Authorization: Bearer ${TOKEN}" \
+        -H "Content-Type: application/json" \
+        -d "{
+            \"workspaceId\": \"default\",
+            \"environment\": \"dev\",
+            \"secretValue\": \"${value}\",
+            \"type\": \"shared\"
+        }" 2>&1) || true
+
+    if echo "$response" | grep -q '"secret"' 2>/dev/null; then
+        echo -e "  ${GREEN}✓${NC} ${secret_name}"
+        imported=$((imported + 1))
+    else
+        # Try updating if create fails (secret may already exist)
+        response=$(curl -sf -X PATCH "${INFISICAL_URL}/api/v3/secrets/raw/${secret_name}" \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{
+                \"workspaceId\": \"default\",
+                \"environment\": \"dev\",
+                \"secretValue\": \"${value}\",
+                \"type\": \"shared\"
+            }" 2>&1) || true
+
+        if echo "$response" | grep -q '"secret"' 2>/dev/null; then
+            echo -e "  ${GREEN}✓${NC} ${secret_name} (updated)"
+            imported=$((imported + 1))
+        else
+            echo -e "  ${RED}✗${NC} ${secret_name} - failed to import"
+            echo -e "      API response: ${response}"
+            skipped=$((skipped + 1))
+        fi
+    fi
+done
+
+echo ""
+echo -e "${GREEN}╔═══════════════════════════════════════════════════════════════╗${NC}"
+echo -e "${GREEN}║                    Seeding Complete!                          ║${NC}"
+echo -e "${GREEN}╚═══════════════════════════════════════════════════════════════╝${NC}"
+echo ""
+echo -e "  Imported: ${GREEN}${imported}${NC} secrets"
+echo -e "  Skipped:  ${YELLOW}${skipped}${NC} secrets"
+echo ""
+echo -e "${BOLD}Next steps:${NC}"
+echo -e "  1. Install Infisical CLI:  ${CYAN}brew install infisical/get-cli/infisical${NC}"
+echo -e "  2. Authenticate:           ${CYAN}infisical login --domain=${INFISICAL_URL}${NC}"
+echo -e "  3. Start with injection:   ${CYAN}make up${NC}"
+echo ""
+echo -e "  Secrets are now managed at ${CYAN}${INFISICAL_URL}${NC}"
+echo -e "  Rotate secrets there — no .env changes needed."
+echo ""

--- a/scripts/seed-infisical.sh
+++ b/scripts/seed-infisical.sh
@@ -133,9 +133,9 @@ for secret_name in "${APP_SECRETS[@]}"; do
         '{workspaceId: $ws, environment: $env, secretValue: $val, type: $typ}')
 
     # Create/update secret in Infisical via API
-    # Token passed via env var to avoid exposure in process listing
-    response=$(AUTH_TOKEN="$TOKEN" curl -sf -X POST "${INFISICAL_URL}/api/v3/secrets/raw/${secret_name}" \
-        -H "Authorization: Bearer $AUTH_TOKEN" \
+    # Use curl --config to pass auth header via stdin, avoiding token in process listing
+    response=$(curl -sf -X POST "${INFISICAL_URL}/api/v3/secrets/raw/${secret_name}" \
+        --config <(printf 'header = "Authorization: Bearer %s"\n' "$TOKEN") \
         -H "Content-Type: application/json" \
         -d "$json_payload" 2>&1) || true
 
@@ -144,8 +144,8 @@ for secret_name in "${APP_SECRETS[@]}"; do
         imported=$((imported + 1))
     else
         # Try updating if create fails (secret may already exist)
-        response=$(AUTH_TOKEN="$TOKEN" curl -sf -X PATCH "${INFISICAL_URL}/api/v3/secrets/raw/${secret_name}" \
-            -H "Authorization: Bearer $AUTH_TOKEN" \
+        response=$(curl -sf -X PATCH "${INFISICAL_URL}/api/v3/secrets/raw/${secret_name}" \
+            --config <(printf 'header = "Authorization: Bearer %s"\n' "$TOKEN") \
             -H "Content-Type: application/json" \
             -d "$json_payload" 2>&1) || true
 

--- a/services/audit/src/auth/auth.module.ts
+++ b/services/audit/src/auth/auth.module.ts
@@ -1,0 +1,19 @@
+import { Global, Module } from '@nestjs/common';
+import { DevAuthGuard, RolesGuard, PermissionsGuard, PRISMA_SERVICE } from '@gigachad-grc/shared';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Global()
+@Module({
+  providers: [
+    PrismaService,
+    {
+      provide: PRISMA_SERVICE,
+      useExisting: PrismaService,
+    },
+    DevAuthGuard,
+    RolesGuard,
+    PermissionsGuard,
+  ],
+  exports: [PrismaService, PRISMA_SERVICE, DevAuthGuard, RolesGuard, PermissionsGuard],
+})
+export class AuthModule {}

--- a/services/controls/src/app.module.ts
+++ b/services/controls/src/app.module.ts
@@ -54,7 +54,7 @@ import { AuthModule } from './auth/auth.module';
 import { ModulesController } from './modules/modules.controller';
 import { CustomThrottlerGuard } from './auth/throttler.guard';
 import { CorrelationIdMiddleware } from './common/correlation-id.middleware';
-import { StorageModule, EventsModule, CacheModule, HealthModule } from '@gigachad-grc/shared';
+import { StorageModule, EventsModule, CacheModule, HealthModule, SecretsModule } from '@gigachad-grc/shared';
 
 @Module({
   imports: [
@@ -86,6 +86,7 @@ import { StorageModule, EventsModule, CacheModule, HealthModule } from '@gigacha
       path: 'api/metrics',
     }),
     PrismaModule,
+    SecretsModule.forRoot(),
     StorageModule.forRoot(),
     EventsModule,
     CacheModule.forRoot({

--- a/services/controls/src/integrations/connectors/base-connector.ts
+++ b/services/controls/src/integrations/connectors/base-connector.ts
@@ -2,6 +2,9 @@ import { Logger } from '@nestjs/common';
 import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
 import { URL } from 'url';
 import * as net from 'net';
+import * as dns from 'dns';
+import * as http from 'http';
+import * as https from 'https';
 
 /**
  * HTTP request result type.
@@ -64,9 +67,156 @@ function getErrorMessage(error: unknown): string {
   return 'Request failed';
 }
 
+// =============================================================================
+// SSRF Protection
+// =============================================================================
+
+/**
+ * Check if an IPv4 address is in a blocked range (private, loopback, link-local, etc.).
+ */
+function isBlockedIPv4(ip: string): string | null {
+  const octets = ip.split('.').map(Number);
+  if (octets.length !== 4 || octets.some((o) => isNaN(o) || o < 0 || o > 255)) return null;
+
+  if (octets[0] === 10) return 'private IP range (10.x.x.x)';
+  if (octets[0] === 172 && octets[1] >= 16 && octets[1] <= 31) return 'private IP range (172.16-31.x.x)';
+  if (octets[0] === 192 && octets[1] === 168) return 'private IP range (192.168.x.x)';
+  if (octets[0] === 127) return 'loopback address';
+  if (octets[0] === 169 && octets[1] === 254) return 'link-local address';
+  if (octets.every((o) => o === 0)) return 'unspecified address';
+  return null;
+}
+
+/**
+ * Parse an IPv6 address string into 16 bytes. Returns null if not valid IPv6.
+ */
+function parseIPv6Bytes(ip: string): number[] | null {
+  // Handle IPv6-mapped IPv4 (e.g., ::ffff:127.0.0.1)
+  const mappedMatch = ip.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
+  if (mappedMatch) {
+    const v4octets = mappedMatch[1].split('.').map(Number);
+    if (v4octets.length === 4 && v4octets.every((o) => o >= 0 && o <= 255)) {
+      return [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, ...v4octets];
+    }
+  }
+
+  // Expand :: notation
+  const halves = ip.split('::');
+  if (halves.length > 2) return null;
+
+  const expandGroup = (s: string): number[] => {
+    if (!s) return [];
+    return s.split(':').flatMap((g) => {
+      const val = parseInt(g, 16);
+      if (isNaN(val) || val < 0 || val > 0xffff) return [NaN, NaN];
+      return [(val >> 8) & 0xff, val & 0xff];
+    });
+  };
+
+  let bytes: number[];
+  if (halves.length === 2) {
+    const left = expandGroup(halves[0]);
+    const right = expandGroup(halves[1]);
+    const pad = 16 - left.length - right.length;
+    if (pad < 0) return null;
+    bytes = [...left, ...new Array(pad).fill(0), ...right];
+  } else {
+    bytes = expandGroup(halves[0]);
+  }
+
+  if (bytes.length !== 16 || bytes.some((b) => isNaN(b))) return null;
+  return bytes;
+}
+
+/**
+ * Check if an IPv6 address is in a blocked range.
+ */
+function isBlockedIPv6(ip: string): string | null {
+  const bytes = parseIPv6Bytes(ip);
+  if (!bytes) return null;
+
+  // ::1 (loopback)
+  if (bytes.slice(0, 15).every((b) => b === 0) && bytes[15] === 1) {
+    return 'IPv6 loopback address';
+  }
+
+  // :: (unspecified)
+  if (bytes.every((b) => b === 0)) {
+    return 'IPv6 unspecified address';
+  }
+
+  // ::ffff:0:0/96 (IPv6-mapped IPv4) — check the embedded IPv4
+  if (
+    bytes.slice(0, 10).every((b) => b === 0) &&
+    bytes[10] === 0xff &&
+    bytes[11] === 0xff
+  ) {
+    const embeddedIPv4 = `${bytes[12]}.${bytes[13]}.${bytes[14]}.${bytes[15]}`;
+    const v4Reason = isBlockedIPv4(embeddedIPv4);
+    if (v4Reason) return `IPv6-mapped IPv4: ${v4Reason}`;
+  }
+
+  // fc00::/7 (Unique Local Address — includes fd00::/8)
+  if ((bytes[0] & 0xfe) === 0xfc) {
+    return 'IPv6 unique local address (fc00::/7)';
+  }
+
+  // fe80::/10 (link-local)
+  if (bytes[0] === 0xfe && (bytes[1] & 0xc0) === 0x80) {
+    return 'IPv6 link-local address (fe80::/10)';
+  }
+
+  return null;
+}
+
+/**
+ * Validate a resolved IP address is not in a blocked range.
+ * Throws if the IP is private, loopback, link-local, etc.
+ */
+function validateResolvedIp(hostname: string, ip: string): void {
+  if (net.isIPv4(ip)) {
+    const reason = isBlockedIPv4(ip);
+    if (reason) {
+      throw new Error(`SSRF blocked: "${hostname}" resolves to ${ip} (${reason})`);
+    }
+  } else if (net.isIPv6(ip)) {
+    const reason = isBlockedIPv6(ip);
+    if (reason) {
+      throw new Error(`SSRF blocked: "${hostname}" resolves to ${ip} (${reason})`);
+    }
+  }
+}
+
+/**
+ * Custom DNS lookup function that validates the resolved IP against SSRF blocklists.
+ * Used as the `lookup` option for http.Agent/https.Agent to enforce SSRF protection
+ * at connection time — preventing DNS rebinding and domain-based bypasses.
+ */
+const ssrfSafeLookup: dns.LookupFunction = (hostname, options, callback) => {
+  dns.lookup(hostname, options, (err, address, family) => {
+    if (err) return callback(err, address, family);
+    try {
+      validateResolvedIp(hostname, address);
+    } catch (e) {
+      return callback(e as NodeJS.ErrnoException, address, family);
+    }
+    callback(null, address, family);
+  });
+};
+
+/** Shared SSRF-safe HTTP agent (connection-time IP validation). */
+const ssrfSafeHttpAgent = new http.Agent({ lookup: ssrfSafeLookup });
+/** Shared SSRF-safe HTTPS agent (connection-time IP validation). */
+const ssrfSafeHttpsAgent = new https.Agent({ lookup: ssrfSafeLookup });
+
 /**
  * Validate a URL is safe for server-side requests (SSRF protection).
- * Blocks private IPs, loopback, link-local, and cloud metadata endpoints.
+ * Blocks private IPs, loopback, link-local, cloud metadata endpoints,
+ * and IPv6 private/mapped ranges.
+ *
+ * This provides fast, synchronous rejection of obviously-blocked URLs.
+ * DNS-resolution-time validation is handled separately by ssrfSafeLookup
+ * on the HTTP agents (prevents DNS rebinding / domain-based bypasses).
  */
 function validateUrlSafe(urlString: string): void {
   let parsed: URL;
@@ -76,10 +226,15 @@ function validateUrlSafe(urlString: string): void {
     throw new Error(`Invalid URL: ${urlString}`);
   }
 
+  // Only allow http and https schemes
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`SSRF blocked: unsupported protocol ${parsed.protocol}`);
+  }
+
   const hostname = parsed.hostname.toLowerCase();
 
   // Block localhost
-  if (hostname === 'localhost' || hostname === '[::1]') {
+  if (hostname === 'localhost') {
     throw new Error('SSRF blocked: localhost URLs are not allowed');
   }
 
@@ -88,55 +243,39 @@ function validateUrlSafe(urlString: string): void {
     throw new Error('SSRF blocked: cloud metadata endpoints are not allowed');
   }
 
-  // Check if hostname is an IP address
+  // Check IPv4
   if (net.isIPv4(hostname)) {
-    const octets = hostname.split('.').map(Number);
-    // 10.0.0.0/8
-    if (octets[0] === 10) {
-      throw new Error('SSRF blocked: private IP range (10.x.x.x)');
-    }
-    // 172.16.0.0/12
-    if (octets[0] === 172 && octets[1] >= 16 && octets[1] <= 31) {
-      throw new Error('SSRF blocked: private IP range (172.16-31.x.x)');
-    }
-    // 192.168.0.0/16
-    if (octets[0] === 192 && octets[1] === 168) {
-      throw new Error('SSRF blocked: private IP range (192.168.x.x)');
-    }
-    // 127.0.0.0/8
-    if (octets[0] === 127) {
-      throw new Error('SSRF blocked: loopback address');
-    }
-    // 169.254.0.0/16 (link-local)
-    if (octets[0] === 169 && octets[1] === 254) {
-      throw new Error('SSRF blocked: link-local address');
-    }
-    // 0.0.0.0
-    if (octets.every((o) => o === 0)) {
-      throw new Error('SSRF blocked: unspecified address');
-    }
+    const reason = isBlockedIPv4(hostname);
+    if (reason) throw new Error(`SSRF blocked: ${reason}`);
   }
 
-  // Only allow http and https schemes
-  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-    throw new Error(`SSRF blocked: unsupported protocol ${parsed.protocol}`);
+  // Check IPv6 (URL parser strips brackets, so hostname is bare IPv6)
+  if (net.isIPv6(hostname)) {
+    const reason = isBlockedIPv6(hostname);
+    if (reason) throw new Error(`SSRF blocked: ${reason}`);
   }
 }
 
 /**
  * Base connector class with common HTTP functionality.
  * All integration connectors should extend this for consistent behavior.
- * 
+ *
+ * SSRF protection is enforced at two layers:
+ * 1. URL string validation (validateUrlSafe) — fast rejection of obvious attacks
+ * 2. DNS resolution validation (ssrfSafeLookup on agents) — prevents DNS rebinding
+ *
+ * Redirects are disabled (maxRedirects: 0) to prevent redirect-based SSRF bypasses.
+ *
  * @example
  * ```typescript
  * @Injectable()
  * export class MyConnector extends BaseConnector {
  *   constructor() { super('MyConnector'); }
- *   
+ *
  *   async testConnection(config: MyConfig): Promise<ConnectionTestResult> {
  *     // Implementation
  *   }
- *   
+ *
  *   async sync(config: MyConfig): Promise<SyncResult> {
  *     // Implementation
  *   }
@@ -151,7 +290,10 @@ export abstract class BaseConnector {
     this.logger = new Logger(connectorName);
     this.axiosInstance = axios.create({
       timeout: 30000,
+      maxRedirects: 0,
       validateStatus: (status) => status < 500, // Don't throw on 4xx errors
+      httpAgent: ssrfSafeHttpAgent,
+      httpsAgent: ssrfSafeHttpsAgent,
     });
   }
 
@@ -161,6 +303,8 @@ export abstract class BaseConnector {
    * for concurrent use in singleton NestJS services.
    *
    * Includes SSRF validation on the base URL.
+   * Redirects are disabled to prevent redirect-based SSRF bypasses.
+   * DNS resolution is validated at connection time via custom agents.
    */
   protected createClient(
     baseURL: string,
@@ -170,7 +314,10 @@ export abstract class BaseConnector {
     validateUrlSafe(baseURL);
     return axios.create({
       timeout: timeout || 30000,
+      maxRedirects: 0,
       validateStatus: (status) => status < 500,
+      httpAgent: ssrfSafeHttpAgent,
+      httpsAgent: ssrfSafeHttpsAgent,
       baseURL,
       headers,
     });
@@ -306,7 +453,8 @@ export abstract class BaseConnector {
    * shared mutable state in singleton services. This method mutates the
    * shared axiosInstance defaults and is unsafe for concurrent use.
    *
-   * Includes SSRF validation.
+   * Includes SSRF URL validation. DNS resolution is validated at connection
+   * time by the SSRF-safe agents.
    */
   protected setBaseURL(baseURL: string): void {
     validateUrlSafe(baseURL);
@@ -350,4 +498,3 @@ export abstract class BaseConnector {
   abstract testConnection(config: BaseConnectorConfig): Promise<ConnectionTestResult>;
   abstract sync(config: BaseConnectorConfig): Promise<SyncResult>;
 }
-

--- a/services/controls/src/integrations/connectors/base-connector.ts
+++ b/services/controls/src/integrations/connectors/base-connector.ts
@@ -1,5 +1,7 @@
 import { Logger } from '@nestjs/common';
 import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
+import { URL } from 'url';
+import * as net from 'net';
 
 /**
  * HTTP request result type.
@@ -63,6 +65,65 @@ function getErrorMessage(error: unknown): string {
 }
 
 /**
+ * Validate a URL is safe for server-side requests (SSRF protection).
+ * Blocks private IPs, loopback, link-local, and cloud metadata endpoints.
+ */
+function validateUrlSafe(urlString: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(urlString);
+  } catch {
+    throw new Error(`Invalid URL: ${urlString}`);
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+
+  // Block localhost
+  if (hostname === 'localhost' || hostname === '[::1]') {
+    throw new Error('SSRF blocked: localhost URLs are not allowed');
+  }
+
+  // Block cloud metadata endpoints
+  if (hostname === '169.254.169.254' || hostname === 'metadata.google.internal') {
+    throw new Error('SSRF blocked: cloud metadata endpoints are not allowed');
+  }
+
+  // Check if hostname is an IP address
+  if (net.isIPv4(hostname)) {
+    const octets = hostname.split('.').map(Number);
+    // 10.0.0.0/8
+    if (octets[0] === 10) {
+      throw new Error('SSRF blocked: private IP range (10.x.x.x)');
+    }
+    // 172.16.0.0/12
+    if (octets[0] === 172 && octets[1] >= 16 && octets[1] <= 31) {
+      throw new Error('SSRF blocked: private IP range (172.16-31.x.x)');
+    }
+    // 192.168.0.0/16
+    if (octets[0] === 192 && octets[1] === 168) {
+      throw new Error('SSRF blocked: private IP range (192.168.x.x)');
+    }
+    // 127.0.0.0/8
+    if (octets[0] === 127) {
+      throw new Error('SSRF blocked: loopback address');
+    }
+    // 169.254.0.0/16 (link-local)
+    if (octets[0] === 169 && octets[1] === 254) {
+      throw new Error('SSRF blocked: link-local address');
+    }
+    // 0.0.0.0
+    if (octets.every((o) => o === 0)) {
+      throw new Error('SSRF blocked: unspecified address');
+    }
+  }
+
+  // Only allow http and https schemes
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`SSRF blocked: unsupported protocol ${parsed.protocol}`);
+  }
+}
+
+/**
  * Base connector class with common HTTP functionality.
  * All integration connectors should extend this for consistent behavior.
  * 
@@ -95,14 +156,48 @@ export abstract class BaseConnector {
   }
 
   /**
+   * Create a request-scoped HTTP client with the given base URL and headers.
+   * This returns a fresh AxiosInstance that is NOT shared, making it safe
+   * for concurrent use in singleton NestJS services.
+   *
+   * Includes SSRF validation on the base URL.
+   */
+  protected createClient(
+    baseURL: string,
+    headers?: Record<string, string>,
+    timeout?: number,
+  ): AxiosInstance {
+    validateUrlSafe(baseURL);
+    return axios.create({
+      timeout: timeout || 30000,
+      validateStatus: (status) => status < 500,
+      baseURL,
+      headers,
+    });
+  }
+
+  private getClient(config?: AxiosRequestConfig & { client?: AxiosInstance }): {
+    client: AxiosInstance;
+    axiosConfig?: AxiosRequestConfig;
+  } {
+    if (config?.client) {
+      const { client, ...rest } = config;
+      return { client, axiosConfig: Object.keys(rest).length > 0 ? rest : undefined };
+    }
+    return { client: this.axiosInstance, axiosConfig: config };
+  }
+
+  /**
    * Make an authenticated GET request.
+   * Pass { client } in config to use a request-scoped client.
    */
   protected async get<T = unknown>(
     url: string,
-    config?: AxiosRequestConfig,
+    config?: AxiosRequestConfig & { client?: AxiosInstance },
   ): Promise<HttpResult<T>> {
     try {
-      const response = await this.axiosInstance.get<T>(url, config);
+      const { client, axiosConfig } = this.getClient(config);
+      const response = await client.get<T>(url, axiosConfig);
       if (response.status >= 400) {
         return {
           error: `HTTP ${response.status}: ${response.statusText}`,
@@ -119,14 +214,16 @@ export abstract class BaseConnector {
 
   /**
    * Make an authenticated POST request.
+   * Pass { client } in config to use a request-scoped client.
    */
   protected async post<T = unknown, D = unknown>(
     url: string,
     data?: D,
-    config?: AxiosRequestConfig,
+    config?: AxiosRequestConfig & { client?: AxiosInstance },
   ): Promise<HttpResult<T>> {
     try {
-      const response = await this.axiosInstance.post<T>(url, data, config);
+      const { client, axiosConfig } = this.getClient(config);
+      const response = await client.post<T>(url, data, axiosConfig);
       if (response.status >= 400) {
         return {
           error: `HTTP ${response.status}: ${response.statusText}`,
@@ -143,14 +240,16 @@ export abstract class BaseConnector {
 
   /**
    * Make an authenticated PUT request.
+   * Pass { client } in config to use a request-scoped client.
    */
   protected async put<T = unknown, D = unknown>(
     url: string,
     data?: D,
-    config?: AxiosRequestConfig,
+    config?: AxiosRequestConfig & { client?: AxiosInstance },
   ): Promise<HttpResult<T>> {
     try {
-      const response = await this.axiosInstance.put<T>(url, data, config);
+      const { client, axiosConfig } = this.getClient(config);
+      const response = await client.put<T>(url, data, axiosConfig);
       if (response.status >= 400) {
         return {
           error: `HTTP ${response.status}: ${response.statusText}`,
@@ -167,13 +266,15 @@ export abstract class BaseConnector {
 
   /**
    * Make an authenticated DELETE request.
+   * Pass { client } in config to use a request-scoped client.
    */
   protected async delete<T = unknown>(
     url: string,
-    config?: AxiosRequestConfig,
+    config?: AxiosRequestConfig & { client?: AxiosInstance },
   ): Promise<HttpResult<T>> {
     try {
-      const response = await this.axiosInstance.delete<T>(url, config);
+      const { client, axiosConfig } = this.getClient(config);
+      const response = await client.delete<T>(url, axiosConfig);
       if (response.status >= 400) {
         return {
           error: `HTTP ${response.status}: ${response.statusText}`,
@@ -189,7 +290,9 @@ export abstract class BaseConnector {
   }
 
   /**
-   * Set default headers (Authorization, Content-Type, etc.).
+   * @deprecated Use createClient() for request-scoped clients to avoid
+   * shared mutable state in singleton services. This method mutates the
+   * shared axiosInstance defaults and is unsafe for concurrent use.
    */
   protected setHeaders(headers: Record<string, string>): void {
     this.axiosInstance.defaults.headers.common = {
@@ -199,9 +302,14 @@ export abstract class BaseConnector {
   }
 
   /**
-   * Set base URL for all requests.
+   * @deprecated Use createClient() for request-scoped clients to avoid
+   * shared mutable state in singleton services. This method mutates the
+   * shared axiosInstance defaults and is unsafe for concurrent use.
+   *
+   * Includes SSRF validation.
    */
   protected setBaseURL(baseURL: string): void {
+    validateUrlSafe(baseURL);
     this.axiosInstance.defaults.baseURL = baseURL;
   }
 

--- a/services/controls/src/integrations/integrations.module.ts
+++ b/services/controls/src/integrations/integrations.module.ts
@@ -3,9 +3,10 @@ import { IntegrationsController } from './integrations.controller';
 import { IntegrationsService } from './integrations.service';
 import { CustomIntegrationService } from './custom/custom-integration.service';
 import { PrismaModule } from '../prisma/prisma.module';
+import { SecretsModule } from '@gigachad-grc/shared';
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, SecretsModule.forRoot()],
   controllers: [IntegrationsController],
   providers: [IntegrationsService, CustomIntegrationService],
   exports: [IntegrationsService, CustomIntegrationService],

--- a/services/controls/src/integrations/integrations.service.ts
+++ b/services/controls/src/integrations/integrations.service.ts
@@ -235,13 +235,25 @@ export class IntegrationsService {
     return false;
   }
 
-  private encrypt(text: string): string {
+  /** Cache for the legacy key derivation (constant inputs: encryptionKey + 'salt') */
+  private legacyDerivedKey: Buffer | null = null;
+
+  private scryptAsync(password: string, salt: string | Buffer, keylen: number): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+      crypto.scrypt(password, salt, keylen, (err, derivedKey) => {
+        if (err) reject(err);
+        else resolve(derivedKey);
+      });
+    });
+  }
+
+  private async encrypt(text: string): Promise<string> {
     if (!text) return text;
 
     const iv = crypto.randomBytes(16);
     // SECURITY FIX: Generate random salt per encryption instead of using hardcoded salt
     const salt = crypto.randomBytes(16);
-    const key = crypto.scryptSync(this.encryptionKey, salt, 32);
+    const key = await this.scryptAsync(this.encryptionKey, salt, 32);
     const cipher = crypto.createCipheriv(this.algorithm, key, iv);
 
     let encrypted = cipher.update(text, 'utf8', 'hex');
@@ -253,7 +265,7 @@ export class IntegrationsService {
     return `${iv.toString('hex')}:${authTag.toString('hex')}:${salt.toString('hex')}:${encrypted}`;
   }
 
-  private decrypt(encryptedText: string, depth = 0): string {
+  private async decrypt(encryptedText: string, depth = 0): Promise<string> {
     if (!encryptedText) return encryptedText;
     // Guard against infinite recursion (max 3 layers should be more than enough)
     if (depth > 3) return encryptedText;
@@ -265,13 +277,15 @@ export class IntegrationsService {
 
       // Support both old format (3 parts: iv:authTag:encrypted) and new format (4 parts: iv:authTag:salt:encrypted)
       if (parts.length === 3) {
-        // Legacy format without salt - use hardcoded salt for backwards compatibility
+        // Legacy format without salt - use cached key for backwards compatibility
         const [ivHex, authTagHex, encrypted] = parts;
         const iv = Buffer.from(ivHex, 'hex');
         const authTag = Buffer.from(authTagHex, 'hex');
-        const key = crypto.scryptSync(this.encryptionKey, 'salt', 32); // Legacy salt
+        if (!this.legacyDerivedKey) {
+          this.legacyDerivedKey = await this.scryptAsync(this.encryptionKey, 'salt', 32);
+        }
 
-        const decipher = crypto.createDecipheriv(this.algorithm, key, iv);
+        const decipher = crypto.createDecipheriv(this.algorithm, this.legacyDerivedKey, iv);
         decipher.setAuthTag(authTag);
 
         decrypted = decipher.update(encrypted, 'hex', 'utf8');
@@ -282,7 +296,7 @@ export class IntegrationsService {
         const iv = Buffer.from(ivHex, 'hex');
         const authTag = Buffer.from(authTagHex, 'hex');
         const salt = Buffer.from(saltHex, 'hex');
-        const key = crypto.scryptSync(this.encryptionKey, salt, 32);
+        const key = await this.scryptAsync(this.encryptionKey, salt, 32);
 
         const decipher = crypto.createDecipheriv(this.algorithm, key, iv);
         decipher.setAuthTag(authTag);
@@ -364,10 +378,10 @@ export class IntegrationsService {
             this.logger.warn(
               `Failed to store ${key} in Infisical, falling back to local encryption: ${error}`
             );
-            safePropertySet(encrypted, key, this.encrypt(value));
+            safePropertySet(encrypted, key, await this.encrypt(value));
           }
         } else {
-          safePropertySet(encrypted, key, this.encrypt(value));
+          safePropertySet(encrypted, key, await this.encrypt(value));
         }
       } else {
         safePropertySet(encrypted, key, value);
@@ -378,9 +392,9 @@ export class IntegrationsService {
   }
 
   /**
-   * Synchronous encrypt for backward compatibility (no Infisical).
+   * Async encrypt without Infisical (local-only).
    */
-  private encryptConfig(config: Record<string, unknown>): Record<string, unknown> {
+  private async encryptConfig(config: Record<string, unknown>): Promise<Record<string, unknown>> {
     if (!config) return config;
 
     const encrypted: Record<string, unknown> = {};
@@ -395,7 +409,7 @@ export class IntegrationsService {
         // Preserve arrays as-is (e.g., evidenceTypes)
         safePropertySet(encrypted, key, value);
       } else if (typeof value === 'object' && value !== null) {
-        safePropertySet(encrypted, key, this.encryptConfig(value as Record<string, unknown>));
+        safePropertySet(encrypted, key, await this.encryptConfig(value as Record<string, unknown>));
       } else if (
         typeof value === 'string' &&
         SENSITIVE_FIELDS.some((f) => key.toLowerCase().includes(f.toLowerCase()))
@@ -404,7 +418,7 @@ export class IntegrationsService {
         if (this.isEncryptedFormat(value)) {
           safePropertySet(encrypted, key, value);
         } else {
-          safePropertySet(encrypted, key, this.encrypt(value));
+          safePropertySet(encrypted, key, await this.encrypt(value));
         }
       } else {
         safePropertySet(encrypted, key, value);
@@ -457,7 +471,7 @@ export class IntegrationsService {
         SENSITIVE_FIELDS.some((f) => key.toLowerCase().includes(f.toLowerCase()))
       ) {
         // Decrypt locally (legacy or fallback)
-        safePropertySet(decrypted, key, this.decrypt(value));
+        safePropertySet(decrypted, key, await this.decrypt(value));
       } else {
         safePropertySet(decrypted, key, value);
       }
@@ -467,9 +481,9 @@ export class IntegrationsService {
   }
 
   /**
-   * Synchronous decrypt for backward compatibility (no Infisical refs).
+   * Async decrypt without Infisical refs (local-only).
    */
-  private decryptConfig(config: Record<string, unknown>): Record<string, unknown> {
+  private async decryptConfig(config: Record<string, unknown>): Promise<Record<string, unknown>> {
     if (!config) return config;
 
     const decrypted: Record<string, unknown> = {};
@@ -484,12 +498,12 @@ export class IntegrationsService {
         // Preserve arrays as-is (e.g., evidenceTypes)
         safePropertySet(decrypted, key, value);
       } else if (typeof value === 'object' && value !== null) {
-        safePropertySet(decrypted, key, this.decryptConfig(value as Record<string, unknown>));
+        safePropertySet(decrypted, key, await this.decryptConfig(value as Record<string, unknown>));
       } else if (
         typeof value === 'string' &&
         SENSITIVE_FIELDS.some((f) => key.toLowerCase().includes(f.toLowerCase()))
       ) {
-        safePropertySet(decrypted, key, this.decrypt(value));
+        safePropertySet(decrypted, key, await this.decrypt(value));
       } else {
         safePropertySet(decrypted, key, value);
       }
@@ -742,7 +756,14 @@ export class IntegrationsService {
       entityId: existing.id,
       entityName: existing.name,
       description: `Deleted integration "${existing.name}" (${existing.type})`,
-      changes: { before: existing },
+      changes: {
+        before: {
+          name: existing.name,
+          type: existing.type,
+          status: existing.status,
+          syncFrequency: existing.syncFrequency,
+        },
+      },
     });
 
     return { success: true };
@@ -1559,9 +1580,9 @@ export class IntegrationsService {
         } else if (
           typeof value === 'string' &&
           SENSITIVE_FIELDS.some((f) => key.toLowerCase().includes(f.toLowerCase())) &&
-          this.isEncryptedFormat(value)
+          (this.isEncryptedFormat(value) || this.isInfisicalRef(value))
         ) {
-          // Mask any encrypted sensitive field even if not in configFields
+          // Mask any encrypted or Infisical-referenced sensitive field
           result[key] = '••••••••';
         } else if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
           result[key] = maskObject(value as Record<string, unknown>);

--- a/services/controls/src/integrations/integrations.service.ts
+++ b/services/controls/src/integrations/integrations.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, NotFoundException, BadRequestException, Logger, Inject } from '@nestjs/common';
 import * as crypto from 'crypto';
 import { PrismaService } from '../prisma/prisma.service';
-import { isSafePropertyName, safePropertySet } from '@gigachad-grc/shared';
+import { isSafePropertyName, safePropertySet, SecretsService } from '@gigachad-grc/shared';
 import { AuditService } from '../audit/audit.service';
 import { NotificationsService } from '../notifications/notifications.service';
 import { NotificationType, NotificationSeverity } from '../notifications/dto/notification.dto';
@@ -106,14 +106,134 @@ export class IntegrationsService {
     private prisma: PrismaService,
     private auditService: AuditService,
     private notificationsService: NotificationsService,
-    @Inject(STORAGE_PROVIDER) private storage: StorageProvider
+    @Inject(STORAGE_PROVIDER) private storage: StorageProvider,
+    private secretsService: SecretsService
   ) {
     this.connectorFactory = new ConnectorFactory();
     this.encryptionKey = this.validateEncryptionKey();
   }
+
+  /** Infisical secret path prefix for integration credentials */
+  private readonly INFISICAL_PREFIX = 'infisical://';
+
+  /**
+   * Generate an opaque Infisical secret name for an integration field
+   */
+  private infisicalSecretName(
+    organizationId: string,
+    integrationId: string,
+    fieldName: string
+  ): string {
+    return `int_${organizationId.slice(0, 8)}_${integrationId.slice(0, 8)}_${fieldName}`;
+  }
+
+  /**
+   * Infisical path for integration credentials
+   */
+  private infisicalSecretPath(organizationId: string): string {
+    return `/integrations/${organizationId}`;
+  }
+
+  /**
+   * Store a sensitive field in Infisical and return a reference string
+   */
+  private async storeInInfisical(
+    organizationId: string,
+    integrationId: string,
+    fieldName: string,
+    value: string
+  ): Promise<string> {
+    const secretName = this.infisicalSecretName(organizationId, integrationId, fieldName);
+    const secretPath = this.infisicalSecretPath(organizationId);
+    await this.secretsService.setSecret(secretName, value, secretPath);
+    return `${this.INFISICAL_PREFIX}${secretName}`;
+  }
+
+  /**
+   * Retrieve a sensitive field from Infisical by its reference string
+   */
+  private async fetchFromInfisical(
+    reference: string,
+    organizationId: string
+  ): Promise<string | undefined> {
+    const secretName = reference.replace(this.INFISICAL_PREFIX, '');
+    const secretPath = this.infisicalSecretPath(organizationId);
+    return this.secretsService.getSecret(secretName, secretPath);
+  }
+
+  /**
+   * Check if a value is an Infisical reference
+   */
+  private isInfisicalRef(value: unknown): value is string {
+    return typeof value === 'string' && value.startsWith(this.INFISICAL_PREFIX);
+  }
+
+  /**
+   * Clean up Infisical secrets for a deleted integration
+   */
+  private async cleanupInfisicalSecrets(
+    organizationId: string,
+    integrationId: string,
+    config: Record<string, unknown>
+  ): Promise<void> {
+    if (!this.secretsService.isEnabled()) return;
+
+    for (const [key, value] of Object.entries(config)) {
+      if (this.isInfisicalRef(value)) {
+        try {
+          const secretName = (value as string).replace(this.INFISICAL_PREFIX, '');
+          const secretPath = this.infisicalSecretPath(organizationId);
+          await this.secretsService.deleteSecret(secretName, secretPath);
+        } catch (error) {
+          this.logger.warn(`Failed to cleanup Infisical secret for ${key}: ${error}`);
+        }
+      } else if (typeof value === 'object' && value !== null) {
+        await this.cleanupInfisicalSecrets(
+          organizationId,
+          integrationId,
+          value as Record<string, unknown>
+        );
+      }
+    }
+  }
   // ============================================
   // Encryption/Decryption for Sensitive Data
   // ============================================
+
+  /**
+   * Check if a string value is already in our encrypted format (iv:authTag:salt:encrypted or legacy iv:authTag:encrypted).
+   * Used to prevent double-encryption when the frontend sends back encrypted values.
+   */
+  private isEncryptedFormat(value: string): boolean {
+    if (!value || typeof value !== 'string') return false;
+    const parts = value.split(':');
+    const hexPattern = /^[0-9a-f]+$/i;
+    if (parts.length === 4) {
+      // New format: iv(32 hex chars):authTag(32):salt(32):encrypted(hex)
+      return (
+        parts[0].length === 32 &&
+        parts[1].length === 32 &&
+        parts[2].length === 32 &&
+        parts[3].length > 0 &&
+        hexPattern.test(parts[0]) &&
+        hexPattern.test(parts[1]) &&
+        hexPattern.test(parts[2]) &&
+        hexPattern.test(parts[3])
+      );
+    }
+    if (parts.length === 3) {
+      // Legacy format: iv(32):authTag(32):encrypted(hex)
+      return (
+        parts[0].length === 32 &&
+        parts[1].length === 32 &&
+        parts[2].length > 0 &&
+        hexPattern.test(parts[0]) &&
+        hexPattern.test(parts[1]) &&
+        hexPattern.test(parts[2])
+      );
+    }
+    return false;
+  }
 
   private encrypt(text: string): string {
     if (!text) return text;
@@ -133,11 +253,15 @@ export class IntegrationsService {
     return `${iv.toString('hex')}:${authTag.toString('hex')}:${salt.toString('hex')}:${encrypted}`;
   }
 
-  private decrypt(encryptedText: string): string {
+  private decrypt(encryptedText: string, depth = 0): string {
     if (!encryptedText) return encryptedText;
+    // Guard against infinite recursion (max 3 layers should be more than enough)
+    if (depth > 3) return encryptedText;
 
     try {
       const parts = encryptedText.split(':');
+
+      let decrypted: string;
 
       // Support both old format (3 parts: iv:authTag:encrypted) and new format (4 parts: iv:authTag:salt:encrypted)
       if (parts.length === 3) {
@@ -150,10 +274,8 @@ export class IntegrationsService {
         const decipher = crypto.createDecipheriv(this.algorithm, key, iv);
         decipher.setAuthTag(authTag);
 
-        let decrypted = decipher.update(encrypted, 'hex', 'utf8');
+        decrypted = decipher.update(encrypted, 'hex', 'utf8');
         decrypted += decipher.final('utf8');
-
-        return decrypted;
       } else if (parts.length === 4) {
         // New format with random salt
         const [ivHex, authTagHex, saltHex, encrypted] = parts;
@@ -165,14 +287,22 @@ export class IntegrationsService {
         const decipher = crypto.createDecipheriv(this.algorithm, key, iv);
         decipher.setAuthTag(authTag);
 
-        let decrypted = decipher.update(encrypted, 'hex', 'utf8');
+        decrypted = decipher.update(encrypted, 'hex', 'utf8');
         decrypted += decipher.final('utf8');
-
-        return decrypted;
       } else {
         // Not encrypted or invalid format
         return encryptedText;
       }
+
+      // Handle double-encrypted values: if decrypted result is still in encrypted format,
+      // decrypt again. This can happen when the frontend sends back raw encrypted values
+      // that get re-encrypted on update.
+      if (this.isEncryptedFormat(decrypted)) {
+        this.logger.warn('Detected double-encrypted value, decrypting inner layer');
+        return this.decrypt(decrypted, depth + 1);
+      }
+
+      return decrypted;
     } catch {
       this.logger.warn('Failed to decrypt value, returning as-is');
       return encryptedText;
@@ -180,9 +310,15 @@ export class IntegrationsService {
   }
 
   /**
-   * Encrypt sensitive fields in config object before storing
+   * Encrypt sensitive fields in config object before storing.
+   * When Infisical is enabled, stores sensitive fields there and saves a reference.
+   * Falls back to local AES-256-GCM encryption otherwise.
    */
-  private encryptConfig(config: Record<string, unknown>): Record<string, unknown> {
+  private async encryptConfigAsync(
+    config: Record<string, unknown>,
+    organizationId: string,
+    integrationId: string
+  ): Promise<Record<string, unknown>> {
     if (!config) return config;
 
     const encrypted: Record<string, unknown> = {};
@@ -194,15 +330,45 @@ export class IntegrationsService {
         continue;
       }
 
-      if (typeof value === 'object' && value !== null) {
+      if (Array.isArray(value)) {
+        // Preserve arrays as-is (e.g., evidenceTypes)
+        safePropertySet(encrypted, key, value);
+      } else if (typeof value === 'object' && value !== null) {
         // Recursively encrypt nested objects
-        safePropertySet(encrypted, key, this.encryptConfig(value as Record<string, unknown>));
+        safePropertySet(
+          encrypted,
+          key,
+          await this.encryptConfigAsync(
+            value as Record<string, unknown>,
+            organizationId,
+            integrationId
+          )
+        );
       } else if (
         typeof value === 'string' &&
         SENSITIVE_FIELDS.some((f) => key.toLowerCase().includes(f.toLowerCase()))
       ) {
-        // Encrypt sensitive string fields
-        safePropertySet(encrypted, key, this.encrypt(value));
+        // Skip already-encrypted values to prevent double encryption
+        // (can happen when frontend sends back raw encrypted values on update)
+        if (this.isEncryptedFormat(value)) {
+          safePropertySet(encrypted, key, value);
+        } else if (this.isInfisicalRef(value)) {
+          // Preserve existing Infisical references
+          safePropertySet(encrypted, key, value);
+        } else if (this.secretsService.isEnabled()) {
+          // Store in Infisical if available, otherwise encrypt locally
+          try {
+            const ref = await this.storeInInfisical(organizationId, integrationId, key, value);
+            safePropertySet(encrypted, key, ref);
+          } catch (error) {
+            this.logger.warn(
+              `Failed to store ${key} in Infisical, falling back to local encryption: ${error}`
+            );
+            safePropertySet(encrypted, key, this.encrypt(value));
+          }
+        } else {
+          safePropertySet(encrypted, key, this.encrypt(value));
+        }
       } else {
         safePropertySet(encrypted, key, value);
       }
@@ -212,9 +378,50 @@ export class IntegrationsService {
   }
 
   /**
-   * Decrypt sensitive fields in config object for internal use
+   * Synchronous encrypt for backward compatibility (no Infisical).
    */
-  private decryptConfig(config: Record<string, unknown>): Record<string, unknown> {
+  private encryptConfig(config: Record<string, unknown>): Record<string, unknown> {
+    if (!config) return config;
+
+    const encrypted: Record<string, unknown> = {};
+
+    for (const [key, value] of Object.entries(config)) {
+      if (!isSafePropertyName(key)) {
+        this.logger.warn(`Skipping blocked property name in encryptConfig: ${key}`);
+        continue;
+      }
+
+      if (Array.isArray(value)) {
+        // Preserve arrays as-is (e.g., evidenceTypes)
+        safePropertySet(encrypted, key, value);
+      } else if (typeof value === 'object' && value !== null) {
+        safePropertySet(encrypted, key, this.encryptConfig(value as Record<string, unknown>));
+      } else if (
+        typeof value === 'string' &&
+        SENSITIVE_FIELDS.some((f) => key.toLowerCase().includes(f.toLowerCase()))
+      ) {
+        // Skip already-encrypted values to prevent double encryption
+        if (this.isEncryptedFormat(value)) {
+          safePropertySet(encrypted, key, value);
+        } else {
+          safePropertySet(encrypted, key, this.encrypt(value));
+        }
+      } else {
+        safePropertySet(encrypted, key, value);
+      }
+    }
+
+    return encrypted;
+  }
+
+  /**
+   * Decrypt sensitive fields in config object for internal use.
+   * Supports both Infisical references (infisical://...) and local encrypted values.
+   */
+  private async decryptConfigAsync(
+    config: Record<string, unknown>,
+    organizationId: string
+  ): Promise<Record<string, unknown>> {
     if (!config) return config;
 
     const decrypted: Record<string, unknown> = {};
@@ -226,14 +433,62 @@ export class IntegrationsService {
         continue;
       }
 
-      if (typeof value === 'object' && value !== null) {
+      if (Array.isArray(value)) {
+        // Preserve arrays as-is (e.g., evidenceTypes)
+        safePropertySet(decrypted, key, value);
+      } else if (typeof value === 'object' && value !== null) {
         // Recursively decrypt nested objects
+        safePropertySet(
+          decrypted,
+          key,
+          await this.decryptConfigAsync(value as Record<string, unknown>, organizationId)
+        );
+      } else if (this.isInfisicalRef(value)) {
+        // Fetch from Infisical
+        try {
+          const fetched = await this.fetchFromInfisical(value, organizationId);
+          safePropertySet(decrypted, key, fetched || value);
+        } catch (error) {
+          this.logger.warn(`Failed to fetch ${key} from Infisical: ${error}`);
+          safePropertySet(decrypted, key, value);
+        }
+      } else if (
+        typeof value === 'string' &&
+        SENSITIVE_FIELDS.some((f) => key.toLowerCase().includes(f.toLowerCase()))
+      ) {
+        // Decrypt locally (legacy or fallback)
+        safePropertySet(decrypted, key, this.decrypt(value));
+      } else {
+        safePropertySet(decrypted, key, value);
+      }
+    }
+
+    return decrypted;
+  }
+
+  /**
+   * Synchronous decrypt for backward compatibility (no Infisical refs).
+   */
+  private decryptConfig(config: Record<string, unknown>): Record<string, unknown> {
+    if (!config) return config;
+
+    const decrypted: Record<string, unknown> = {};
+
+    for (const [key, value] of Object.entries(config)) {
+      if (!isSafePropertyName(key)) {
+        this.logger.warn(`Skipping blocked property name in decryptConfig: ${key}`);
+        continue;
+      }
+
+      if (Array.isArray(value)) {
+        // Preserve arrays as-is (e.g., evidenceTypes)
+        safePropertySet(decrypted, key, value);
+      } else if (typeof value === 'object' && value !== null) {
         safePropertySet(decrypted, key, this.decryptConfig(value as Record<string, unknown>));
       } else if (
         typeof value === 'string' &&
         SENSITIVE_FIELDS.some((f) => key.toLowerCase().includes(f.toLowerCase()))
       ) {
-        // Decrypt sensitive string fields
         safePropertySet(decrypted, key, this.decrypt(value));
       } else {
         safePropertySet(decrypted, key, value);
@@ -335,8 +590,13 @@ export class IntegrationsService {
       throw new BadRequestException(`Invalid integration type: ${dto.type}`);
     }
 
-    // Encrypt sensitive fields in config before storing
-    const encryptedConfig = dto.config ? this.encryptConfig(dto.config) : {};
+    // Generate a temporary ID for Infisical path (will be replaced with actual ID)
+    const tempId = crypto.randomUUID();
+
+    // Encrypt sensitive fields in config before storing (uses Infisical when available)
+    const encryptedConfig = dto.config
+      ? await this.encryptConfigAsync(dto.config, organizationId, tempId)
+      : {};
 
     const integration = await this.prisma.integration.create({
       data: {
@@ -391,8 +651,8 @@ export class IntegrationsService {
     // Merge config if provided (don't overwrite entire config)
     let newConfig = existing.config as Record<string, unknown>;
     if (dto.config) {
-      // Encrypt sensitive fields in the new config before merging
-      const encryptedNewConfig = this.encryptConfig(dto.config);
+      // Encrypt sensitive fields in the new config before merging (uses Infisical when available)
+      const encryptedNewConfig = await this.encryptConfigAsync(dto.config, organizationId, id);
       newConfig = { ...newConfig, ...encryptedNewConfig };
     }
 
@@ -458,6 +718,15 @@ export class IntegrationsService {
       throw new NotFoundException('Integration not found');
     }
 
+    // Clean up Infisical secrets for this integration
+    if (existing.config && this.secretsService.isEnabled()) {
+      await this.cleanupInfisicalSecrets(
+        organizationId,
+        id,
+        existing.config as Record<string, unknown>
+      );
+    }
+
     await this.prisma.integration.delete({
       where: { id },
     });
@@ -494,8 +763,26 @@ export class IntegrationsService {
       throw new NotFoundException('Integration not found');
     }
 
-    // Decrypt config for use in connection testing
-    const config = this.decryptConfig(integration.config as Record<string, unknown>);
+    // Decrypt config for use in connection testing (supports Infisical refs)
+    const rawConfig = await this.decryptConfigAsync(
+      integration.config as Record<string, unknown>,
+      organizationId
+    );
+
+    // Flatten credentials into top-level config so connectors can access fields
+    // directly (quick setup stores them under config.credentials)
+    const credentials = rawConfig.credentials as Record<string, unknown> | undefined;
+    const flattened = credentials
+      ? { ...rawConfig, ...credentials }
+      : { ...rawConfig };
+
+    // Map common field aliases (quick setup may use different names than configFields)
+    if (flattened.baseUrl && !flattened.siteUrl) {
+      flattened.siteUrl = flattened.baseUrl;
+    }
+
+    const config = flattened;
+
     const typeMeta = INTEGRATION_TYPES[integration.type as keyof typeof INTEGRATION_TYPES];
 
     if (!typeMeta) {
@@ -574,8 +861,11 @@ export class IntegrationsService {
       );
     }
 
-    // Decrypt config for use in sync operations
-    const config = this.decryptConfig(integration.config as Record<string, unknown>);
+    // Decrypt config for use in sync operations (supports Infisical refs)
+    const config = await this.decryptConfigAsync(
+      integration.config as Record<string, unknown>,
+      organizationId
+    );
 
     // Create a sync job
     const syncJob = await this.prisma.syncJob.create({
@@ -1252,14 +1542,34 @@ export class IntegrationsService {
     const typeMeta = INTEGRATION_TYPES[type as keyof typeof INTEGRATION_TYPES];
     if (!typeMeta) return config;
 
-    const masked = { ...config };
-    for (const field of typeMeta.configFields) {
-      if (field.type === 'password' && masked[field.key]) {
-        // Show only last 4 characters
-        const value = String(masked[field.key]);
-        masked[field.key] = value.length > 4 ? '••••••••' + value.slice(-4) : '••••••••';
+    const passwordFieldKeys = new Set(
+      typeMeta.configFields.filter((f) => f.type === 'password').map((f) => f.key)
+    );
+
+    const maskValue = (val: unknown): string => {
+      const str = String(val);
+      return str.length > 4 ? '••••••••' + str.slice(-4) : '••••••••';
+    };
+
+    const maskObject = (obj: Record<string, unknown>): Record<string, unknown> => {
+      const result = { ...obj };
+      for (const [key, value] of Object.entries(result)) {
+        if (passwordFieldKeys.has(key) && value) {
+          result[key] = maskValue(value);
+        } else if (
+          typeof value === 'string' &&
+          SENSITIVE_FIELDS.some((f) => key.toLowerCase().includes(f.toLowerCase())) &&
+          this.isEncryptedFormat(value)
+        ) {
+          // Mask any encrypted sensitive field even if not in configFields
+          result[key] = '••••••••';
+        } else if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+          result[key] = maskObject(value as Record<string, unknown>);
+        }
       }
-    }
-    return masked;
+      return result;
+    };
+
+    return maskObject(config);
   }
 }

--- a/services/frameworks/src/auth/auth.module.ts
+++ b/services/frameworks/src/auth/auth.module.ts
@@ -1,0 +1,19 @@
+import { Global, Module } from '@nestjs/common';
+import { DevAuthGuard, RolesGuard, PermissionsGuard, PRISMA_SERVICE } from '@gigachad-grc/shared';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Global()
+@Module({
+  providers: [
+    PrismaService,
+    {
+      provide: PRISMA_SERVICE,
+      useExisting: PrismaService,
+    },
+    DevAuthGuard,
+    RolesGuard,
+    PermissionsGuard,
+  ],
+  exports: [PrismaService, PRISMA_SERVICE, DevAuthGuard, RolesGuard, PermissionsGuard],
+})
+export class AuthModule {}

--- a/services/policies/src/auth/auth.module.ts
+++ b/services/policies/src/auth/auth.module.ts
@@ -1,0 +1,19 @@
+import { Global, Module } from '@nestjs/common';
+import { DevAuthGuard, RolesGuard, PermissionsGuard, PRISMA_SERVICE } from '@gigachad-grc/shared';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Global()
+@Module({
+  providers: [
+    PrismaService,
+    {
+      provide: PRISMA_SERVICE,
+      useExisting: PrismaService,
+    },
+    DevAuthGuard,
+    RolesGuard,
+    PermissionsGuard,
+  ],
+  exports: [PrismaService, PRISMA_SERVICE, DevAuthGuard, RolesGuard, PermissionsGuard],
+})
+export class AuthModule {}

--- a/services/shared/package.json
+++ b/services/shared/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.985.0",
+    "@infisical/sdk": "^4.0.6",
     "@aws-sdk/s3-request-presigner": "^3.450.0",
     "@azure/storage-blob": "^12.17.0",
     "@nestjs/throttler": "^6.5.0",

--- a/services/shared/src/index.ts
+++ b/services/shared/src/index.ts
@@ -172,3 +172,6 @@ export * from './session';
 
 // Security (Rate Limiting and SSRF protection)
 export * from './security';
+
+// Secrets (Infisical integration)
+export * from './secrets';

--- a/services/shared/src/secrets/index.ts
+++ b/services/shared/src/secrets/index.ts
@@ -1,0 +1,2 @@
+export { SecretsModule } from './secrets.module';
+export { SecretsService, SECRETS_PROVIDER } from './secrets.service';

--- a/services/shared/src/secrets/secrets.module.ts
+++ b/services/shared/src/secrets/secrets.module.ts
@@ -1,0 +1,23 @@
+import { Module, DynamicModule, Global } from '@nestjs/common';
+import { SecretsService, SecretsConfig, SECRETS_PROVIDER } from './secrets.service';
+
+@Global()
+@Module({})
+export class SecretsModule {
+  static forRoot(config?: SecretsConfig): DynamicModule {
+    return {
+      module: SecretsModule,
+      providers: [
+        {
+          provide: SECRETS_PROVIDER,
+          useFactory: () => new SecretsService(config),
+        },
+        {
+          provide: SecretsService,
+          useExisting: SECRETS_PROVIDER,
+        },
+      ],
+      exports: [SECRETS_PROVIDER, SecretsService],
+    };
+  }
+}

--- a/services/shared/src/secrets/secrets.service.ts
+++ b/services/shared/src/secrets/secrets.service.ts
@@ -1,0 +1,233 @@
+import { Injectable, Logger, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
+
+export const SECRETS_PROVIDER = 'SECRETS_PROVIDER';
+
+export interface SecretsConfig {
+  /** Infisical site URL (e.g., http://localhost:8443) */
+  siteUrl?: string;
+  /** Machine Identity Client ID */
+  clientId?: string;
+  /** Machine Identity Client Secret */
+  clientSecret?: string;
+  /** Infisical project ID (workspace) */
+  projectId?: string;
+  /** Environment slug (dev, staging, production) */
+  environment?: string;
+  /** Secret path prefix (default: /) */
+  secretPath?: string;
+  /** Cache TTL in seconds (default: 300) */
+  cacheTtlSeconds?: number;
+}
+
+interface CacheEntry {
+  value: string;
+  expiresAt: number;
+}
+
+@Injectable()
+export class SecretsService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(SecretsService.name);
+  private readonly cache = new Map<string, CacheEntry>();
+  private readonly cacheTtl: number;
+  private readonly config: SecretsConfig;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private client: any = null;
+  private enabled = false;
+
+  constructor(config?: SecretsConfig) {
+    this.config = config || this.getConfigFromEnv();
+    this.cacheTtl = (this.config.cacheTtlSeconds ?? 300) * 1000;
+  }
+
+  private getConfigFromEnv(): SecretsConfig {
+    return {
+      siteUrl: process.env.INFISICAL_SITE_URL || process.env.INFISICAL_URL,
+      clientId: process.env.INFISICAL_CLIENT_ID,
+      clientSecret: process.env.INFISICAL_CLIENT_SECRET,
+      projectId: process.env.INFISICAL_PROJECT_ID,
+      environment: process.env.INFISICAL_ENVIRONMENT || 'dev',
+      secretPath: process.env.INFISICAL_SECRET_PATH || '/',
+      cacheTtlSeconds: parseInt(process.env.INFISICAL_CACHE_TTL || '300', 10),
+    };
+  }
+
+  async onModuleInit(): Promise<void> {
+    if (!this.config.siteUrl || !this.config.clientId || !this.config.clientSecret) {
+      this.logger.log(
+        'Infisical not configured (missing INFISICAL_SITE_URL, INFISICAL_CLIENT_ID, or INFISICAL_CLIENT_SECRET). Falling back to process.env.'
+      );
+      return;
+    }
+
+    try {
+      const { InfisicalSDK } = await import('@infisical/sdk');
+      this.client = new InfisicalSDK({
+        siteUrl: this.config.siteUrl,
+      });
+      await this.client.auth().universalAuth.login({
+        clientId: this.config.clientId,
+        clientSecret: this.config.clientSecret,
+      });
+      this.enabled = true;
+      this.logger.log('Infisical SDK connected successfully');
+    } catch (error) {
+      this.logger.warn(
+        `Failed to initialize Infisical SDK: ${error instanceof Error ? error.message : error}. Falling back to process.env.`
+      );
+    }
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    this.cache.clear();
+  }
+
+  /**
+   * Get a secret by name. Falls back to process.env if Infisical is not configured.
+   */
+  async getSecret(name: string, path?: string): Promise<string | undefined> {
+    // Check cache first
+    const cacheKey = `${path || this.config.secretPath}:${name}`;
+    const cached = this.cache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.value;
+    }
+
+    if (this.enabled && this.client && this.config.projectId) {
+      try {
+        const secret = await this.client.secrets().getSecret({
+          environment: this.config.environment || 'dev',
+          projectId: this.config.projectId,
+          secretName: name,
+          secretPath: path || this.config.secretPath || '/',
+        });
+
+        const value = secret.secretValue;
+        if (value !== undefined) {
+          this.cache.set(cacheKey, {
+            value,
+            expiresAt: Date.now() + this.cacheTtl,
+          });
+        }
+        return value;
+      } catch (error) {
+        this.logger.warn(
+          `Failed to fetch secret "${name}" from Infisical: ${error instanceof Error ? error.message : error}. Falling back to process.env.`
+        );
+      }
+    }
+
+    // Fallback to process.env
+    return process.env[name];
+  }
+
+  /**
+   * List secrets at a given path. Falls back to empty array if not configured.
+   */
+  async listSecrets(
+    path?: string
+  ): Promise<Array<{ key: string; value: string }>> {
+    if (this.enabled && this.client && this.config.projectId) {
+      try {
+        const result = await this.client.secrets().listSecrets({
+          environment: this.config.environment || 'dev',
+          projectId: this.config.projectId,
+          secretPath: path || this.config.secretPath || '/',
+        });
+        const secrets = result?.secrets || result || [];
+        return (Array.isArray(secrets) ? secrets : []).map(
+          (s: { secretKey: string; secretValue: string }) => ({
+            key: s.secretKey,
+            value: s.secretValue,
+          })
+        );
+      } catch (error) {
+        this.logger.warn(
+          `Failed to list secrets from Infisical: ${error instanceof Error ? error.message : error}`
+        );
+      }
+    }
+    return [];
+  }
+
+  /**
+   * Create or update a secret. No-op if Infisical is not configured.
+   */
+  async setSecret(name: string, value: string, path?: string): Promise<void> {
+    if (!this.enabled || !this.client || !this.config.projectId) {
+      this.logger.warn(
+        `Cannot set secret "${name}": Infisical is not configured`
+      );
+      return;
+    }
+
+    try {
+      await this.client.secrets().createSecret(name, {
+        environment: this.config.environment || 'dev',
+        projectId: this.config.projectId,
+        secretValue: value,
+        secretPath: path || this.config.secretPath || '/',
+      });
+
+      // Update cache
+      const cacheKey = `${path || this.config.secretPath}:${name}`;
+      this.cache.set(cacheKey, {
+        value,
+        expiresAt: Date.now() + this.cacheTtl,
+      });
+    } catch {
+      // If create fails (already exists), try update
+      try {
+        await this.client.secrets().updateSecret(name, {
+          environment: this.config.environment || 'dev',
+          projectId: this.config.projectId,
+          secretValue: value,
+          secretPath: path || this.config.secretPath || '/',
+        });
+
+        const cacheKey = `${path || this.config.secretPath}:${name}`;
+        this.cache.set(cacheKey, {
+          value,
+          expiresAt: Date.now() + this.cacheTtl,
+        });
+      } catch (error) {
+        this.logger.error(
+          `Failed to set secret "${name}" in Infisical: ${error instanceof Error ? error.message : error}`
+        );
+        throw error;
+      }
+    }
+  }
+
+  /**
+   * Delete a secret. No-op if Infisical is not configured.
+   */
+  async deleteSecret(name: string, path?: string): Promise<void> {
+    if (!this.enabled || !this.client || !this.config.projectId) {
+      return;
+    }
+
+    try {
+      await this.client.secrets().deleteSecret(name, {
+        environment: this.config.environment || 'dev',
+        projectId: this.config.projectId,
+        secretPath: path || this.config.secretPath || '/',
+      });
+
+      // Remove from cache
+      const cacheKey = `${path || this.config.secretPath}:${name}`;
+      this.cache.delete(cacheKey);
+    } catch (error) {
+      this.logger.error(
+        `Failed to delete secret "${name}" from Infisical: ${error instanceof Error ? error.message : error}`
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Check if Infisical SDK is connected and active.
+   */
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+}

--- a/services/trust/src/auth/auth.module.ts
+++ b/services/trust/src/auth/auth.module.ts
@@ -1,0 +1,19 @@
+import { Global, Module } from '@nestjs/common';
+import { DevAuthGuard, RolesGuard, PermissionsGuard, PRISMA_SERVICE } from '@gigachad-grc/shared';
+import { PrismaService } from '../common/prisma.service';
+
+@Global()
+@Module({
+  providers: [
+    PrismaService,
+    {
+      provide: PRISMA_SERVICE,
+      useExisting: PrismaService,
+    },
+    DevAuthGuard,
+    RolesGuard,
+    PermissionsGuard,
+  ],
+  exports: [PrismaService, PRISMA_SERVICE, DevAuthGuard, RolesGuard, PermissionsGuard],
+})
+export class AuthModule {}

--- a/start.sh
+++ b/start.sh
@@ -62,6 +62,20 @@ setup_env() {
     # Check if .env exists
     if [ -f ".env" ]; then
         echo -e "${GREEN}✓${NC} Using existing .env file"
+        # Migrate: append Infisical bootstrap secrets if missing from older .env
+        if ! grep -q '^INFISICAL_ENCRYPTION_KEY=' ".env" 2>/dev/null; then
+            echo -e "${YELLOW}⚠${NC} Adding missing Infisical secrets to existing .env..."
+            local INF_ENC_KEY INF_AUTH_SEC
+            INF_ENC_KEY=$(openssl rand -hex 16 2>/dev/null || head -c 16 /dev/urandom | xxd -p | tr -d '\n')
+            INF_AUTH_SEC=$(openssl rand -base64 32 2>/dev/null | tr -d '\n' || head -c 32 /dev/urandom | base64 | tr -d '\n')
+            cat >> ".env" << INFISICAL_EOF
+
+# Infisical Secrets Manager (auto-added)
+INFISICAL_ENCRYPTION_KEY=${INF_ENC_KEY}
+INFISICAL_AUTH_SECRET=${INF_AUTH_SEC}
+INFISICAL_EOF
+            echo -e "${GREEN}✓${NC} Infisical bootstrap secrets added to .env"
+        fi
         return 0
     fi
 
@@ -75,6 +89,8 @@ setup_env() {
     REDIS_PASSWORD=$(openssl rand -base64 24 2>/dev/null | tr -d '\n' | tr '+/' '-_' || head -c 24 /dev/urandom | base64 | tr '+/' '-_')
     MINIO_PASSWORD=$(openssl rand -base64 20 2>/dev/null | tr -d '\n' | tr '+/' '-_' || head -c 20 /dev/urandom | base64 | tr '+/' '-_')
     GRAFANA_PASSWORD=$(openssl rand -base64 32 2>/dev/null | tr -d '\n' | tr '+/' '-_' || head -c 32 /dev/urandom | base64 | tr '+/' '-_')
+    INFISICAL_ENCRYPTION_KEY=$(openssl rand -hex 16 2>/dev/null || head -c 16 /dev/urandom | xxd -p | tr -d '\n')
+    INFISICAL_AUTH_SECRET=$(openssl rand -base64 32 2>/dev/null | tr -d '\n' || head -c 32 /dev/urandom | base64 | tr -d '\n')
 
     cat > ".env" << EOF
 # ============================================================================
@@ -126,6 +142,10 @@ RATE_LIMIT_MAX_REQUESTS=1000
 # Logging
 LOG_LEVEL=debug
 
+# Infisical Secrets Manager
+INFISICAL_ENCRYPTION_KEY=${INFISICAL_ENCRYPTION_KEY}
+INFISICAL_AUTH_SECRET=${INFISICAL_AUTH_SECRET}
+
 # Frontend
 VITE_API_URL=http://localhost:3001
 VITE_ENABLE_DEV_AUTH=true
@@ -161,6 +181,7 @@ start_services() {
     echo -e "   ${CYAN}Frontend${NC}        http://localhost:3000"
     echo -e "   ${CYAN}API Docs${NC}        http://localhost:3001/api/docs"
     echo -e "   ${CYAN}Keycloak${NC}        http://localhost:8080 (admin/admin)"
+    echo -e "   ${CYAN}Secrets (Infisical)${NC} http://localhost:8443"
     echo -e "   ${CYAN}Grafana${NC}         http://localhost:3003 (admin/admin)"
     echo ""
     echo -e "${BOLD}How to Login:${NC}"
@@ -175,6 +196,20 @@ start_services() {
     echo -e "   ${CYAN}./start.sh logs${NC}    View logs"
     echo -e "   ${CYAN}./start.sh status${NC}  Check service status"
     echo ""
+
+    # Wait for Infisical to be ready (first-time setup)
+    if [ ! -f ".infisical-initialized" ]; then
+        echo -e "${BLUE}Waiting for Infisical secrets manager...${NC}"
+        for i in $(seq 1 30); do
+            if curl -sf http://localhost:8443/api/status > /dev/null 2>&1; then
+                echo -e "${GREEN}✓${NC} Infisical is ready"
+                echo -e "${YELLOW}→ Visit http://localhost:8443 to create your admin account and set up secrets${NC}"
+                touch .infisical-initialized
+                break
+            fi
+            sleep 2
+        done
+    fi
 
     # Open browser on macOS
     if [[ "$OSTYPE" == "darwin"* ]]; then
@@ -221,6 +256,7 @@ reset_all() {
             echo -e "${YELLOW}Removing .env file...${NC}"
             rm -f .env
         fi
+        rm -f .infisical-initialized
         
         echo -e "${GREEN}✓ Reset complete${NC}"
         echo ""


### PR DESCRIPTION
## Summary

> Depends on #140 — merge #140 first, then this PR.

Fixes 4 verified security issues found during review of #140:

### 1. SSRF: DNS rebinding / dotless-domain bypass (Critical)
Added custom `dns.lookup` callback on HTTP agents (`ssrfSafeLookup`) that validates resolved IPs at **connection time** against the same blocklists. This prevents:
- DNS rebinding (attacker domain with A record pointing to `127.0.0.1`)
- Dotless internal domains resolving to private IPs (e.g., `http://internal.corp/` → `10.0.0.1`)
- Services like `nip.io` / `sslip.io` (e.g., `10.0.0.1.nip.io`)

### 2. SSRF: Redirect-based bypass (Critical)
Set `maxRedirects: 0` on all axios instances (constructor, `createClient`). Previously axios followed up to 5 redirects by default, allowing `http://evil.com/redirect` → `302 http://127.0.0.1/admin` to bypass URL validation.

### 3. SSRF: IPv6 bypass — no range checks (High)
Added full IPv6 blocklist logic:
- `::1` (loopback)
- `::` (unspecified)
- `::ffff:x.x.x.x` (IPv6-mapped IPv4 — extracts and validates embedded IPv4)
- `fc00::/7` (Unique Local Address, includes `fd00::/8`)
- `fe80::/10` (link-local)

### 4. Shell: `AUTH_TOKEN` sends empty bearer token (Medium)
The pattern `AUTH_TOKEN="$TOKEN" curl -H "Authorization: Bearer $AUTH_TOKEN"` is broken — the inline env var sets `AUTH_TOKEN` for curl's child process, but `$AUTH_TOKEN` is expanded by the **parent shell** (where it's unset → empty string). All Infisical API requests were sending `Authorization: Bearer ` with no token.

Fixed by using `curl --config <(printf ...)` with process substitution, which also keeps the token out of `/proc/pid/cmdline`.

## Design decisions

- **Agent-level DNS validation** instead of making `createClient`/`setBaseURL` async — no signature changes, no updates needed for the 11 connector files that call `setBaseURL`, and more robust (validates at socket time, not parse time)
- Shared singleton agents (`ssrfSafeHttpAgent`, `ssrfSafeHttpsAgent`) to avoid creating new agents per request

## Test plan
- [ ] SSRF: `http://[::ffff:127.0.0.1]/` blocked (IPv6-mapped IPv4)
- [ ] SSRF: `http://[fd00::1]/` blocked (IPv6 ULA)
- [ ] SSRF: Domain resolving to `127.0.0.1` blocked at connection time
- [ ] SSRF: 302 redirect to internal IP does not follow (maxRedirects: 0)
- [ ] Shell: `seed-infisical.sh` sends valid Authorization header with token
- [ ] Shell: Token not visible in `ps aux` output
- [ ] Existing connectors still work (setBaseURL signature unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)