### PR TITLE
fix(deps): add rollup and @smithy/config-resolver security overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "html2canvas": "^1.4.1",
         "jspdf": "^4.2.0",
         "keycloak-js": "^25.0.0",
-        "lucide-react": "^0.564.0",
+        "lucide-react": "^0.575.0",
         "mammoth": "^1.11.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -14786,6 +14786,7 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -17666,9 +17667,9 @@
       "license": "ISC"
     },
     "node_modules/lucide-react": {
-      "version": "0.564.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.564.0.tgz",
-      "integrity": "sha512-JJ8GVTQqFwuliifD48U6+h7DXEHdkhJ/E87kksGByII3qHxtPciVb8T8woQONHBQgHVOl7rSMrrip3SeVNy7Fg==",
+      "version": "0.575.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.575.0.tgz",
+      "integrity": "sha512-VuXgKZrk0uiDlWjGGXmKV6MSk9Yy4l10qgVvzGn2AWBx1Ylt0iBexKOAoA6I7JO3m+M9oeovJd3yYENfkUbOeg==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -71,6 +71,8 @@
     "fast-xml-parser": "^5.3.6",
     "ajv": "^8.18.0",
     "axios": "^1.13.5",
-    "minimatch": "^10.2.1"
+    "minimatch": "^10.2.1",
+    "rollup": "^4.59.0",
+    "@smithy/config-resolver": "^4.4.0"
   }
 }


### PR DESCRIPTION
## Summary
- Adds npm overrides for rollup (>= 4.59.0) to address high severity CVE
- Adds npm overrides for @smithy/config-resolver (>= 4.4.0) to address GHSA-6475-r3vj-m8vf
- Existing fast-xml-parser and minimatch overrides remain in place

## Test Plan
- [ ] npm install completes successfully
- [ ] Container rebuild resolves alerts

Made with [Cursor](https://cursor.com)