### PR TITLE
fix(security): add axios override to force 1.13.5 resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -116,17 +116,6 @@
         "node": ">=18"
       }
     },
-    "frontend/node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "frontend/node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -11134,7 +11123,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.4",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -22425,17 +22416,6 @@
         "undici-types": "~6.21.0"
       }
     },
-    "services/audit/node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "services/controls": {
       "name": "@gigachad-grc/controls",
       "version": "1.0.0",
@@ -22509,17 +22489,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
-      }
-    },
-    "services/controls/node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "services/controls/node_modules/date-fns": {
@@ -23468,17 +23437,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
-      }
-    },
-    "services/trust/node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@isaacs/brace-expansion": "^5.0.0",
     "lodash": "^4.17.23",
     "fast-xml-parser": "^5.3.6",
-    "ajv": "^8.18.0"
+    "ajv": "^8.18.0",
+    "axios": "^1.13.5"
   }
 }


### PR DESCRIPTION
## Summary
- Add axios ^1.13.5 to root package.json overrides to force lockfile resolution past 1.13.4
- The lockfile was pinned to 1.13.4 (vulnerable to __proto__ DoS) despite package.json specs already at ^1.13.5

## Test plan
- [x] Verify axios resolves to 1.13.5 in lockfile
- [ ] Verify dependabot alert #75 auto-closes

Made with [Cursor](https://cursor.com)