### PR TITLE
fix(security): remediate CVE-2026-26278, CVE-2026-26960, CVE-2025-69873

### DIFF
--- a/mcp-servers/grc-evidence/package-lock.json
+++ b/mcp-servers/grc-evidence/package-lock.json
@@ -3969,9 +3969,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.4.tgz",
-      "integrity": "sha512-EFd6afGmXlCx8H8WTZHhAoDaWaGyuIBoZJ2mknrNxug+aZKjkp0a0dlars9Izl+jF+7Gu1/5f/2h68cQpe0IiA==",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz",
+      "integrity": "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==",
       "funding": [
         {
           "type": "github",
@@ -3980,7 +3980,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^2.1.0"
+        "strnum": "^2.1.2"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -5484,9 +5484,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
-      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
+      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
       "funding": [
         {
           "type": "github",

--- a/mcp-servers/grc-evidence/package.json
+++ b/mcp-servers/grc-evidence/package.json
@@ -33,10 +33,6 @@
     "tsx": "^4.0.0"
   },
   "overrides": {
-    "fast-xml-parser": "^5.3.4"
+    "fast-xml-parser": "^5.3.6"
   }
 }
-
-
-
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -5123,6 +5123,24 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/xml-builder/node_modules/fast-xml-parser": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/@aws/lambda-invoke-store": {
       "version": "0.2.3",
       "license": "Apache-2.0",
@@ -6028,26 +6046,6 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/ajv": {
-      "version": "6.12.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@eslint/js": {
       "version": "9.39.2",
@@ -10799,7 +10797,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13343,21 +13343,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/ajv": {
-      "version": "6.12.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "4.2.1",
       "dev": true,
@@ -13368,11 +13353,6 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
-    },
-    "node_modules/eslint/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/espree": {
       "version": "10.4.0",
@@ -13714,7 +13694,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.3.4",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz",
+      "integrity": "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==",
       "funding": [
         {
           "type": "github",
@@ -14029,6 +14011,7 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "minipass": "^7.1.2",
     "@isaacs/brace-expansion": "^5.0.0",
     "lodash": "^4.17.23",
-    "fast-xml-parser": "^5.3.4"
+    "fast-xml-parser": "^5.3.6",
+    "ajv": "^8.18.0"
   }
 }

--- a/services/audit/Dockerfile
+++ b/services/audit/Dockerfile
@@ -42,9 +42,9 @@ RUN npm run build
 # Production stage - Using Docker Hardened Image
 FROM node:20-alpine AS production
 
-# Install OpenSSL for Prisma
+# Install OpenSSL for Prisma and patch npm's bundled tar (CVE-2026-26960)
 USER root
-RUN apk add --no-cache openssl || true
+RUN apk add --no-cache openssl && npm update -g npm
 
 WORKDIR /app
 

--- a/services/controls/Dockerfile
+++ b/services/controls/Dockerfile
@@ -54,8 +54,8 @@ RUN npm run build
 # Production stage
 FROM node:20-alpine AS production
 
-# Install OpenSSL for Prisma
-RUN apk add --no-cache openssl
+# Install OpenSSL for Prisma and patch npm's bundled tar (CVE-2026-26960)
+RUN apk add --no-cache openssl && npm update -g npm
 
 WORKDIR /app
 

--- a/services/frameworks/Dockerfile
+++ b/services/frameworks/Dockerfile
@@ -42,8 +42,8 @@ RUN npm run build
 # Production stage
 FROM node:20-alpine AS production
 
-# Install OpenSSL for Prisma
-RUN apk add --no-cache openssl
+# Install OpenSSL for Prisma and patch npm's bundled tar (CVE-2026-26960)
+RUN apk add --no-cache openssl && npm update -g npm
 
 WORKDIR /app
 

--- a/services/policies/Dockerfile
+++ b/services/policies/Dockerfile
@@ -42,9 +42,9 @@ RUN npm run build
 # Production stage - Using Docker Hardened Image
 FROM node:20-alpine AS production
 
-# Install OpenSSL for Prisma
+# Install OpenSSL for Prisma and patch npm's bundled tar (CVE-2026-26960)
 USER root
-RUN apk add --no-cache openssl || true
+RUN apk add --no-cache openssl && npm update -g npm
 
 WORKDIR /app
 

--- a/services/tprm/Dockerfile
+++ b/services/tprm/Dockerfile
@@ -42,9 +42,9 @@ RUN npm run build
 # Production stage - Using Docker Hardened Image
 FROM node:20-alpine AS production
 
-# Install OpenSSL for Prisma
+# Install OpenSSL for Prisma and patch npm's bundled tar (CVE-2026-26960)
 USER root
-RUN apk add --no-cache openssl || true
+RUN apk add --no-cache openssl && npm update -g npm
 
 WORKDIR /app
 

--- a/services/trust/Dockerfile
+++ b/services/trust/Dockerfile
@@ -42,9 +42,9 @@ RUN npm run build
 # Production stage - Using Docker Hardened Image
 FROM node:20-alpine AS production
 
-# Install OpenSSL for Prisma
+# Install OpenSSL for Prisma and patch npm's bundled tar (CVE-2026-26960)
 USER root
-RUN apk add --no-cache openssl || true
+RUN apk add --no-cache openssl && npm update -g npm
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Bump fast-xml-parser override from ^5.3.4 to ^5.3.6 (CVE-2026-26278: DoS via DOCTYPE entity expansion)
- Add ajv ^8.18.0 override to root package.json (CVE-2025-69873: ReDoS via $data reference)
- Regenerate lockfiles to resolve patched dependency versions
- Update all backend service Dockerfiles to patch npm's bundled tar in production images (CVE-2026-26960: arbitrary file read/write via symlink chain in node-tar)

## Test plan
- [ ] Verify fast-xml-parser resolves to >=5.3.6 in lockfiles
- [ ] Verify ajv resolves to >=8.18.0 in root lockfile
- [ ] Verify Docker builds succeed with npm update step
- [ ] Verify dependabot alerts #69, #70, #75 auto-close
- [ ] Verify code scanning alerts #233-238 auto-close on next container scan