### PR TITLE
docs: rewrite README for explicit setup instructions and fix .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,7 +56,7 @@ REDIS_URL=redis://:change-this-to-a-secure-redis-password@localhost:6380
 # =============================================================================
 # MinIO (Object Storage)
 # =============================================================================
-MINIO_ROOT_USER=minioadmin
+MINIO_ROOT_USER=rustfsadmin
 # Generate: openssl rand -base64 24
 MINIO_ROOT_PASSWORD=change-this-to-a-secure-minio-password
 MINIO_ENDPOINT=localhost
@@ -68,12 +68,19 @@ MINIO_PORT=9000
 KEYCLOAK_ADMIN=admin
 # Change this for production!
 KEYCLOAK_ADMIN_PASSWORD=change-this-admin-password
-KEYCLOAK_REALM=grc
+KEYCLOAK_REALM=gigachad-grc
 # Keycloak client secret for service-to-service auth (REQUIRED)
 # Generate: openssl rand -base64 32
 KEYCLOAK_ADMIN_CLIENT_SECRET=change-me-in-production
 # Enable for development only - MUST be false in production!
 USE_DEV_AUTH=false
+
+# =============================================================================
+# Monitoring (Grafana)
+# =============================================================================
+GRAFANA_ADMIN_USER=admin
+# Generate: openssl rand -base64 24
+GRAFANA_ADMIN_PASSWORD=change-this-to-a-secure-grafana-password
 
 # =============================================================================
 # Phishing Simulation

--- a/README.md
+++ b/README.md
@@ -6,27 +6,25 @@
 [![Node.js 20+](https://img.shields.io/badge/Node.js-20%2B-green.svg)](https://nodejs.org/)
 [![Docker](https://img.shields.io/badge/Docker-Ready-blue.svg)](https://www.docker.com/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-[![Open in Gitpod](https://img.shields.io/badge/Gitpod-Try%20Demo-orange.svg)](https://gitpod.io/#https://github.com/grcengineering/gigachad-grc)
 
 A comprehensive, modular, containerized Governance, Risk, and Compliance (GRC) platform built with modern technologies. Manage your entire security program from compliance tracking to risk management, third-party assessments, and external audits.
 
 ---
 
-## 🚀 Quick Start (Just Docker Required!)
+## Quick Start
 
 ### Prerequisites
 
-You only need **one thing**: [**Docker Desktop**](https://www.docker.com/products/docker-desktop)
+| Requirement | Minimum | Notes |
+|-------------|---------|-------|
+| **Docker Desktop** | v4.0+ | [Download for Mac](https://www.docker.com/products/docker-desktop/) / [Windows](https://www.docker.com/products/docker-desktop/) (requires WSL 2) / Linux: `curl -fsSL https://get.docker.com \| sh` |
+| **RAM** | 8 GB | 16 GB recommended |
+| **CPU** | 4 cores | 8 cores recommended |
+| **Disk** | 10 GB free | 20 GB recommended |
 
-| Platform    | Install Docker                                                                               |
-| ----------- | -------------------------------------------------------------------------------------------- |
-| **macOS**   | [Download for Mac](https://www.docker.com/products/docker-desktop/) (Apple Silicon or Intel) |
-| **Windows** | [Download for Windows](https://www.docker.com/products/docker-desktop/) (requires WSL 2)     |
-| **Linux**   | `curl -fsSL https://get.docker.com \| sh`                                                    |
+> **No Node.js, npm, or other development tools required.** Everything runs inside Docker containers.
 
-> **No Node.js, npm, or other development tools required!**
-
-### Start in 3 Commands
+### Start the Platform
 
 ```bash
 git clone https://github.com/grcengineering/gigachad-grc.git
@@ -34,1233 +32,348 @@ cd gigachad-grc
 ./start.sh
 ```
 
-**Windows Users:**
+**Windows users:** Run `start.bat` instead.
 
-```cmd
-start.bat
-```
+`./start.sh` handles everything automatically:
 
-That's it! Your browser opens to http://localhost:3000 — click **"Dev Login"** to access.
+1. Checks that Docker is installed and running
+2. Generates a `.env` file with secure random secrets (if one doesn't exist)
+3. Builds and starts all containers with `docker compose up`
+4. Opens your browser to `http://localhost:3000`
 
-> **First time?** Initial build takes 3-5 minutes. Subsequent starts are ~30 seconds.
+**First run takes 3-5 minutes** while Docker builds the images. Subsequent starts take ~30 seconds.
 
-### Available Commands
+### Log In
 
-| Command             | Description          |
-| ------------------- | -------------------- |
-| `./start.sh`        | Start the platform   |
-| `./start.sh stop`   | Stop all services    |
-| `./start.sh logs`   | View live logs       |
+When the browser opens to `http://localhost:3000`, click the **"Dev Login"** button. No username or password needed. This bypasses Keycloak SSO and uses a local development account.
+
+> **Important:** The Dev Login button only appears when `VITE_ENABLE_DEV_AUTH=true` is set in your `.env` file. The `./start.sh` script sets this automatically. If you created your `.env` manually, you must add this variable yourself.
+
+### Manage the Platform
+
+| Command | Description |
+|---------|-------------|
+| `./start.sh` | Start the platform |
+| `./start.sh stop` | Stop all services |
+| `./start.sh logs` | View live logs |
 | `./start.sh status` | Check service health |
-
-### Need Help Getting Started?
-
-📖 **[Complete Getting Started Guide](GETTING_STARTED.md)** — Step-by-step instructions with screenshots, troubleshooting, and system requirements.
+| `./start.sh reset` | Stop and remove all containers and volumes |
 
 ---
 
-### Alternative Setup Options
+## Manual Setup (Alternative)
 
-For developers who prefer more control:
+If you prefer to run `docker compose` directly instead of using `./start.sh`, you **must** create a valid `.env` file first. The `.env.example` file contains placeholder values that will not work as-is.
+
+### Step 1: Generate Secrets and Create `.env`
 
 ```bash
-./init.sh demo    # Interactive demo setup with sample data
-./init.sh dev     # Local development mode (requires Node.js 20+)
-make help         # See all Makefile commands
+cp .env.example .env
 ```
 
-**Try in your browser** (no installation):
+Then replace **every placeholder** value in `.env` with real secrets:
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/grcengineering/gigachad-grc)
+```bash
+# Generate and replace ENCRYPTION_KEY
+openssl rand -hex 32
 
-➡️ See the **[Demo & Sandbox Guide](docs/DEMO.md)** for detailed walkthrough with sample data.
+# Generate and replace JWT_SECRET, SESSION_SECRET
+openssl rand -base64 64
+
+# Generate and replace POSTGRES_PASSWORD, REDIS_PASSWORD,
+# MINIO_ROOT_PASSWORD, GRAFANA_ADMIN_PASSWORD,
+# KEYCLOAK_ADMIN_PASSWORD, PHISHING_TRACKING_SECRET
+openssl rand -base64 24
+```
+
+After generating your `POSTGRES_PASSWORD`, update the `DATABASE_URL` to match:
+
+```
+DATABASE_URL=postgresql://grc:YOUR_GENERATED_PASSWORD@localhost:5433/gigachad_grc
+```
+
+Set `VITE_ENABLE_DEV_AUTH=true` to enable the Dev Login button (required for local use without Keycloak HTTPS).
+
+### Step 2: Required Environment Variables
+
+Docker Compose will **refuse to start** if any of these variables are missing or empty:
+
+| Variable | Description | Example Value |
+|----------|-------------|---------------|
+| `POSTGRES_USER` | Database username | `grc` |
+| `POSTGRES_PASSWORD` | Database password | *(generate with openssl)* |
+| `REDIS_PASSWORD` | Redis password | *(generate with openssl)* |
+| `MINIO_ROOT_USER` | RustFS/S3 storage username | `rustfsadmin` |
+| `MINIO_ROOT_PASSWORD` | RustFS/S3 storage password | *(generate with openssl)* |
+| `KEYCLOAK_ADMIN_PASSWORD` | Keycloak admin password | *(generate with openssl)* |
+| `ENCRYPTION_KEY` | AES encryption key (64 hex chars) | *(generate with openssl)* |
+| `PHISHING_TRACKING_SECRET` | Phishing module signing secret | *(generate with openssl)* |
+| `GRAFANA_ADMIN_USER` | Grafana admin username | `admin` |
+| `GRAFANA_ADMIN_PASSWORD` | Grafana admin password | *(generate with openssl)* |
+
+### Step 3: Start
+
+```bash
+docker compose up -d --build
+```
+
+Wait 2-3 minutes on first run, then open `http://localhost:3000`.
 
 ---
 
-## 📚 Documentation
+## Troubleshooting
 
-### Getting Started
+### `GRAFANA_ADMIN_USER is required` or `GRAFANA_ADMIN_PASSWORD is required`
 
-| Document                                        | Description                                               |
-| ----------------------------------------------- | --------------------------------------------------------- |
-| **[Getting Started Guide](GETTING_STARTED.md)** | **Start here!** Complete setup guide for all skill levels |
-| [Quick Start Guide](docs/QUICK_START.md)        | Fast-track setup for experienced users                    |
-| [Demo & Sandbox](docs/DEMO.md)                  | Try with sample data, one-click demo setup                |
-| [Troubleshooting](docs/TROUBLESHOOTING.md)      | Common issues and solutions                               |
+Your `.env` file is missing Grafana credentials. Add:
 
-### Core Documentation
+```
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=your_secure_password
+```
 
-| Document                                         | Description                                                         |
-| ------------------------------------------------ | ------------------------------------------------------------------- |
-| [Architecture Guide](docs/ARCHITECTURE.md)       | System architecture, API gateway, microservices, network topology   |
-| [API Reference](docs/API.md)                     | Complete API documentation with endpoints, authentication, examples |
-| [Configuration Reference](docs/CONFIGURATION.md) | Environment variables, service configuration, Traefik, database     |
-| [Development Guide](docs/DEVELOPMENT.md)         | Local setup, project structure, coding standards, testing           |
-| [Deployment Guide](docs/DEPLOYMENT.md)           | Production deployment, CI/CD, monitoring, backups                   |
-| [Upgrade Guide](docs/UPGRADE.md)                 | Upgrading between versions, migration steps                         |
+Or use `./start.sh` which generates these automatically.
 
-### Security & Compliance
+### Page redirects to `localhost:8080/realms/gigachad-grc/...` and fails
 
-| Document                                                            | Description                                                                       |
-| ------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| [Security Policy](SECURITY.md)                                      | Security vulnerability reporting and policies                                     |
-| [Security Audit](docs/SECURITY_AUDIT.md)                            | Dependency audit findings, vulnerability status, remediation                      |
-| [Security Model](docs/SECURITY_MODEL.md)                            | Comprehensive security architecture, authentication, authorization, and hardening |
-| [Permissions Matrix](docs/PERMISSIONS_MATRIX.md)                    | Role-based access control and permission definitions                              |
-| [MCP Credential Security](docs/security/mcp-credential-security.md) | Secure handling of MCP server credentials                                         |
+Keycloak requires HTTPS, which is not available in local Docker development. The fix is to use Dev Login mode instead:
 
-### Configuration & Operations
+1. Set `VITE_ENABLE_DEV_AUTH=true` in your `.env`
+2. Rebuild the frontend: `docker compose up -d --build frontend`
+3. Open `http://localhost:3000` and use the "Dev Login" button
 
-| Document                                               | Description                             |
-| ------------------------------------------------------ | --------------------------------------- |
-| [Environment Configuration](docs/ENV_CONFIGURATION.md) | Detailed environment variable reference |
-| [Module Configuration](docs/MODULE_CONFIGURATION.md)   | Enable/disable platform modules         |
-| [Production Deployment](docs/PRODUCTION_DEPLOYMENT.md) | Production-ready deployment checklist   |
+The `./start.sh` script enables this automatically.
 
-### Platform Guides
+### `Cannot access 'N' before initialization` (recharts error)
 
-| Document                                          | Description                                  |
-| ------------------------------------------------- | -------------------------------------------- |
-| [Platform Review](docs/PLATFORM_REVIEW.md)        | Comprehensive platform capabilities overview |
-| [Help Center](docs/help/README.md)                | User guides and how-to documentation         |
-| [MCP Quick Start](docs/guides/mcp-quick-start.md) | Getting started with MCP server integration  |
+This was a Vite code-splitting issue that has been fixed. Pull the latest code:
 
-### Audit & Stability Reports
+```bash
+git pull origin main
+./start.sh
+```
 
-| Document                                                         | Description                                |
-| ---------------------------------------------------------------- | ------------------------------------------ |
-| [Stability Audit Phase 1](docs/STABILITY_AUDIT_PHASE1_REPORT.md) | Phase 1 stability audit findings and fixes |
-| [Stability Audit Phase 2](docs/STABILITY_AUDIT_PHASE2_REPORT.md) | Phase 2 stability audit findings and fixes |
+### Port already in use
 
-### Quick Links
+Another process is using one of the required ports. Check with:
 
-- **API Gateway**: Traefik v3.0 - [Configuration Details](docs/ARCHITECTURE.md#api-gateway-traefik)
-- **Authentication**: Keycloak OAuth 2.0 - [Setup Guide](docs/CONFIGURATION.md#keycloak-configuration)
-- **Database**: PostgreSQL 16 - [Schema Details](docs/CONFIGURATION.md#database-configuration)
-- **Monitoring**: Prometheus + Grafana - [Setup Guide](monitoring/README.md)
-- **AI Integration**: OpenAI/Anthropic - [AI Configuration](docs/help/ai-mcp/risk-assistant.md)
+```bash
+# macOS/Linux
+lsof -i :3000
+
+# Stop existing GigaChad containers
+./start.sh stop
+```
+
+### Docker is not running
+
+```
+Cannot connect to the Docker daemon
+```
+
+Start Docker Desktop and wait for it to fully initialize before running `./start.sh`.
+
+### Resetting everything
+
+To completely reset (removes all data, volumes, and containers):
+
+```bash
+docker compose down -v
+./start.sh
+```
+
+> **Warning:** `docker compose down -v` deletes all database data, evidence files, and cached sessions. Run backups first if you have data to preserve.
+
+---
+
+## Access Points
+
+| Service | URL | Credentials |
+|---------|-----|-------------|
+| **Frontend** | http://localhost:3000 | Click "Dev Login" |
+| **Controls API** | http://localhost:3001/api/docs | Swagger UI |
+| **Frameworks API** | http://localhost:3002/api/docs | Swagger UI |
+| **Grafana** | http://localhost:3003 | Set in `.env` |
+| **Policies API** | http://localhost:3004/api/docs | Swagger UI |
+| **TPRM API** | http://localhost:3005/api/docs | Swagger UI |
+| **Trust API** | http://localhost:3006/api/docs | Swagger UI |
+| **Audit API** | http://localhost:3007/api/docs | Swagger UI |
+| **Keycloak Admin** | http://localhost:8080 | Set in `.env` |
+| **Traefik Dashboard** | http://localhost:8090 | None |
+| **RustFS Console** | http://localhost:9001 | Set in `.env` |
+| **Prometheus** | http://localhost:9090 | None |
+| **PostgreSQL** | localhost:5433 | Set in `.env` |
+| **Redis** | localhost:6380 | Set in `.env` |
+
+---
+
+## System Requirements
+
+### Minimum (development/demo)
+
+- Docker Desktop 4.0+
+- 8 GB RAM, 4 CPU cores, 10 GB disk
+- macOS, Windows (WSL 2), or Linux
+
+### Recommended (development)
+
+- 16 GB RAM, 8 cores, 20 GB disk
+- SSD storage for faster Docker builds
+
+### Production
+
+See the [Deployment Guide](docs/DEPLOYMENT.md) and [Production Deployment Checklist](docs/PRODUCTION_DEPLOYMENT.md).
+
+---
 
 ## Platform Overview
 
-GigaChad GRC is a complete enterprise GRC solution organized into specialized modules, each handling a critical aspect of your compliance and risk management program:
-
-- **Compliance**: Controls, frameworks, policies, and evidence management
-- **Data Management**: Evidence library, policies, assets, and integrations
-- **Risk Management**: Risk register, scenarios, heatmaps, and treatment tracking
-- **Third-Party Risk (TPRM)**: Vendor management, assessments, and contracts
-- **Trust**: Security questionnaires, knowledge base, and public trust center
-- **Audit**: Internal and external compliance audits with auditor portal
-- **Tools**: Awareness training, security education programs
-- **AI & Automation**: AI-powered risk scoring, categorization, smart search, and MCP server integration
-- **Administration**: User management, permissions, audit logs, and settings
-
-## Modules & Capabilities
-
-### 1. Compliance Module
-
-#### Controls Management (Port 3001)
-
-Complete lifecycle management for security controls across all frameworks.
-
-**Features:**
-
-- Control library with pre-loaded SOC 2 and ISO 27001 controls
-- Implementation status tracking (Not Started, In Progress, Implemented, Validated)
-- Testing history with evidence collection
-- Control owners and assignment
-- Evidence linking and attachment
-- Test scheduling and reminders
-- Control effectiveness scoring
-- Cross-framework mapping
-
-**API Endpoints:**
-
-- `GET/POST /api/controls` - List and create controls
-- `GET/PATCH/DELETE /api/controls/:id` - Manage individual controls
-- `GET /api/controls/:id/evidence` - View linked evidence
-- `POST /api/controls/:id/test` - Record testing activities
-
-#### Frameworks (Port 3002)
-
-Framework readiness assessment and gap analysis for major compliance standards.
-
-**Pre-loaded Frameworks:**
-
-- SOC 2 Type II (Trust Services Criteria)
-- ISO 27001:2022 (with Annex A controls)
-- NIST CSF 2.0 (ready)
-- PCI DSS (ready)
-- HIPAA (ready)
-- Custom frameworks
-
-**Features:**
-
-- Real-time readiness scoring
-- Gap analysis with prioritized recommendations
-- Control mapping across frameworks
-- Implementation roadmaps
-- Evidence collection per requirement
-- Compliance status dashboards
-- Framework comparison and overlap analysis
-
-**API Endpoints:**
-
-- `GET /api/frameworks` - List all frameworks
-- `GET /api/frameworks/:id` - Framework details with requirements
-- `GET /api/frameworks/:id/readiness` - Calculate readiness score
-- `POST /api/frameworks/:id/assess` - Submit control assessments
-
-### 2. Data Management Module
-
-#### Evidence Library
-
-Centralized repository for all compliance evidence with intelligent organization.
-
-**Features:**
-
-- Multi-backend storage (Local, RustFS/S3, Azure Blob)
-- Document versioning and history
-- Evidence types (Policy, Procedure, Screenshot, Report, Log, Certificate)
-- Control linking with many-to-many relationships
-- Automated retention policies
-- Full-text search and filtering
-- Collection dates and validity periods
-- Evidence review workflows
-
-**API Endpoints:**
-
-- `GET/POST /api/evidence` - List and upload evidence
-- `GET/DELETE /api/evidence/:id` - Manage evidence items
-- `GET /api/evidence/:id/download` - Download evidence files
-
-#### Policies (Port 3004)
-
-Policy lifecycle management with versioning and approval workflows.
-
-**Features:**
-
-- Policy document management with versions
-- Approval workflows (Draft → Review → Approved → Published)
-- Review scheduling and reminders
-- Control linking
-- Policy effectiveness tracking
-- Document history and audit trail
-- Policy categories and tagging
-
-**API Endpoints:**
-
-- `GET/POST /api/policies` - List and create policies
-- `GET /api/policies/:id` - Policy details
-- `POST /api/policies/:id/approve` - Approve policy version
-- `GET /api/policies/:id/versions` - Version history
-
-#### Assets
-
-IT asset inventory with security metadata and classification.
-
-**Features:**
-
-- Asset inventory management (Hardware, Software, Data, People, Services)
-- Criticality classification (Critical, High, Medium, Low)
-- Data sensitivity classification (Public, Internal, Confidential, Restricted)
-- Asset owner assignment
-- Risk and control linking
-- Business process association
-- Asset lifecycle tracking (Active, Retired, Decommissioned)
-- Custom metadata and tagging
-
-**API Endpoints:**
-
-- `GET/POST /api/assets` - List and create assets
-- `GET/PATCH/DELETE /api/assets/:id` - Manage individual assets
-- `POST /api/assets/:id/link` - Link assets to risks/controls
-
-#### Integrations
-
-External tool integrations for automated evidence collection.
-
-**Supported Integrations:**
-
-- **AWS**: S3 bucket configs, IAM policies, EC2 security groups, VPC flow logs, Config rules
-- **Azure**: Resource inventory, security center findings, compliance policies
-- **GitHub**: Branch protection rules, Dependabot alerts, secrets scanning, code scanning
-- **Okta**: MFA enrollment, password policies, inactive users, admin access logs
-- **Google Workspace**: User MFA status, admin roles, Drive sharing settings
-- **Jamf**: Device encryption status, OS versions, security patch compliance
-
-**Features:**
-
-- Scheduled evidence collection (hourly, daily, weekly)
-- Credential management with encryption
-- Collection history and status tracking
-- Automatic evidence upload to library
-- Integration health monitoring
-
-**API Endpoints:**
-
-- `GET/POST /api/integrations` - Integration management
-- `POST /api/integrations/:id/test` - Test connection
-- `POST /api/integrations/:id/collect` - Trigger manual collection
-
-### 3. Risk Management Module (Ports 3001-3002)
-
-Complete enterprise risk management with quantitative and qualitative approaches.
-
-#### Risk Dashboard
-
-Executive overview of organizational risk posture.
-
-**Metrics:**
-
-- Total risks by severity
-- Risk trend analysis
-- Treatment status
-- High-priority risks
-- Risk appetite vs. actual
-- Top risk categories
-
-#### Risk Register
-
-Central repository for all identified risks with comprehensive tracking.
-
-**Features:**
-
-- Risk identification and documentation
-- Likelihood and impact scoring (1-5 scale)
-- Inherent vs. residual risk calculation
-- Risk owners and accountability
-- Treatment plans (Accept, Mitigate, Transfer, Avoid)
-- Status tracking (Identified → Assessed → Treated → Monitored)
-- Control linking and effectiveness
-- Risk categories and tagging
-
-**Risk Scoring:**
-
-- Quantitative: Likelihood × Impact (1-25 scale)
-- Qualitative: Low, Medium, High, Critical
-- Customizable risk matrices
-- Automated risk level calculations
-
-#### Risk Heatmap
-
-Visual risk matrix showing risk distribution by likelihood and impact.
-
-**Features:**
-
-- Interactive heat map visualization
-- Risk clustering by category
-- Drill-down to risk details
-- Filter by status, owner, category
-- Export to PDF/PNG
-
-#### Risk Scenarios
-
-Scenario-based risk modeling and planning.
-
-**Features:**
-
-- Threat scenario modeling
-- Impact analysis
-- Mitigation strategy planning
-- Scenario libraries (Cyber attacks, Data breaches, Disasters)
-
-#### My Risk Queue
-
-Personal task list for assigned risks and actions.
-
-**Features:**
-
-- Assigned risks requiring action
-- Overdue treatment plans
-- Upcoming risk reviews
-- Evidence collection tasks
-
-#### Risk Reports
-
-Comprehensive risk reporting and analytics.
-
-**Report Types:**
-
-- Executive risk summary
-- Risk register report
-- Treatment effectiveness
-- Risk trend analysis
-- Control effectiveness
-- Custom reports with filters
-
-**API Endpoints:**
-
-- `GET/POST /api/risks` - List and create risks
-- `GET/PATCH /api/risks/:id` - Manage risks
-- `POST /api/risks/:id/assess` - Update risk assessment
-- `GET /api/risk-dashboard` - Dashboard statistics
-- `GET /api/risk-heatmap` - Heatmap data
-
-### 4. Third-Party Risk Management (TPRM) (Port 3005)
-
-Complete vendor risk management lifecycle.
-
-#### Vendor Management
-
-Centralized vendor database with risk profiles.
-
-**Features:**
-
-- Vendor contact information
-- Risk tier classification (Critical, High, Medium, Low)
-- Vendor categories (Cloud, SaaS, Consultant, etc.)
-- Vendor status (Active, Under Review, Offboarded)
-- Due diligence documentation
-- Vendor lifecycle tracking
-- Relationship owners
-
-#### Assessments
-
-Security assessments and questionnaires for vendors.
-
-**Assessment Types:**
-
-- Initial due diligence
-- Annual reviews
-- Incident-triggered assessments
-- Ad-hoc assessments
-
-**Features:**
-
-- Customizable questionnaire templates
-- Assessment scoring and risk rating
-- Finding tracking and remediation
-- Evidence collection from vendors
-- Assessment history and trends
-- Approval workflows
-
-#### Contracts
-
-Contract lifecycle management for vendor relationships.
-
-**Features:**
-
-- Contract metadata (dates, value, terms)
-- SLA tracking
-- Renewal reminders
-- Contract document storage
-- Amendment history
-- Contract status (Draft, Active, Expiring, Expired)
-- Vendor linking
-
-**API Endpoints:**
-
-- `GET/POST /api/vendors` - Vendor management
-- `GET/POST /api/assessments` - Assessment workflows
-- `GET/POST /api/contracts` - Contract management
-
-### 5. Trust Module (Port 3006)
-
-Build and maintain customer trust through transparency and responsiveness.
-
-#### Questionnaires
-
-Security questionnaire response management system.
-
-**Features:**
-
-- Questionnaire templates (SOC 2, ISO 27001, Custom)
-- Question bank with reusable answers
-- Response history and versioning
-- Customer portal for submission
-- Approval workflows
-- Evidence attachment
-- Auto-population from knowledge base
-
-#### Knowledge Base
-
-Centralized security knowledge repository for consistent responses.
-
-**Features:**
-
-- Question and answer library
-- Categories and tagging
-- Search and filtering
-- Version control
-- Approval workflows
-- Control/policy linking
-- Confidence scoring
-
-**Use Cases:**
-
-- Pre-populate questionnaire responses
-- Sales engineering reference
-- Customer FAQ
-- Internal training
-
-#### Trust Center
-
-Public-facing security and compliance transparency portal.
-
-**Features:**
-
-- Customizable branding (logo, colors, description)
-- Section-based content management:
-  - **Overview**: Company security commitment
-  - **Certifications & Compliance**: Frameworks and certifications
-  - **Security Controls**: Technical and operational controls
-  - **Policies & Documentation**: Security policies
-  - **Security Updates**: News and incident communications
-  - **Contact**: Security team contact information
-- Publish/draft workflow
-- Preview mode before publishing
-- SEO-friendly public URLs
-- Responsive design
-
-**API Endpoints:**
-
-- `GET/POST /api/questionnaires` - Questionnaire management
-- `GET/POST /api/knowledge-base` - Knowledge base entries
-- `GET/PATCH /api/trust-center/config` - Trust center configuration
-- `GET/POST /api/trust-center/content` - Content management
-- `GET /api/trust-center/public` - Public trust center view
-
-### 6. Audit Module (Port 3007) **[NEW]**
-
-Comprehensive audit management for internal and external compliance audits.
-
-#### Audits
-
-Central audit management with support for multiple audit types.
-
-**Audit Types:**
-
-- Internal audits
-- External audits (SOC 2, ISO 27001)
-- Surveillance audits
-- Certification audits
-
-**Features:**
-
-- Audit planning and scoping
-- Framework selection (SOC 2, ISO 27001, HIPAA, PCI DSS)
-- Audit team management
-- External auditor information tracking
-- Timeline tracking (planned vs. actual)
-- Audit status workflow (Planning → Fieldwork → Testing → Reporting → Completed)
-- Finding aggregation and statistics
-- Portal access for external auditors
-- FieldGuide integration ready
-
-**Auditor Portal:**
-
-- Secure access code generation
-- Temporary access with expiration
-- Document request submission
-- Evidence review interface
-- Comment threads on requests
-
-#### Audit Requests
-
-Evidence and documentation request tracking.
-
-**Request Categories:**
-
-- Control documentation
-- Policy review
-- Evidence collection
-- Interviews
-- System access
-- Walkthroughs
-
-**Features:**
-
-- Request assignment to internal team
-- Priority levels (Low, Medium, High, Critical)
-- Due date tracking with overdue alerts
-- Status workflow (Open → In Progress → Submitted → Under Review → Approved)
-- Evidence attachment
-- Comment threads
-- Clarification requests
-- Control/requirement linking
-
-#### Findings
-
-Audit finding and observation management.
-
-**Finding Types:**
-
-- Control deficiencies
-- Documentation gaps
-- Process issues
-- Compliance gaps
-
-**Features:**
-
-- Severity classification (Critical, High, Medium, Low, Observation)
-- Root cause analysis
-- Impact assessment
-- Remediation planning
-- Remediation owner assignment
-- Target and actual completion dates
-- Management response tracking
-- Status tracking (Open → Remediation Planned → In Progress → Resolved)
-- Control/requirement linking
-
-#### Additional Capabilities:
-
-- **Test Results**: Control testing with sampling methodologies
-- **Meetings**: Audit kickoffs, status updates, interviews, closing meetings
-- **Activity Log**: Complete audit trail of all actions
-- **Dashboard**: Real-time audit statistics and progress
-
-**API Endpoints:**
-
-- `GET/POST /api/audits` - Audit management
-- `GET /api/audits/dashboard` - Audit statistics
-- `POST /api/audits/:id/portal/enable` - Enable auditor portal
-- `GET/POST /api/audit-requests` - Request management
-- `POST /api/audit-requests/:id/comments` - Discussion threads
-- `GET/POST /api/audit-findings` - Finding management
-
-**FieldGuide Integration:**
-
-- OAuth 2.0 authentication with FieldGuide
-- Bi-directional sync with FieldGuide platform
-- Audit data synchronization
-- Request mapping with automatic updates
-- Evidence sharing between platforms
-- Webhook support for real-time updates
-- Conflict resolution for simultaneous edits
-- Sync history and audit logging
-
-**FieldGuide API Endpoints:**
-
-- `GET /api/fieldguide/connect` - Initiate OAuth connection
-- `GET /api/fieldguide/callback` - OAuth callback handler
-- `POST /api/fieldguide/sync` - Trigger bi-directional sync
-- `POST /api/fieldguide/webhooks` - Webhook receiver
-
-### 7. Tools Module
-
-#### Awareness & Training
-
-Comprehensive security awareness training program management.
-
-**Features:**
-
-- Training course management (Security Basics, Phishing Awareness, Data Protection, etc.)
-- Training assignment to users and groups
-- Progress tracking and completion status
-- Quiz engine with multiple question types
-- Certificate generation upon completion
-- Compliance tracking for required training
-- Training content management
-
-**Quiz Engine:**
-
-- Multiple choice, true/false, and multi-select questions
-- Configurable passing scores
-- Question randomization
-- Answer explanations
-- Retake policies
-
-**Certificate Features:**
-
-- Automatic generation on course completion
-- PDF download
-- Unique certificate IDs for verification
-- Expiration dates for recurring training
-
-**API Endpoints:**
-
-- `GET/POST /api/training/courses` - Course management
-- `GET/POST /api/training/assignments` - Assign training
-- `POST /api/training/:courseId/quiz` - Take quiz
-- `GET /api/training/:courseId/certificate` - Download certificate
-
-#### Phishing Simulations
-
-Security awareness through realistic phishing simulations.
-
-**Campaign Features:**
-
-- Campaign creation with templates
-- Target group selection
-- Scheduling (immediate, scheduled, recurring)
-- Email template customization
-- Landing page configuration
-- Real-time tracking and analytics
-
-**Analytics & Reporting:**
-
-- Click rates by department
-- Report rates
-- Training completion correlation
-- Historical trend analysis
-- User risk scoring
-- Department benchmarking
-
-**Template Library:**
-
-- Pre-built phishing templates (Credential harvesting, Malware, Gift card scams, etc.)
-- Custom template creation
-- Template difficulty ratings
-- Industry-specific templates
-
-**API Endpoints:**
-
-- `GET/POST /api/phishing/campaigns` - Campaign management
-- `GET /api/phishing/campaigns/:id/analytics` - Campaign analytics
-- `GET/POST /api/phishing/templates` - Template management
-- `POST /api/phishing/report` - User phishing report submission
-
-### 8. AI & Automation Module
-
-Enterprise AI capabilities and MCP (Model Context Protocol) server integration for intelligent GRC operations.
-
-#### AI Configuration
-
-AI-powered features using GPT-5 (OpenAI) or Claude Opus 4.5 (Anthropic).
-
-**Supported AI Providers**:
-
-- **OpenAI**: GPT-5 (Most Capable), GPT-5 Mini, o3 (Advanced Reasoning), o3-mini
-- **Anthropic**: Claude Opus 4.5 (Most Capable), Claude Sonnet 4, Claude 3.5 Sonnet, Claude 3.5 Haiku
-
-**AI Features**:
-
-- **Risk Scoring**: AI-suggested risk likelihood and impact with rationale
-- **Auto-Categorization**: Automatic categorization and tagging of controls, risks, policies
-- **Smart Search**: Natural language search across all GRC modules
-- **Policy Drafting**: Generate policy drafts based on requirements and context
-- **Control Suggestions**: AI-recommended controls for risks and compliance requirements
-
-#### MCP Server Integration
-
-Model Context Protocol servers for automated GRC workflows.
-
-**Available MCP Servers**:
-
-- **grc-evidence**: Automated evidence collection from cloud providers and security tools
-  - AWS (S3, IAM, EC2, VPC, Config)
-  - Azure resources
-  - GitHub (branch protection, secrets scanning, Dependabot)
-  - Okta (MFA status, password policies, inactive users)
-  - Google Workspace (user MFA, admin roles, sharing settings)
-  - Jamf (device encryption, OS versions, security patches)
-  - Vulnerability scanning integration
-  - Screenshot capture for visual evidence
-
-- **grc-compliance**: Automated compliance checking and reporting
-  - Control testing automation
-  - Policy validation against requirements
-  - Compliance report generation
-  - Framework-specific checks (SOC 2, ISO 27001, HIPAA, GDPR)
-
-- **grc-ai-assistant**: AI-powered GRC operations
-  - Deep risk analysis with contextual understanding
-  - Control recommendations based on risks and requirements
-  - Policy document drafting
-  - Automatic requirement mapping
-  - Finding explanation in plain language
-  - Remediation prioritization
-  - Compliance gap analysis
-  - Vendor risk assessment
-
-**API Endpoints**:
-
-- `GET /api/ai/config` - Get AI configuration
-- `POST /api/ai/risk-scoring` - AI risk scoring suggestions
-- `POST /api/ai/categorize` - Auto-categorization
-- `POST /api/ai/search` - Smart natural language search
-- `GET /api/mcp/servers` - List active MCP servers
-- `POST /api/mcp/tools/call` - Execute MCP tool
-- `POST /api/mcp/workflows` - Manage MCP workflows
-
-### 9. Settings & Administration
-
-#### User Management
-
-User account and access control management via Keycloak.
-
-**Features:**
-
-- User provisioning and deactivation
-- Role assignment (Admin, Compliance Manager, Auditor, Viewer)
-- SSO integration via Keycloak
-- Multi-factor authentication
-- Session management
-
-#### Permissions
-
-Role-based access control and permission groups.
-
-**Default Roles:**
-
-- **Admin**: Full system access
-- **Compliance Manager**: Manage controls, evidence, frameworks
-- **Risk Manager**: Manage risks and treatments
-- **Auditor**: Read-only access to controls and evidence
-- **Viewer**: Limited read access
-
-#### Audit Log
-
-Complete system audit trail for compliance and forensics.
-
-**Tracked Events:**
-
-- User actions (login, logout, changes)
-- Entity changes (create, update, delete)
-- Access attempts
-- Configuration changes
-- Evidence uploads/downloads
-- Approval actions
-
-**Features:**
-
-- Search and filtering
-- Export to CSV
-- Date range queries
-- User activity reports
-- Change history with before/after values
-
-#### Risk Configuration
-
-Risk management system configuration.
-
-**Settings:**
-
-- Risk scoring methodology
-- Likelihood definitions (1-5)
-- Impact definitions (1-5)
-- Risk appetite thresholds
-- Risk categories
-- Treatment options
-- Review frequencies
-
-## Dashboard
-
-The main dashboard provides an executive overview of your entire GRC program:
-
-**Compliance Metrics:**
-
-- Overall compliance score
-- Control implementation status
-- Framework readiness percentages
-- Evidence collection status
-- Upcoming control tests
-
-**Risk Metrics:**
-
-- Risk distribution by severity
-- High-priority risks requiring attention
-- Risk treatment progress
-- Top risk categories
-
-**Audit Metrics:**
-
-- Active audits
-- Open audit requests
-- Pending findings
-- Upcoming audit activities
-
-**Recent Activity:**
-
-- Control updates
-- Evidence uploads
-- Risk assessments
-- Audit progress
-- Policy approvals
+GigaChad GRC is a complete enterprise GRC solution organized into specialized modules:
+
+| Module | Description |
+|--------|-------------|
+| **Compliance** | Controls library, framework readiness (SOC 2, ISO 27001, NIST CSF, PCI DSS, HIPAA), evidence collection, cross-framework mapping |
+| **Risk Management** | Risk register, likelihood/impact scoring, heatmaps, treatment tracking, scenario modeling, risk workflows |
+| **Policies** | Policy lifecycle management with versioning, approval workflows, review scheduling |
+| **Third-Party Risk (TPRM)** | Vendor management, security assessments, contract lifecycle, SLA tracking |
+| **Trust** | Security questionnaires, knowledge base, public-facing trust center portal |
+| **Audit** | Internal/external audit management, evidence requests, findings, auditor portal, FieldGuide integration |
+| **Tools** | Security awareness training, phishing simulations, certificate management |
+| **AI & Automation** | AI-powered risk scoring, auto-categorization, smart search, MCP server integration |
+| **Integrations** | AWS, Azure, GitHub, Okta, Google Workspace, Jamf, and 40+ connectors for automated evidence collection |
+| **Administration** | User management, RBAC, audit logging, risk configuration, system health monitoring |
+
+For detailed module documentation including API endpoints, see the [API Reference](docs/API.md).
+
+---
 
 ## Architecture
 
 ```
-┌───────────────────────────────────────────────────────────────────────┐
-│                           Traefik Gateway                              │
-│                           (API Routing)                                │
-├──────────┬──────────┬──────────┬──────────┬──────────┬──────────┬────┤
-│ Controls │Frameworks│ Policies │   TPRM   │  Trust   │  Audit   │ UI │
-│  :3001   │  :3002   │  :3004   │  :3005   │  :3006   │  :3007   │:5173
-├──────────┴──────────┴──────────┴──────────┴──────────┴──────────┴────┤
-│                          Shared Library                                │
-│          (Prisma Schema, Types, Auth, Storage, Events)                 │
-├──────────┬──────────┬──────────┬──────────────────────────────────────┤
-│PostgreSQL│  Redis   │ Keycloak │              RustFS                  │
-│  :5433   │  :6380   │  :8080   │         :9000 / :9001                │
-│(Database)│ (Cache)  │  (Auth)  │    (S3-Compatible Storage)           │
-└──────────┴──────────┴──────────┴──────────────────────────────────────┘
-
-Frontend (React + Vite)
-    ↓
-Traefik (API Gateway)
-    ↓
-Microservices Layer:
-  - Controls Service (NestJS) → Controls + Evidence + Audit Logging
-  - Frameworks Service (NestJS) → Frameworks + Risk Management
-  - Policies Service (NestJS) → Policy Lifecycle
-  - TPRM Service (NestJS) → Vendors + Assessments + Contracts
-  - Trust Service (NestJS) → Questionnaires + Knowledge Base + Trust Center
-  - Audit Service (NestJS) → Audit Management + Auditor Portal
-    ↓
-Infrastructure Layer:
-  - PostgreSQL (Single database, multi-tenant schema)
-  - Redis (Caching + Session Management)
-  - Keycloak (SSO + RBAC)
-  - RustFS (S3-compatible object storage - https://github.com/rustfs/rustfs)
+                           ┌─────────────────────────────────┐
+                           │       Traefik API Gateway       │
+                           │         (Ports 80/443)          │
+                           └──────────┬──────────────────────┘
+                                      │
+          ┌───────────┬───────────┬────┴────┬───────────┬───────────┬───────────┐
+          │           │           │         │           │           │           │
+     Controls    Frameworks   Policies    TPRM       Trust       Audit     Frontend
+      :3001        :3002       :3004     :3005      :3006       :3007       :3000
+          │           │           │         │           │           │
+          └───────────┴───────────┴────┬────┴───────────┴───────────┘
+                                       │
+                              Shared Library
+                    (Prisma, Auth, Storage, Events, Types)
+                                       │
+               ┌───────────┬───────────┼───────────┐
+               │           │           │           │
+          PostgreSQL     Redis     Keycloak     RustFS
+            :5433        :6380      :8080     :9000/:9001
 ```
 
-## Tech Stack
+### Tech Stack
 
-- **Backend**: Node.js + TypeScript with NestJS
+- **Backend**: Node.js 20 + TypeScript with NestJS
 - **Frontend**: React + TypeScript with Vite, TailwindCSS
-- **Database**: PostgreSQL with Prisma ORM
-- **Authentication**: Keycloak (SSO, RBAC)
-- **API Gateway**: Traefik
-- **Cache/Events**: Redis
-- **Storage**: RustFS (S3-compatible, Apache 2.0 - https://github.com/rustfs/rustfs)
+- **Database**: PostgreSQL 16 with Prisma ORM
+- **Authentication**: Keycloak (SSO, RBAC) with dev-mode bypass
+- **API Gateway**: Traefik v3
+- **Cache**: Redis
+- **Storage**: RustFS (S3-compatible, Apache 2.0 -- [github.com/rustfs/rustfs](https://github.com/rustfs/rustfs))
+- **Monitoring**: Prometheus + Grafana
 - **Containers**: Docker with Docker Compose
 
-## Quick Start
+---
 
-### Prerequisites
+## Documentation
 
-- Docker and Docker Compose
-- Node.js 20+ (for local development)
+### Getting Started
 
-### The Easy Way (Recommended)
+| Document | Description |
+|----------|-------------|
+| **[Getting Started Guide](GETTING_STARTED.md)** | Complete setup guide with screenshots for all skill levels |
+| [Quick Start Guide](docs/QUICK_START.md) | Fast-track setup for experienced users |
+| [Demo & Sandbox](docs/DEMO.md) | One-click demo setup with sample data |
+| [Troubleshooting](docs/TROUBLESHOOTING.md) | Common issues and solutions |
 
-```bash
-git clone https://github.com/grcengineering/gigachad-grc.git
-cd gigachad-grc
-./init.sh demo
-```
+### Core Documentation
 
-This single command:
+| Document | Description |
+|----------|-------------|
+| [Architecture Guide](docs/ARCHITECTURE.md) | System architecture, API gateway, microservices, network topology |
+| [API Reference](docs/API.md) | Complete API documentation with endpoints and examples |
+| [Configuration Reference](docs/CONFIGURATION.md) | Environment variables, service configuration, database |
+| [Development Guide](docs/DEVELOPMENT.md) | Local setup, project structure, coding standards, testing |
+| [Deployment Guide](docs/DEPLOYMENT.md) | Production deployment, CI/CD, monitoring, backups |
 
-- Generates secure secrets and creates `.env`
-- Starts all infrastructure (PostgreSQL, Redis, Keycloak, RustFS)
-- Builds and starts all backend services
-- Starts the frontend and opens your browser
+### Security
 
-**Login**: Click "Dev Login" - no password needed!
+| Document | Description |
+|----------|-------------|
+| [Security Policy](SECURITY.md) | Vulnerability reporting and policies |
+| [Security Model](docs/SECURITY_MODEL.md) | Authentication, authorization, and hardening |
+| [Permissions Matrix](docs/PERMISSIONS_MATRIX.md) | Role-based access control definitions |
 
-### Using Make
+### Operations
 
-```bash
-make demo      # One-click demo
-make dev       # Development setup
-make up        # Start containers
-make down      # Stop containers
-make logs      # View logs
-make help      # See all commands
-```
+| Document | Description |
+|----------|-------------|
+| [Environment Configuration](docs/ENV_CONFIGURATION.md) | Detailed environment variable reference |
+| [Module Configuration](docs/MODULE_CONFIGURATION.md) | Enable/disable platform modules |
+| [Production Deployment](docs/PRODUCTION_DEPLOYMENT.md) | Production-ready deployment checklist |
+| [Monitoring](monitoring/README.md) | Prometheus + Grafana setup |
 
-### Manual Setup
-
-If you prefer manual control:
-
-```bash
-# 1. Create environment
-cp .env.example .env
-
-# 2. Start infrastructure
-docker compose up -d postgres redis keycloak rustfs
-
-# 3. Start services
-docker compose up -d
-
-# 4. Access the app
-open http://localhost:3000
-```
-
-### Access Points
-
-- **Frontend**: http://localhost:3000 (or :5173 in dev)
-- **Keycloak Admin**: http://localhost:8080 (admin/admin)
-- **API Docs**: http://localhost:3001/api/docs
-- **RustFS Console**: http://localhost:9001 (rustfsadmin/rustfsadmin)
-
-## Production Readiness & Resilience
-
-GigaChad GRC includes comprehensive built-in tools for ensuring production readiness:
-
-### Production Validation CLI
-
-Before deploying to production, run the validation script to check all configuration:
-
-```bash
-# Basic validation
-npm run validate:production
-
-# Strict mode (exit non-zero on warnings)
-npm run validate:production:strict
-```
-
-The script validates:
-
-- Security configuration (encryption keys, passwords, auth mode)
-- Database connections and SSL
-- Backup configuration
-- Authentication setup (Keycloak)
-- Network/CORS settings
-
-### System Health Dashboard
-
-Administrators can view real-time system health in **Settings > Organization Settings > System Health**:
-
-- **System Health Banner**: Displays critical warnings for security issues, backup problems, and misconfigurations
-- **Production Readiness Score**: 0-100 score indicating deployment readiness
-- **Setup Wizard**: Guided configuration for new installations
-
-### Automatic Features
-
-When running with Docker, the entrypoint script provides:
-
-| Feature                | Environment Variable       | Description                                    |
-| ---------------------- | -------------------------- | ---------------------------------------------- |
-| Auto-backup scheduling | `AUTO_BACKUP_ENABLED=true` | Schedules daily backups via cron               |
-| Database migrations    | `AUTO_MIGRATE=true`        | Runs migrations on startup                     |
-| Dependency wait        | `WAIT_FOR_DB=true`         | Waits for PostgreSQL before starting           |
-| Config warnings        | Always enabled             | Logs warnings for production misconfigurations |
-
-### Data Persistence
-
-All critical data is stored in Docker named volumes that survive container restarts:
-
-| Data Type      | Volume            | Survives Crash |
-| -------------- | ----------------- | -------------- |
-| Database       | `postgres_data`   | ✅ Yes         |
-| Evidence Files | `rustfs_data`     | ✅ Yes         |
-| Cache/Sessions | `redis_data`      | ✅ Yes         |
-| Metrics        | `prometheus_data` | ✅ Yes         |
-
-**Important**: Running `docker-compose down -v` will delete volumes. Always run backups before maintenance.
-
-### Backup & Restore
-
-```bash
-# Create backup (stored in /backups/gigachad-grc/)
-npm run backup
-
-# Restore from backup
-npm run restore /path/to/backup.tar.gz
-```
-
-For detailed resilience documentation, see [System Health Guide](docs/help/admin/system-health.md).
+---
 
 ## Project Structure
 
 ```
 gigachad-grc/
+├── frontend/                 # React SPA (Vite + TailwindCSS)
 ├── services/
-│   ├── shared/               # Shared TypeScript library
-│   │   ├── src/
-│   │   │   ├── types/        # Type definitions
-│   │   │   ├── auth/         # Auth middleware
-│   │   │   ├── storage/      # Storage abstraction
-│   │   │   ├── events/       # Event bus
-│   │   │   ├── utils/        # Utilities
-│   │   │   └── logger/       # Logging
-│   │   └── prisma/           # Unified database schema (all modules)
-│   │       └── schema.prisma # Single source of truth
-│   │
-│   ├── controls/             # Controls + Evidence + Audit Logging
-│   │   ├── src/
-│   │   │   ├── controls/     # Control management
-│   │   │   ├── evidence/     # Evidence library
-│   │   │   ├── audit/        # Activity audit logging
-│   │   │   └── testing/      # Control testing
-│   │   ├── Dockerfile
-│   │   └── package.json
-│   │
-│   ├── frameworks/           # Frameworks + Risk Management
-│   │   ├── src/
-│   │   │   ├── frameworks/   # Framework assessments
-│   │   │   ├── risks/        # Risk register
-│   │   │   ├── scenarios/    # Risk scenarios
-│   │   │   └── treatments/   # Risk treatments
-│   │   ├── Dockerfile
-│   │   └── package.json
-│   │
-│   ├── policies/             # Policy Lifecycle Management
-│   │   ├── src/
-│   │   │   ├── policies/     # Policy CRUD
-│   │   │   ├── versions/     # Version control
-│   │   │   └── approvals/    # Approval workflows
-│   │   ├── Dockerfile
-│   │   └── package.json
-│   │
-│   ├── tprm/                 # Third-Party Risk Management
-│   │   ├── src/
-│   │   │   ├── vendors/      # Vendor management
-│   │   │   ├── assessments/  # Security assessments
-│   │   │   └── contracts/    # Contract lifecycle
-│   │   ├── Dockerfile
-│   │   └── package.json
-│   │
-│   ├── trust/                # Trust & Transparency
-│   │   ├── src/
-│   │   │   ├── questionnaires/  # Security questionnaires
-│   │   │   ├── knowledge-base/  # Q&A repository
-│   │   │   └── trust-center/    # Public trust portal
-│   │   ├── Dockerfile
-│   │   └── package.json
-│   │
-│   └── audit/                # Audit Management (NEW)
-│       ├── src/
-│       │   ├── audits/       # Audit orchestration
-│       │   ├── requests/     # Evidence requests
-│       │   ├── findings/     # Audit findings
-│       │   ├── evidence/     # Audit evidence
-│       │   ├── portal/       # External auditor portal
-│       │   └── fieldguide/   # FieldGuide integration
-│       ├── Dockerfile
-│       └── package.json
-│
-├── frontend/                 # React SPA
-│   ├── src/
-│   │   ├── pages/            # Page components
-│   │   │   ├── Controls.tsx
-│   │   │   ├── Frameworks.tsx
-│   │   │   ├── Risks.tsx
-│   │   │   ├── Vendors.tsx
-│   │   │   ├── Questionnaires.tsx
-│   │   │   ├── Audits.tsx    # NEW
-│   │   │   └── ...
-│   │   ├── components/       # Reusable components
-│   │   ├── contexts/         # React contexts (Auth)
-│   │   └── lib/              # Utilities and API clients
-│   └── package.json
-│
-├── auth/                     # Keycloak configuration
-│   └── realm-export.json     # Pre-configured realm
-│
-├── gateway/                  # Traefik configuration
-│   └── traefik.yml
-│
-├── database/
-│   ├── init/                 # Database initialization
-│   └── seeds/                # Seed data (frameworks, controls)
-│
-├── docker-compose.yml        # Production compose
-├── docker-compose.dev.yml    # Development overrides
-├── .env.example              # Environment template
-└── README.md                 # This file
+│   ├── shared/               # Shared library (Prisma, auth, storage, types)
+│   ├── controls/             # Controls, evidence, integrations, risk, audit logging
+│   ├── frameworks/           # Framework assessments and readiness
+│   ├── policies/             # Policy lifecycle management
+│   ├── tprm/                 # Vendor risk, assessments, contracts
+│   ├── trust/                # Questionnaires, knowledge base, trust center
+│   └── audit/                # Audit management, findings, auditor portal
+├── mcp-servers/              # MCP server integrations (evidence, compliance, AI)
+├── gateway/                  # Traefik API gateway configuration
+├── monitoring/               # Prometheus + Grafana configuration
+├── deploy/                   # Production deployment configs
+├── terraform/                # Infrastructure as Code
+├── docker-compose.yml        # Container orchestration
+├── .env.example              # Environment variable template
+├── start.sh                  # One-command startup script
+└── start.bat                 # Windows startup script
 ```
 
-## Service Ports & Documentation
-
-Each microservice runs on its own port with Swagger API documentation:
-
-| Service            | Port   | Swagger Docs                   | Description                                |
-| ------------------ | ------ | ------------------------------ | ------------------------------------------ |
-| **Frontend**       | 5173   | N/A                            | React SPA (Vite dev server)                |
-| **Controls**       | 3001   | http://localhost:3001/api/docs | Controls, Evidence, Testing                |
-| **Frameworks**     | 3002   | http://localhost:3002/api/docs | Frameworks, Risk Management                |
-| **Policies**       | 3004   | http://localhost:3004/api/docs | Policy Lifecycle Management                |
-| **TPRM**           | 3005   | http://localhost:3005/api/docs | Vendor Risk Management                     |
-| **Trust**          | 3006   | http://localhost:3006/api/docs | Questionnaires, KB, Trust Center           |
-| **Audit**          | 3007   | http://localhost:3007/api/docs | Audit Management                           |
-| **PostgreSQL**     | 5433   | N/A                            | Primary database                           |
-| **Redis**          | 6380   | N/A                            | Cache & sessions                           |
-| **Keycloak**       | 8080   | http://localhost:8080          | Auth & SSO (admin/admin)                   |
-| **Traefik**        | 80/443 | http://localhost:8090          | API Gateway dashboard                      |
-| **RustFS API**     | 9000   | N/A                            | S3-compatible object storage API           |
-| **RustFS Console** | 9001   | http://localhost:9001          | Storage admin UI (rustfsadmin/rustfsadmin) |
-
-## Configuration
-
-### Environment Variables
-
-| Variable                  | Description                      | Default           |
-| ------------------------- | -------------------------------- | ----------------- |
-| `POSTGRES_USER`           | Database user                    | grc               |
-| `POSTGRES_PASSWORD`       | Database password                | grc_secret        |
-| `POSTGRES_DB`             | Database name                    | gigachad_grc      |
-| `REDIS_PASSWORD`          | Redis password                   | redis_secret      |
-| `KEYCLOAK_ADMIN`          | Keycloak admin user              | admin             |
-| `KEYCLOAK_ADMIN_PASSWORD` | Keycloak admin password          | admin             |
-| `MINIO_ROOT_USER`         | RustFS/S3 root user              | rustfsadmin       |
-| `MINIO_ROOT_PASSWORD`     | RustFS/S3 root password          | (secure password) |
-| `STORAGE_TYPE`            | Storage backend (local/s3/minio) | s3                |
-
-### Storage Configuration
-
-The platform supports multiple storage backends:
-
-**Local Storage:**
-
-```env
-STORAGE_TYPE=local
-LOCAL_STORAGE_PATH=./storage
-```
-
-**RustFS/S3 (Recommended):**
-
-```env
-# RustFS is a high-performance, Apache 2.0 licensed S3-compatible storage
-# https://github.com/rustfs/rustfs
-STORAGE_TYPE=s3
-S3_ENDPOINT=rustfs
-S3_PORT=9000
-S3_ACCESS_KEY=rustfsadmin
-S3_SECRET_KEY=your_secure_password
-S3_BUCKET=grc-evidence
-```
-
-## Module Extraction
-
-Each service is designed to run independently. To extract a module:
-
-1. Copy the service directory
-2. Update the `DATABASE_URL` in the service's environment
-3. Run migrations: `npm run prisma:migrate`
-4. Build and run: `docker build -t my-service . && docker run my-service`
-
-## Security Considerations
-
-- All passwords should be changed in production
-- Enable TLS/SSL for all services
-- Configure Keycloak for production use
-- Use proper secrets management
-- Review and harden Docker images
-- Images should be pulled from Docker Hub's Hardened Images
+---
 
 ## License
 
 This project is licensed under the **Elastic License 2.0 (ELv2)**.
 
-### What You CAN Do:
+**You CAN:** Use internally for commercial purposes, modify for your own use, self-host, contribute improvements.
 
-- Use internally at your company for commercial purposes
-- Modify the software for your own use
-- Self-host on your own infrastructure
-- Contribute improvements back to the project
+**You CANNOT:** Offer as a hosted/managed service, sell the software, create a competing commercial product, remove license notices.
 
-### What You CANNOT Do:
-
-- Offer this software as a hosted/managed service to third parties
-- Sell the software or derivatives to others
-- Create a competing commercial GRC product based on this code
-- Remove or obscure license/copyright notices
-
-See the [LICENSE](LICENSE) file for the complete license terms.
-
-For commercial licensing inquiries (e.g., to offer as a managed service), please contact the project maintainers.
+See [LICENSE](LICENSE) for complete terms.
 
 ## Contributing
 
-We welcome contributions! Please read our [Contributing Guide](CONTRIBUTING.md) to get started.
-
-By contributing, you agree that your contributions will be licensed under the same Elastic License 2.0. Please also review our [Code of Conduct](CODE_OF_CONDUCT.md).
-
-**Quick Start:**
+We welcome contributions. Please read the [Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](CODE_OF_CONDUCT.md).
 
 1. Fork the repository
 2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Make your changes following our [coding standards](CONTRIBUTING.md#coding-standards)
+3. Make your changes following the [coding standards](CONTRIBUTING.md#coding-standards)
 4. Run tests (`npm test`)
 5. Submit a pull request
 
 ## Support
 
-- **Documentation**: Check the [docs folder](./docs) for guides and references
-- **Issues**: Use the [GitHub issue tracker](../../issues) for bugs and feature requests
-- **Security**: Report vulnerabilities privately via [GitHub Security Advisories](../../security/advisories/new)
-- **Discussions**: Use [GitHub Discussions](../../discussions) for questions and ideas
+- **Documentation**: [docs/](./docs)
+- **Issues**: [GitHub Issues](../../issues)
+- **Discussions**: [GitHub Discussions](../../discussions)
+- **Security**: [Report vulnerabilities](../../security/advisories/new)

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ A comprehensive, modular, containerized Governance, Risk, and Compliance (GRC) p
 
 ### Prerequisites
 
-| Requirement | Minimum | Notes |
-|-------------|---------|-------|
-| **Docker Desktop** | v4.0+ | [Download for Mac](https://www.docker.com/products/docker-desktop/) / [Windows](https://www.docker.com/products/docker-desktop/) (requires WSL 2) / Linux: `curl -fsSL https://get.docker.com \| sh` |
-| **RAM** | 8 GB | 16 GB recommended |
-| **CPU** | 4 cores | 8 cores recommended |
-| **Disk** | 10 GB free | 20 GB recommended |
+| Requirement        | Minimum    | Notes                                                                                                                                                                                                |
+| ------------------ | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Docker Desktop** | v4.0+      | [Download for Mac](https://www.docker.com/products/docker-desktop/) / [Windows](https://www.docker.com/products/docker-desktop/) (requires WSL 2) / Linux: `curl -fsSL https://get.docker.com \| sh` |
+| **RAM**            | 8 GB       | 16 GB recommended                                                                                                                                                                                    |
+| **CPU**            | 4 cores    | 8 cores recommended                                                                                                                                                                                  |
+| **Disk**           | 10 GB free | 20 GB recommended                                                                                                                                                                                    |
 
 > **No Node.js, npm, or other development tools required.** Everything runs inside Docker containers.
 
@@ -51,13 +51,13 @@ When the browser opens to `http://localhost:3000`, click the **"Dev Login"** but
 
 ### Manage the Platform
 
-| Command | Description |
-|---------|-------------|
-| `./start.sh` | Start the platform |
-| `./start.sh stop` | Stop all services |
-| `./start.sh logs` | View live logs |
-| `./start.sh status` | Check service health |
-| `./start.sh reset` | Stop and remove all containers and volumes |
+| Command             | Description                                |
+| ------------------- | ------------------------------------------ |
+| `./start.sh`        | Start the platform                         |
+| `./start.sh stop`   | Stop all services                          |
+| `./start.sh logs`   | View live logs                             |
+| `./start.sh status` | Check service health                       |
+| `./start.sh reset`  | Stop and remove all containers and volumes |
 
 ---
 
@@ -98,18 +98,18 @@ Set `VITE_ENABLE_DEV_AUTH=true` to enable the Dev Login button (required for loc
 
 Docker Compose will **refuse to start** if any of these variables are missing or empty:
 
-| Variable | Description | Example Value |
-|----------|-------------|---------------|
-| `POSTGRES_USER` | Database username | `grc` |
-| `POSTGRES_PASSWORD` | Database password | *(generate with openssl)* |
-| `REDIS_PASSWORD` | Redis password | *(generate with openssl)* |
-| `MINIO_ROOT_USER` | RustFS/S3 storage username | `rustfsadmin` |
-| `MINIO_ROOT_PASSWORD` | RustFS/S3 storage password | *(generate with openssl)* |
-| `KEYCLOAK_ADMIN_PASSWORD` | Keycloak admin password | *(generate with openssl)* |
-| `ENCRYPTION_KEY` | AES encryption key (64 hex chars) | *(generate with openssl)* |
-| `PHISHING_TRACKING_SECRET` | Phishing module signing secret | *(generate with openssl)* |
-| `GRAFANA_ADMIN_USER` | Grafana admin username | `admin` |
-| `GRAFANA_ADMIN_PASSWORD` | Grafana admin password | *(generate with openssl)* |
+| Variable                   | Description                       | Example Value             |
+| -------------------------- | --------------------------------- | ------------------------- |
+| `POSTGRES_USER`            | Database username                 | `grc`                     |
+| `POSTGRES_PASSWORD`        | Database password                 | _(generate with openssl)_ |
+| `REDIS_PASSWORD`           | Redis password                    | _(generate with openssl)_ |
+| `MINIO_ROOT_USER`          | RustFS/S3 storage username        | `rustfsadmin`             |
+| `MINIO_ROOT_PASSWORD`      | RustFS/S3 storage password        | _(generate with openssl)_ |
+| `KEYCLOAK_ADMIN_PASSWORD`  | Keycloak admin password           | _(generate with openssl)_ |
+| `ENCRYPTION_KEY`           | AES encryption key (64 hex chars) | _(generate with openssl)_ |
+| `PHISHING_TRACKING_SECRET` | Phishing module signing secret    | _(generate with openssl)_ |
+| `GRAFANA_ADMIN_USER`       | Grafana admin username            | `admin`                   |
+| `GRAFANA_ADMIN_PASSWORD`   | Grafana admin password            | _(generate with openssl)_ |
 
 ### Step 3: Start
 
@@ -188,22 +188,22 @@ docker compose down -v
 
 ## Access Points
 
-| Service | URL | Credentials |
-|---------|-----|-------------|
-| **Frontend** | http://localhost:3000 | Click "Dev Login" |
-| **Controls API** | http://localhost:3001/api/docs | Swagger UI |
-| **Frameworks API** | http://localhost:3002/api/docs | Swagger UI |
-| **Grafana** | http://localhost:3003 | Set in `.env` |
-| **Policies API** | http://localhost:3004/api/docs | Swagger UI |
-| **TPRM API** | http://localhost:3005/api/docs | Swagger UI |
-| **Trust API** | http://localhost:3006/api/docs | Swagger UI |
-| **Audit API** | http://localhost:3007/api/docs | Swagger UI |
-| **Keycloak Admin** | http://localhost:8080 | Set in `.env` |
-| **Traefik Dashboard** | http://localhost:8090 | None |
-| **RustFS Console** | http://localhost:9001 | Set in `.env` |
-| **Prometheus** | http://localhost:9090 | None |
-| **PostgreSQL** | localhost:5433 | Set in `.env` |
-| **Redis** | localhost:6380 | Set in `.env` |
+| Service               | URL                            | Credentials       |
+| --------------------- | ------------------------------ | ----------------- |
+| **Frontend**          | http://localhost:3000          | Click "Dev Login" |
+| **Controls API**      | http://localhost:3001/api/docs | Swagger UI        |
+| **Frameworks API**    | http://localhost:3002/api/docs | Swagger UI        |
+| **Grafana**           | http://localhost:3003          | Set in `.env`     |
+| **Policies API**      | http://localhost:3004/api/docs | Swagger UI        |
+| **TPRM API**          | http://localhost:3005/api/docs | Swagger UI        |
+| **Trust API**         | http://localhost:3006/api/docs | Swagger UI        |
+| **Audit API**         | http://localhost:3007/api/docs | Swagger UI        |
+| **Keycloak Admin**    | http://localhost:8080          | Set in `.env`     |
+| **Traefik Dashboard** | http://localhost:8090          | None              |
+| **RustFS Console**    | http://localhost:9001          | Set in `.env`     |
+| **Prometheus**        | http://localhost:9090          | None              |
+| **PostgreSQL**        | localhost:5433                 | Set in `.env`     |
+| **Redis**             | localhost:6380                 | Set in `.env`     |
 
 ---
 
@@ -230,18 +230,18 @@ See the [Deployment Guide](docs/DEPLOYMENT.md) and [Production Deployment Checkl
 
 GigaChad GRC is a complete enterprise GRC solution organized into specialized modules:
 
-| Module | Description |
-|--------|-------------|
-| **Compliance** | Controls library, framework readiness (SOC 2, ISO 27001, NIST CSF, PCI DSS, HIPAA), evidence collection, cross-framework mapping |
-| **Risk Management** | Risk register, likelihood/impact scoring, heatmaps, treatment tracking, scenario modeling, risk workflows |
-| **Policies** | Policy lifecycle management with versioning, approval workflows, review scheduling |
-| **Third-Party Risk (TPRM)** | Vendor management, security assessments, contract lifecycle, SLA tracking |
-| **Trust** | Security questionnaires, knowledge base, public-facing trust center portal |
-| **Audit** | Internal/external audit management, evidence requests, findings, auditor portal, FieldGuide integration |
-| **Tools** | Security awareness training, phishing simulations, certificate management |
-| **AI & Automation** | AI-powered risk scoring, auto-categorization, smart search, MCP server integration |
-| **Integrations** | AWS, Azure, GitHub, Okta, Google Workspace, Jamf, and 40+ connectors for automated evidence collection |
-| **Administration** | User management, RBAC, audit logging, risk configuration, system health monitoring |
+| Module                      | Description                                                                                                                      |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| **Compliance**              | Controls library, framework readiness (SOC 2, ISO 27001, NIST CSF, PCI DSS, HIPAA), evidence collection, cross-framework mapping |
+| **Risk Management**         | Risk register, likelihood/impact scoring, heatmaps, treatment tracking, scenario modeling, risk workflows                        |
+| **Policies**                | Policy lifecycle management with versioning, approval workflows, review scheduling                                               |
+| **Third-Party Risk (TPRM)** | Vendor management, security assessments, contract lifecycle, SLA tracking                                                        |
+| **Trust**                   | Security questionnaires, knowledge base, public-facing trust center portal                                                       |
+| **Audit**                   | Internal/external audit management, evidence requests, findings, auditor portal, FieldGuide integration                          |
+| **Tools**                   | Security awareness training, phishing simulations, certificate management                                                        |
+| **AI & Automation**         | AI-powered risk scoring, auto-categorization, smart search, MCP server integration                                               |
+| **Integrations**            | AWS, Azure, GitHub, Okta, Google Workspace, Jamf, and 40+ connectors for automated evidence collection                           |
+| **Administration**          | User management, RBAC, audit logging, risk configuration, system health monitoring                                               |
 
 For detailed module documentation including API endpoints, see the [API Reference](docs/API.md).
 
@@ -289,39 +289,42 @@ For detailed module documentation including API endpoints, see the [API Referenc
 
 ### Getting Started
 
-| Document | Description |
-|----------|-------------|
+| Document                                        | Description                                                |
+| ----------------------------------------------- | ---------------------------------------------------------- |
 | **[Getting Started Guide](GETTING_STARTED.md)** | Complete setup guide with screenshots for all skill levels |
-| [Quick Start Guide](docs/QUICK_START.md) | Fast-track setup for experienced users |
-| [Demo & Sandbox](docs/DEMO.md) | One-click demo setup with sample data |
-| [Troubleshooting](docs/TROUBLESHOOTING.md) | Common issues and solutions |
+| [Quick Start Guide](docs/QUICK_START.md)        | Fast-track setup for experienced users                     |
+| [Demo & Sandbox](docs/DEMO.md)                  | One-click demo setup with sample data                      |
+| [Troubleshooting](docs/TROUBLESHOOTING.md)      | Common issues and solutions                                |
 
 ### Core Documentation
 
-| Document | Description |
-|----------|-------------|
-| [Architecture Guide](docs/ARCHITECTURE.md) | System architecture, API gateway, microservices, network topology |
-| [API Reference](docs/API.md) | Complete API documentation with endpoints and examples |
-| [Configuration Reference](docs/CONFIGURATION.md) | Environment variables, service configuration, database |
-| [Development Guide](docs/DEVELOPMENT.md) | Local setup, project structure, coding standards, testing |
-| [Deployment Guide](docs/DEPLOYMENT.md) | Production deployment, CI/CD, monitoring, backups |
+| Document                                         | Description                                                       |
+| ------------------------------------------------ | ----------------------------------------------------------------- |
+| [Architecture Guide](docs/ARCHITECTURE.md)       | System architecture, API gateway, microservices, network topology |
+| [API Reference](docs/API.md)                     | Complete API documentation with endpoints and examples            |
+| [Configuration Reference](docs/CONFIGURATION.md) | Environment variables, service configuration, database            |
+| [Development Guide](docs/DEVELOPMENT.md)         | Local setup, project structure, coding standards, testing         |
+| [Deployment Guide](docs/DEPLOYMENT.md)           | Production deployment, CI/CD, monitoring, backups                 |
+| [Database Schema](docs/DATABASE_SCHEMA.md)       | All Prisma models, enums, and entity relationships                |
+| [Shared Library](services/shared/README.md)      | Auth, storage, events, utils, and shared types                    |
 
 ### Security
 
-| Document | Description |
-|----------|-------------|
-| [Security Policy](SECURITY.md) | Vulnerability reporting and policies |
-| [Security Model](docs/SECURITY_MODEL.md) | Authentication, authorization, and hardening |
-| [Permissions Matrix](docs/PERMISSIONS_MATRIX.md) | Role-based access control definitions |
+| Document                                         | Description                                  |
+| ------------------------------------------------ | -------------------------------------------- |
+| [Security Policy](SECURITY.md)                   | Vulnerability reporting and policies         |
+| [Security Model](docs/SECURITY_MODEL.md)         | Authentication, authorization, and hardening |
+| [Permissions Matrix](docs/PERMISSIONS_MATRIX.md) | Role-based access control definitions        |
 
 ### Operations
 
-| Document | Description |
-|----------|-------------|
-| [Environment Configuration](docs/ENV_CONFIGURATION.md) | Detailed environment variable reference |
-| [Module Configuration](docs/MODULE_CONFIGURATION.md) | Enable/disable platform modules |
-| [Production Deployment](docs/PRODUCTION_DEPLOYMENT.md) | Production-ready deployment checklist |
-| [Monitoring](monitoring/README.md) | Prometheus + Grafana setup |
+| Document                                               | Description                              |
+| ------------------------------------------------------ | ---------------------------------------- |
+| [Environment Configuration](docs/ENV_CONFIGURATION.md) | Detailed environment variable reference  |
+| [Module Configuration](docs/MODULE_CONFIGURATION.md)   | Enable/disable platform modules          |
+| [Production Deployment](docs/PRODUCTION_DEPLOYMENT.md) | Production-ready deployment checklist    |
+| [Remote Deployment](docs/REMOTE_DEPLOYMENT.md)         | Deploying on remote servers, VMs, or LAN |
+| [Monitoring](monitoring/README.md)                     | Prometheus + Grafana setup               |
 
 ---
 

--- a/docs/DATABASE_SCHEMA.md
+++ b/docs/DATABASE_SCHEMA.md
@@ -1,0 +1,220 @@
+# Database Schema Reference
+
+GigaChad GRC uses a single PostgreSQL database with a unified Prisma schema located at `services/shared/prisma/schema.prisma`. All microservices share this schema through the `@gigachad-grc/shared` package.
+
+## Entity Relationship Overview
+
+```
+Organization (tenant root)
+├── Users, Workspaces, Departments
+├── Controls ──── ControlImplementations ──── ControlTests
+│   └── ControlMappings ── FrameworkRequirements ── Frameworks
+├── Evidence ──── EvidenceControlLinks
+├── Policies ──── PolicyVersions ──── PolicyApprovals
+├── Risks ──── RiskAssessments, RiskTreatments
+│   └── RiskControls, RiskAssets, RiskScenarios
+├── Vendors ──── VendorAssessments, VendorContracts
+├── Audits ──── AuditRequests, AuditFindings, AuditTestResults
+├── Questionnaires ──── KnowledgeBase
+├── Integrations ──── SyncJobs, ComplianceChecks
+├── Assets
+├── CorrelatedEmployees ──── Training, BackgroundChecks
+└── BCDR ──── Incidents, RecoveryTeams
+```
+
+## Models by Domain
+
+### Auth, Users, and RBAC
+
+| Model                      | Purpose                                                                                                          |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| **Organization**           | Top-level tenant. All entities belong to an organization.                                                        |
+| **User**                   | Platform users. Linked to Keycloak via `keycloakId`. Roles: admin, compliance_manager, auditor, viewer.          |
+| **Workspace**              | Multi-product workspaces within an organization. Controls, evidence, risks, and vendors can be workspace-scoped. |
+| **WorkspaceMember**        | User membership in a workspace with a role (owner, manager, contributor, viewer).                                |
+| **Department**             | Organizational departments with hierarchy (self-referencing `parentId`).                                         |
+| **PermissionGroup**        | Named permission sets for RBAC. System groups are immutable.                                                     |
+| **UserGroupMembership**    | Links users to permission groups.                                                                                |
+| **UserPermissionOverride** | Per-user permission grants/denials that override group permissions.                                              |
+
+### Controls and Compliance
+
+| Model                        | Purpose                                                                                                  |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------- |
+| **Control**                  | Security controls (e.g., AC-001 "User Access Management"). Has category, status, and organizationId.     |
+| **ControlImplementation**    | Per-organization/workspace instance of a control. Tracks implementation status, owner, and test history. |
+| **ControlTest**              | Test results for a control implementation (manual or automated, pass/fail/partial).                      |
+| **ControlMapping**           | Links a control to a framework requirement (primary, supporting, or partial mapping).                    |
+| **ControlEvidenceCollector** | Automated evidence collector tied to a control and integration.                                          |
+
+### Frameworks
+
+| Model                    | Purpose                                                                                    |
+| ------------------------ | ------------------------------------------------------------------------------------------ |
+| **Framework**            | Compliance frameworks (SOC 2, ISO 27001, NIST CSF, PCI DSS, HIPAA, custom).                |
+| **FrameworkRequirement** | Individual requirements within a framework (e.g., CC6.1).                                  |
+| **ReadinessAssessment**  | Assessment of an organization's readiness against a framework. Produces a readiness score. |
+| **RequirementStatus**    | Per-requirement status within a readiness assessment.                                      |
+| **Gap**                  | Identified gaps from readiness assessments, with severity and remediation status.          |
+| **RemediationTask**      | Tasks to close gaps, assigned to users with due dates.                                     |
+
+### Evidence
+
+| Model                   | Purpose                                                                                                |
+| ----------------------- | ------------------------------------------------------------------------------------------------------ |
+| **Evidence**            | Evidence artifacts (screenshots, documents, exports, logs, certificates). Stored via storage provider. |
+| **EvidenceFolder**      | Hierarchical folder structure for organizing evidence.                                                 |
+| **EvidenceControlLink** | Many-to-many link between evidence and control implementations.                                        |
+
+### Policies
+
+| Model                 | Purpose                                                                                   |
+| --------------------- | ----------------------------------------------------------------------------------------- |
+| **Policy**            | Security policies with lifecycle status (draft, in_review, approved, published, retired). |
+| **PolicyVersion**     | Versioned snapshots of a policy document.                                                 |
+| **PolicyApproval**    | Approval records for policy versions.                                                     |
+| **PolicyReview**      | Scheduled review dates for policies.                                                      |
+| **PolicyControlLink** | Links policies to controls.                                                               |
+
+### Risk Management
+
+The risk module uses a three-ticket workflow: Risk (intake) -> RiskAssessment -> RiskTreatment.
+
+| Model                    | Purpose                                                                                                            |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| **Risk**                 | Risk intake tickets. Status follows the `RiskIntakeStatus` enum (risk_identified -> actual_risk -> risk_analyzed). |
+| **RiskAssessment**       | Assessment sub-ticket. Scores likelihood and impact, assigned to a risk assessor.                                  |
+| **RiskTreatment**        | Treatment sub-ticket. Tracks treatment decision (mitigate, accept, transfer, avoid) and progress.                  |
+| **RiskControl**          | Links risks to controls with effectiveness ratings.                                                                |
+| **RiskAsset**            | Links risks to assets.                                                                                             |
+| **RiskScenario**         | Scenario modeling attached to a risk.                                                                              |
+| **RiskScenarioTemplate** | Reusable scenario templates (e.g., "Ransomware Attack", "Data Breach").                                            |
+| **RiskWorkflowTask**     | Workflow tasks generated during risk processing, assigned to users.                                                |
+| **RiskConfiguration**    | Per-organization risk methodology settings (scales, thresholds, categories).                                       |
+| **RiskHistory**          | Audit trail of all changes to a risk.                                                                              |
+
+### TPRM (Third-Party Risk Management)
+
+| Model                   | Purpose                                                                          |
+| ----------------------- | -------------------------------------------------------------------------------- |
+| **Vendor**              | Third-party vendors with tier classification (tier_1 through tier_4) and status. |
+| **VendorAssessment**    | Security assessments of vendors. Tracks inherent and residual risk scores.       |
+| **VendorContract**      | Contract lifecycle (draft, active, expiring_soon, expired, terminated, renewed). |
+| **VendorContact**       | Contact information for vendor personnel.                                        |
+| **VendorRiskFinding**   | Risk findings from vendor assessments.                                           |
+| **VendorAccessReview**  | Periodic reviews of vendor access to systems and data.                           |
+| **VendorCertification** | Vendor compliance certifications with expiration tracking.                       |
+
+### Trust Module
+
+| Model                     | Purpose                                                                               |
+| ------------------------- | ------------------------------------------------------------------------------------- |
+| **QuestionnaireRequest**  | Inbound security questionnaire requests from customers/prospects.                     |
+| **QuestionnaireQuestion** | Individual questions within a questionnaire, with answers and knowledge base links.   |
+| **KnowledgeBaseEntry**    | Reusable answers for security questionnaires, categorized and versioned.              |
+| **TrustCenterConfig**     | Configuration for the public-facing trust center portal.                              |
+| **TrustCenterContent**    | Content sections for the trust center (overview, certifications, controls, policies). |
+| **AnswerTemplate**        | Pre-built answer templates for common security questions.                             |
+
+### Audit Management
+
+| Model               | Purpose                                                                            |
+| ------------------- | ---------------------------------------------------------------------------------- |
+| **Audit**           | Internal/external audits with type, status workflow, and framework scope.          |
+| **AuditRequest**    | Evidence and document requests from auditors, with assignment and status tracking. |
+| **AuditFinding**    | Audit findings with severity, status, and remediation tracking.                    |
+| **AuditTestResult** | Control testing results within an audit.                                           |
+| **AuditWorkpaper**  | Formal audit workpapers with version history.                                      |
+| **AuditPortalUser** | External auditor portal access with access codes and expiration.                   |
+| **AuditTemplate**   | Reusable audit templates with checklists.                                          |
+| **RemediationPlan** | Plans to address audit findings (POA&M), with milestones.                          |
+
+### Assets
+
+| Model     | Purpose                                                                                                                                                                |
+| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Asset** | IT assets (servers, workstations, mobile, network, applications, data). Tracked with criticality and data sensitivity. Can be linked to risks, vendors, and employees. |
+
+### Integrations
+
+| Model                                         | Purpose                                                                                            |
+| --------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| **Integration**                               | Third-party tool connections (AWS, Azure, GitHub, Okta, Jira, etc.). Stores encrypted credentials. |
+| **SyncJob**                                   | Integration sync execution history.                                                                |
+| **CustomIntegrationConfig**                   | Configuration for custom API integrations.                                                         |
+| **JiraConnection** / **ServiceNowConnection** | Dedicated connection configs for Jira and ServiceNow bi-directional sync.                          |
+| **ApiKey**                                    | API keys for programmatic access with scoped permissions.                                          |
+| **WebhookSubscription**                       | Outbound webhook subscriptions with event filtering.                                               |
+
+### Employee Compliance
+
+| Model                       | Purpose                                                         |
+| --------------------------- | --------------------------------------------------------------- |
+| **CorrelatedEmployee**      | Employee records correlated from HR, IdP, and MDM integrations. |
+| **EmployeeTrainingRecord**  | Training completion records from LMS integrations.              |
+| **EmployeeBackgroundCheck** | Background check status from HR integrations.                   |
+| **EmployeeAssetAssignment** | Device assignments from MDM (Jamf, Intune).                     |
+| **EmployeeAccessRecord**    | System access records from IdP (Okta, Azure AD).                |
+| **EmployeeSecurityScore**   | Composite security awareness score per employee.                |
+| **EmployeeAttestation**     | Policy acknowledgement records.                                 |
+
+### BCDR (Business Continuity / Disaster Recovery)
+
+| Model                       | Purpose                                                     |
+| --------------------------- | ----------------------------------------------------------- |
+| **BCDRIncident**            | BC/DR incidents and plan activations with timeline entries. |
+| **RecoveryTeam**            | Recovery teams with members and plan assignments.           |
+| **ExerciseTemplate**        | Templates for BC/DR exercises.                              |
+| **ProcessVendorDependency** | Vendor dependencies for business processes.                 |
+
+### Supporting Models
+
+| Model                                            | Purpose                                                                                                            |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| **Tag**                                          | Centralized tag registry. Entity-specific junction tables: ControlTag, EvidenceTag, PolicyTag, RiskTag, VendorTag. |
+| **Comment**                                      | Comments on any entity (polymorphic via entityType/entityId).                                                      |
+| **Task**                                         | Generic tasks linked to any entity.                                                                                |
+| **Notification**                                 | User notifications with read/unread tracking.                                                                      |
+| **AuditLog**                                     | System audit trail (all user actions, entity changes).                                                             |
+| **CalendarEvent**                                | Compliance calendar events (control tests, policy reviews, audit dates).                                           |
+| **ApprovalWorkflow**                             | Configurable approval workflows with multi-step approvals.                                                         |
+| **CustomFieldDefinition** / **CustomFieldValue** | User-defined custom fields on any entity type.                                                                     |
+| **Dashboard** / **DashboardWidget**              | User-configurable dashboards with widgets.                                                                         |
+| **ScheduledReport**                              | Automated report generation on a schedule.                                                                         |
+| **ConfigFile** / **ConfigFileVersion**           | Config-as-code file storage with version history.                                                                  |
+| **RetentionPolicy**                              | Data retention policies per entity type.                                                                           |
+| **ExportJob**                                    | Async data export jobs (CSV, PDF, JSON).                                                                           |
+
+## Key Enums
+
+| Enum                            | Values                                                                                                           |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| **UserRole**                    | admin, compliance_manager, auditor, viewer                                                                       |
+| **ControlImplementationStatus** | not_started, in_progress, implemented, not_applicable                                                            |
+| **PolicyStatus**                | draft, in_review, approved, published, retired                                                                   |
+| **RiskIntakeStatus**            | risk_identified, not_a_risk, actual_risk, risk_analysis_in_progress, risk_analyzed                               |
+| **RiskTreatmentDecision**       | mitigate, accept, transfer, avoid                                                                                |
+| **RiskLevel**                   | very_low, low, medium, high, very_high                                                                           |
+| **VendorTier**                  | tier_1, tier_2, tier_3, tier_4                                                                                   |
+| **VendorStatus**                | active, inactive, pending_onboarding, offboarding, terminated                                                    |
+| **AuditStatus**                 | planning, fieldwork, testing, reporting, completed, cancelled                                                    |
+| **AuditFindingStatus**          | open, acknowledged, remediation_planned, remediation_in_progress, resolved, accepted_risk                        |
+| **EvidenceStatus**              | pending_review, approved, rejected, expired                                                                      |
+| **FrameworkType**               | soc2, iso27001, hipaa, gdpr, pci_dss, nist_csf, nist_800_53, cis, fedramp, cmmc, ccpa, custom                    |
+| **IntegrationType**             | aws, azure, gcp, github, gitlab, okta, jira, slack, google_workspace, servicenow, jamf, intune, custom, and more |
+| **Priority**                    | low, medium, high, critical                                                                                      |
+| **Severity**                    | critical, high, medium, low, info, observation                                                                   |
+
+The full schema with all 62 enums and 130+ models is in `services/shared/prisma/schema.prisma`.
+
+## Multi-Tenancy
+
+All data is scoped to an **Organization**. Most queries filter by `organizationId`. Within an organization, **Workspaces** provide optional sub-scoping for multi-product teams.
+
+## Soft Deletes
+
+Most entities use soft deletion via a `deletedAt` timestamp field. Queries should filter `deletedAt: null` to exclude deleted records.
+
+## Audit Fields
+
+Most entities include standard audit fields: `createdAt`, `updatedAt`, `createdBy`, `updatedBy`.

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -37,6 +37,7 @@ That's it! The script handles everything: environment setup, Docker containers, 
 ```
 
 The script will ask what you want to do:
+
 - **Demo Mode** - One-click demo with sample data
 - **Dev Mode** - Set up for local development
 - **Docker Only** - Start all services in containers
@@ -94,7 +95,7 @@ Then start services manually:
 # Terminal 1 - Backend
 cd services/controls && npm run start:dev
 
-# Terminal 2 - Frontend  
+# Terminal 2 - Frontend
 cd frontend && npm run dev
 ```
 
@@ -110,13 +111,13 @@ Everything containerized:
 
 ## Access Points
 
-| Service | URL | Credentials |
-|---------|-----|-------------|
-| **Frontend** | http://localhost:3000 | Click "Dev Login" |
-| **API Docs** | http://localhost:3001/api/docs | - |
-| **Keycloak Admin** | http://localhost:8080 | admin / admin |
-| **RustFS Console** | http://localhost:9001 | rustfsadmin / (see .env) |
-| **Grafana** | http://localhost:3003 | admin / admin |
+| Service            | URL                            | Credentials              |
+| ------------------ | ------------------------------ | ------------------------ |
+| **Frontend**       | http://localhost:3000          | Click "Dev Login"        |
+| **API Docs**       | http://localhost:3001/api/docs | -                        |
+| **Keycloak Admin** | http://localhost:8080          | admin / admin            |
+| **RustFS Console** | http://localhost:9001          | rustfsadmin / (see .env) |
+| **Grafana**        | http://localhost:3003          | admin / admin            |
 
 ---
 
@@ -186,6 +187,7 @@ docker compose exec postgres pg_isready -U grc
 ```
 
 This removes:
+
 - All Docker containers and volumes
 - All `node_modules` directories
 - The `.env` file
@@ -202,7 +204,7 @@ This removes:
 
 ## Getting Help
 
-- 📖 [Full Documentation](./docs/)
+- 📖 [Full Documentation](./)
 - 🐛 [Troubleshooting Guide](./TROUBLESHOOTING.md)
 - 🚀 [Production Deployment](./PRODUCTION_DEPLOYMENT.md)
 - 💬 [GitHub Discussions](../../discussions)

--- a/docs/REMOTE_DEPLOYMENT.md
+++ b/docs/REMOTE_DEPLOYMENT.md
@@ -1,0 +1,182 @@
+# Remote / Non-Localhost Deployment Guide
+
+This guide covers deploying GigaChad GRC on a remote server, a VM, or a machine on your local network where users access it via IP address or hostname instead of `localhost`.
+
+## Overview
+
+When running GigaChad GRC on a remote machine, three things change compared to localhost:
+
+1. **CORS** -- The browser's origin (`http://192.168.1.50:3000`) must be allowed by backend services
+2. **Keycloak redirect URIs** -- Keycloak must know the correct frontend URL for OAuth callbacks
+3. **Frontend API URL** -- The frontend must know where to send API requests
+
+If any of these are misconfigured, you will see one of:
+
+- Keycloak redirect loop (page loads briefly then redirects to `localhost:8080/realms/...`)
+- CORS errors in the browser console (`Access-Control-Allow-Origin` missing)
+- API requests failing with `Failed to fetch`
+
+## Step 1: Determine Your Access URL
+
+Decide how users will access the platform:
+
+| Scenario      | Example URL                | Notes                            |
+| ------------- | -------------------------- | -------------------------------- |
+| Same machine  | `http://localhost:3000`    | Default, no changes needed       |
+| LAN IP        | `http://192.168.1.50:3000` | Other machines on same network   |
+| Hostname      | `http://grc.internal:3000` | Requires DNS or `/etc/hosts`     |
+| Public domain | `https://grc.example.com`  | Requires DNS, reverse proxy, TLS |
+
+## Step 2: Configure Environment Variables
+
+### `.env` file changes
+
+```bash
+# Replace YOUR_HOST with your IP or hostname
+# Examples: 192.168.1.50, grc.internal, grc.example.com
+
+# CORS: Allow the browser origin
+CORS_ORIGINS=http://YOUR_HOST:3000,http://localhost:3000
+
+# Frontend: Tell the frontend where the API is
+# Leave blank if using Traefik (requests go through same origin)
+VITE_API_URL=
+
+# Keycloak: Set the frontend URL for OAuth redirects
+KEYCLOAK_FRONTEND_URL=http://YOUR_HOST:8080
+
+# Dev Auth: Enable for local/demo use (skip Keycloak entirely)
+VITE_ENABLE_DEV_AUTH=true
+USE_DEV_AUTH=true
+```
+
+### Using Dev Auth (recommended for non-production)
+
+The simplest approach for demo or development on a remote machine is to use Dev Auth mode, which bypasses Keycloak entirely:
+
+1. Set `VITE_ENABLE_DEV_AUTH=true` and `USE_DEV_AUTH=true` in `.env`
+2. Rebuild the frontend: `docker compose up -d --build frontend`
+3. Access the platform and click "Dev Login"
+
+This avoids all Keycloak redirect URI and HTTPS configuration.
+
+### Using Keycloak (production)
+
+If you need Keycloak SSO for production use:
+
+1. Set up TLS/HTTPS (Keycloak requires HTTPS in production mode)
+2. Configure Keycloak realm redirect URIs (see Step 3)
+3. Set `VITE_ENABLE_DEV_AUTH=false` and `USE_DEV_AUTH=false`
+
+## Step 3: Configure Keycloak Redirect URIs
+
+If using Keycloak (not Dev Auth), you must update the allowed redirect URIs.
+
+### Option A: Edit the realm export before first start
+
+Edit `auth/realm-export.json` and find the `grc-frontend` client. Update `redirectUris` and `webOrigins`:
+
+```json
+{
+  "clientId": "grc-frontend",
+  "redirectUris": ["http://YOUR_HOST:3000/*", "http://localhost:3000/*"],
+  "webOrigins": ["http://YOUR_HOST:3000", "http://localhost:3000"]
+}
+```
+
+### Option B: Update via Keycloak Admin Console (after first start)
+
+1. Open `http://YOUR_HOST:8080` (Keycloak Admin Console)
+2. Log in with the credentials from your `.env` (`KEYCLOAK_ADMIN` / `KEYCLOAK_ADMIN_PASSWORD`)
+3. Select the `gigachad-grc` realm
+4. Go to **Clients** -> **grc-frontend**
+5. Under **Settings**:
+   - Add `http://YOUR_HOST:3000/*` to **Valid Redirect URIs**
+   - Add `http://YOUR_HOST:3000` to **Web Origins**
+6. Click **Save**
+
+## Step 4: Configure Docker Compose for Remote Access
+
+By default, ports bind to `127.0.0.1` (localhost only). To allow remote access, you need to bind to `0.0.0.0`.
+
+### Override port bindings
+
+Create a `docker-compose.override.yml`:
+
+```yaml
+services:
+  frontend:
+    ports:
+      - '0.0.0.0:3000:80'
+  keycloak:
+    ports:
+      - '0.0.0.0:8080:8080'
+  traefik:
+    ports:
+      - '0.0.0.0:80:80'
+      - '0.0.0.0:443:443'
+```
+
+Or modify the port bindings directly in `docker-compose.yml` by removing the `127.0.0.1:` prefix.
+
+> **Security warning:** Binding to `0.0.0.0` exposes services to your entire network. Use firewall rules to restrict access in production.
+
+## Step 5: Rebuild and Start
+
+```bash
+# Rebuild with new environment
+docker compose up -d --build
+
+# Verify services are accessible
+curl http://YOUR_HOST:3000    # Frontend
+curl http://YOUR_HOST:3001    # Controls API
+```
+
+## Firewall Configuration
+
+If running on a cloud VM or behind a firewall, open these ports:
+
+| Port      | Service               | Required                                                       |
+| --------- | --------------------- | -------------------------------------------------------------- |
+| 3000      | Frontend              | Yes                                                            |
+| 80/443    | Traefik (API Gateway) | Yes (if using Traefik routing)                                 |
+| 8080      | Keycloak              | Only if using Keycloak SSO                                     |
+| 3001-3007 | Backend services      | Only for direct API access (Traefik handles routing otherwise) |
+
+## Troubleshooting
+
+### Keycloak redirects to `localhost` instead of your IP
+
+Your Keycloak `KEYCLOAK_FRONTEND_URL` is not set or still points to localhost. Set it in `.env`:
+
+```
+KEYCLOAK_FRONTEND_URL=http://YOUR_HOST:8080
+```
+
+Then restart Keycloak: `docker compose restart keycloak`
+
+### CORS errors in browser console
+
+The browser origin is not in the `CORS_ORIGINS` list. Add your access URL:
+
+```
+CORS_ORIGINS=http://YOUR_HOST:3000,http://localhost:3000
+```
+
+Restart backend services: `docker compose restart controls frameworks policies tprm trust audit`
+
+### "Failed to fetch" on API calls
+
+The frontend cannot reach the backend API. Check:
+
+1. Backend services are running: `docker compose ps`
+2. If not using Traefik, set `VITE_API_URL=http://YOUR_HOST:3001` and rebuild the frontend
+3. If using Traefik, ensure port 80 is accessible from the client machine
+
+### Connection refused from another machine
+
+Ports are bound to `127.0.0.1`. See Step 4 to bind to `0.0.0.0`.
+
+### HTTPS required for production Keycloak
+
+Keycloak production mode requires HTTPS. For local/demo use, enable Dev Auth instead. For production, see the [SSL Configuration Guide](SSL_CONFIGURATION.md) and [Production Deployment Guide](PRODUCTION_DEPLOYMENT.md).

--- a/docs/help/deployment/cloud-deployment.md
+++ b/docs/help/deployment/cloud-deployment.md
@@ -7,6 +7,7 @@ GigaChad GRC can be deployed to the cloud using Supabase for database/storage an
 ### Option 1: Supabase + Vercel (Recommended)
 
 The recommended cloud deployment uses:
+
 - **Vercel** for frontend hosting and serverless API functions
 - **Supabase** for PostgreSQL database and file storage
 - **Okta** for enterprise SSO authentication
@@ -15,7 +16,7 @@ The recommended cloud deployment uses:
 
 ### Option 2: Docker Self-Hosted
 
-For organizations requiring on-premise deployment, GigaChad GRC supports Docker Compose deployment. See the [Self-Hosted Deployment Guide](self-hosted-deployment.md).
+For organizations requiring on-premise deployment, GigaChad GRC supports Docker Compose deployment. See the [Self-Hosted Deployment Guide](../../DEPLOYMENT.md).
 
 ---
 
@@ -73,16 +74,16 @@ Navigate to **Settings > Database** for connection strings:
 
 Configure these in Vercel Dashboard (**Settings > Environment Variables**):
 
-| Variable | Description |
-|----------|-------------|
-| `VITE_OKTA_ISSUER` | Your Okta authorization server URL |
-| `VITE_OKTA_CLIENT_ID` | Okta application client ID |
-| `DATABASE_URL` | Supabase pooled connection string |
-| `DIRECT_URL` | Supabase direct connection string |
-| `SUPABASE_URL` | Supabase project URL |
-| `SUPABASE_ANON_KEY` | Supabase anonymous key |
-| `SUPABASE_SERVICE_KEY` | Supabase service role key |
-| `ENCRYPTION_KEY` | 32-byte hex key for encryption |
+| Variable               | Description                        |
+| ---------------------- | ---------------------------------- |
+| `VITE_OKTA_ISSUER`     | Your Okta authorization server URL |
+| `VITE_OKTA_CLIENT_ID`  | Okta application client ID         |
+| `DATABASE_URL`         | Supabase pooled connection string  |
+| `DIRECT_URL`           | Supabase direct connection string  |
+| `SUPABASE_URL`         | Supabase project URL               |
+| `SUPABASE_ANON_KEY`    | Supabase anonymous key             |
+| `SUPABASE_SERVICE_KEY` | Supabase service role key          |
+| `ENCRYPTION_KEY`       | 32-byte hex key for encryption     |
 
 ### Step 5: Run Database Migrations
 
@@ -98,13 +99,13 @@ npx prisma migrate deploy
 
 Create these storage buckets in Supabase:
 
-| Bucket | Access | Purpose |
-|--------|--------|---------|
-| `evidence` | Private | Evidence files and documents |
-| `policies` | Private | Policy document storage |
-| `integrations` | Private | Integration configuration |
-| `questionnaires` | Private | Questionnaire attachments |
-| `trust-center` | Public | Trust center public assets |
+| Bucket           | Access  | Purpose                      |
+| ---------------- | ------- | ---------------------------- |
+| `evidence`       | Private | Evidence files and documents |
+| `policies`       | Private | Policy document storage      |
+| `integrations`   | Private | Integration configuration    |
+| `questionnaires` | Private | Questionnaire attachments    |
+| `trust-center`   | Public  | Trust center public assets   |
 
 ---
 
@@ -120,10 +121,12 @@ Create these storage buckets in Supabase:
 ## Monitoring & Logs
 
 ### Vercel Logs
+
 - Access via Vercel Dashboard > **Deployments > Logs**
 - Real-time function execution logs
 
 ### Supabase Logs
+
 - Access via Supabase Dashboard > **Logs**
 - Database query logs and performance metrics
 
@@ -142,14 +145,17 @@ Create these storage buckets in Supabase:
 ## Scaling Considerations
 
 ### Database
+
 - Supabase Pro supports up to 8GB database
 - For larger deployments, consider Supabase Enterprise
 
 ### API
+
 - Vercel Functions auto-scale based on traffic
 - Cold starts can be mitigated with Edge Functions
 
 ### Storage
+
 - Supabase Storage has no hard limits on Pro plan
 - Consider CDN for frequently accessed files
 
@@ -158,10 +164,11 @@ Create these storage buckets in Supabase:
 ## Support
 
 For deployment assistance:
+
 - Technical Documentation: `/docs/deployment/`
 - Community Support: GitHub Discussions
 - Enterprise Support: Contact your account manager
 
 ---
 
-*Last Updated: December 2025*
+_Last Updated: December 2025_

--- a/docs/help/getting-started/README.md
+++ b/docs/help/getting-started/README.md
@@ -46,12 +46,12 @@ Integrations automate evidence collection from your existing tools.
 
 ### Recommended First Integrations
 
-| Priority | Integration | Why |
-|----------|-------------|-----|
-| 1 | Cloud Provider (AWS/GCP/Azure) | Provides infrastructure security evidence |
-| 2 | Identity Provider (Okta/Azure AD) | Shows user access management |
-| 3 | Version Control (GitHub/GitLab) | Demonstrates secure development practices |
-| 4 | HR System (BambooHR/Workday) | Powers employee compliance tracking |
+| Priority | Integration                       | Why                                       |
+| -------- | --------------------------------- | ----------------------------------------- |
+| 1        | Cloud Provider (AWS/GCP/Azure)    | Provides infrastructure security evidence |
+| 2        | Identity Provider (Okta/Azure AD) | Shows user access management              |
+| 3        | Version Control (GitHub/GitLab)   | Demonstrates secure development practices |
+| 4        | HR System (BambooHR/Workday)      | Powers employee compliance tracking       |
 
 ### How to Connect
 
@@ -113,11 +113,11 @@ Your Trust Center is your public-facing security portal:
 
 Now that you're set up, explore these areas:
 
-- **[Managing Risks](/help/risk-management/creating-risks.md)** - Document and track security risks
-- **[Policy Management](/help/policies/creating-policies.md)** - Create and maintain security policies
-- **[Vendor Management](/help/vendors/vendor-assessment.md)** - Assess third-party vendor risks
-- **[Evidence Collection](/help/evidence/collecting-evidence.md)** - Automate compliance evidence
-- **[Preparing for Audits](/help/audits/preparing-for-audit.md)** - Get audit-ready
+- **[Managing Risks](../risk-management/creating-risks.md)** - Document and track security risks
+- **[Policy Management](../compliance/policies.md)** - Create and maintain security policies
+- **[Vendor Management](../vendors/vendor-assessment.md)** - Assess third-party vendor risks
+- **[Evidence Collection](../compliance/evidence.md)** - Automate compliance evidence
+- **[Preparing for Audits](../audit/overview.md)** - Get audit-ready
 
 ## Need Help?
 
@@ -127,5 +127,4 @@ Now that you're set up, explore these areas:
 
 ---
 
-*Last updated: December 2025*
-
+_Last updated: December 2025_

--- a/services/shared/README.md
+++ b/services/shared/README.md
@@ -1,0 +1,208 @@
+# @gigachad-grc/shared
+
+Shared library used by all GigaChad GRC microservices. Provides the unified Prisma schema, authentication, storage abstraction, event bus, utilities, and common types.
+
+## Installation
+
+All services reference this package via workspace dependencies:
+
+```json
+{
+  "dependencies": {
+    "@gigachad-grc/shared": "file:../shared"
+  }
+}
+```
+
+Build the shared library before building any service:
+
+```bash
+cd services/shared
+npm run build
+```
+
+## Modules
+
+### auth
+
+Authentication and authorization for all services.
+
+| Export                                                 | Purpose                                                                         |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------- |
+| `JwtAuthGuard`, `ApiKeyAuthGuard`, `CombinedAuthGuard` | NestJS guards for JWT tokens and API keys                                       |
+| `DevAuthGuard`                                         | Development-mode auth bypass (uses `x-user-id` and `x-organization-id` headers) |
+| `RolesGuard`, `PermissionsGuard`                       | RBAC enforcement guards                                                         |
+| `@Roles()`, `@RequirePermissions()`                    | Decorators for controller-level access control                                  |
+| `@CurrentUser()`, `@OrganizationId()`                  | Parameter decorators to extract user context from requests                      |
+| `KeycloakAdminService`                                 | Keycloak admin API client for user provisioning                                 |
+| `TokenBlacklistService`                                | Token revocation for logout                                                     |
+| `DEV_USER`, `ensureDevUserExists`                      | Dev mode user constants and database seeding                                    |
+
+### cache
+
+In-memory caching with TTL support.
+
+| Export         | Purpose                                         |
+| -------------- | ----------------------------------------------- |
+| `CacheModule`  | NestJS module (import into your service module) |
+| `CacheService` | Injectable service for get/set/delete/clear     |
+| `@Cacheable()` | Method decorator for automatic cache-through    |
+| `CacheKeys`    | Enum of standard cache key prefixes             |
+
+### storage
+
+Abstracted file storage with pluggable backends.
+
+| Export                    | Purpose                                                     |
+| ------------------------- | ----------------------------------------------------------- |
+| `StorageModule`           | NestJS module (import into your service module)             |
+| `STORAGE_PROVIDER`        | Injection token for the active storage provider             |
+| `StorageProvider`         | Interface: `upload()`, `download()`, `delete()`, `getUrl()` |
+| `LocalStorageProvider`    | Local filesystem backend                                    |
+| `S3StorageProvider`       | S3/RustFS/MinIO backend                                     |
+| `AzureBlobStorage`        | Azure Blob Storage backend                                  |
+| `createStorageProvider()` | Factory that reads `STORAGE_TYPE` from env                  |
+
+### events
+
+Cross-service event bus.
+
+| Export          | Purpose                         |
+| --------------- | ------------------------------- |
+| `EventsModule`  | NestJS module                   |
+| `EventBus`      | Interface for publish/subscribe |
+| `RedisEventBus` | Redis-backed implementation     |
+
+### secrets
+
+External secrets management for integration credentials.
+
+| Export            | Purpose                                                                        |
+| ----------------- | ------------------------------------------------------------------------------ |
+| `SecretsModule`   | NestJS module                                                                  |
+| `SecretsService`  | Injectable service for get/set/delete secrets                                  |
+| `SecretsProvider` | Interface for custom providers                                                 |
+| Providers         | `env` (AES-256-GCM encrypted in DB), `infisical` (Infisical cloud/self-hosted) |
+
+### security
+
+Request-level security utilities.
+
+| Export                                    | Purpose                                              |
+| ----------------------------------------- | ---------------------------------------------------- |
+| `safeFetch()`                             | SSRF-protected HTTP fetch (blocks private IPs)       |
+| `RateLimiterGuard`                        | Per-endpoint rate limiting                           |
+| `validatePropertyName()`, `safeOrderBy()` | Prevent injection via user-controlled property names |
+| `deepSanitizeObjectKeys()`                | Sanitize all keys in nested objects                  |
+
+### resilience
+
+Fault tolerance for external service calls.
+
+| Export                        | Purpose                                |
+| ----------------------------- | -------------------------------------- |
+| `CircuitBreaker`              | Circuit breaker pattern implementation |
+| `withRetry()`, `@Retryable()` | Retry with exponential backoff         |
+| `RetryPolicies`               | Pre-configured retry policies          |
+
+### utils
+
+General-purpose utilities used across all services.
+
+| Category           | Exports                                                                                   |
+| ------------------ | ----------------------------------------------------------------------------------------- |
+| **Crypto**         | `encrypt`, `decrypt`, `hashPassword`, `verifyPassword`, `generateApiKey`, `generateToken` |
+| **Validation**     | `isValidEmail`, `isValidUrl`, `isValidUuid`, `sanitizeString`, `sanitizeObject`           |
+| **Pagination**     | `createPaginatedResponse`, `parsePaginationParams`, `getPrismaSkipTake`                   |
+| **Sanitization**   | `sanitizeFilename`, `escapeHtml`, `sanitizeInput`                                         |
+| **Error handling** | `handleError`, `withErrorHandling`, `safeAsync`, `retryAsync`, `CatchErrors`              |
+| **Helpers**        | `generateId`, `sleep`, `retry`, `chunk`, `unique`, `groupBy`, `pick`, `omit`, `slugify`   |
+
+### types
+
+Shared TypeScript interfaces and DTOs.
+
+| Export                     | Purpose                                                                |
+| -------------------------- | ---------------------------------------------------------------------- |
+| `UserContext`              | Authenticated user context attached to requests                        |
+| `PaginatedResponse<T>`     | Standard paginated API response shape                                  |
+| `OrganizationScopedEntity` | Base interface for all org-scoped entities                             |
+| `AuditableEntity`          | Base interface with `createdAt`, `updatedAt`, `createdBy`, `updatedBy` |
+| `IntegrationCredentials`   | Typed credentials for each integration type                            |
+| `ConnectorConfig`          | Configuration shape for integration connectors                         |
+| Domain types               | `Dashboard`, `WidgetConfig`, workflow types, Prisma helpers            |
+
+### Other Modules
+
+| Module         | Purpose                                                                                                        |
+| -------------- | -------------------------------------------------------------------------------------------------------------- |
+| **logger**     | Structured logging with `getLogger()`, audit log helpers (`logAudit`), PII masking (`maskEmail`, `safeUserId`) |
+| **health**     | Health check module with `PrismaHealthIndicator` and `RedisHealthIndicator`                                    |
+| **filters**    | `GlobalExceptionFilter` that sanitizes error responses in production                                           |
+| **reports**    | PDF report generation (`PDFReportGenerator`) for compliance, risk, and framework reports                       |
+| **search**     | Generic search module that queries across Prisma models                                                        |
+| **watermark**  | PDF watermarking for secure document sharing                                                                   |
+| **decorators** | DTO sanitization decorators (`@SanitizeHtml`, `@SanitizeFileName`)                                             |
+| **middleware** | Express rate limiting middleware                                                                               |
+| **guards**     | Auth-specific rate limiting                                                                                    |
+| **session**    | Redis-backed session store                                                                                     |
+| **services**   | Service registry with circuit breaker state                                                                    |
+
+## Prisma Schema
+
+The unified database schema is at `prisma/schema.prisma`. All services share this schema.
+
+```bash
+# Generate Prisma client after schema changes
+npx prisma generate
+
+# Create a migration
+npx prisma migrate dev --name your_migration_name
+
+# Apply migrations (production)
+npx prisma migrate deploy
+
+# Reset database (destroys all data)
+npx prisma migrate reset --force
+```
+
+For schema documentation, see [Database Schema Reference](../../docs/DATABASE_SCHEMA.md).
+
+## Adding a New Service
+
+When creating a new microservice that uses the shared library:
+
+1. Add the dependency: `"@gigachad-grc/shared": "file:../shared"`
+2. Import modules in your NestJS app module:
+
+```typescript
+import { CacheModule, StorageModule, SecretsModule } from '@gigachad-grc/shared';
+
+@Module({
+  imports: [CacheModule, StorageModule, SecretsModule],
+})
+export class AppModule {}
+```
+
+3. Use guards and decorators in controllers:
+
+```typescript
+import {
+  JwtAuthGuard,
+  RequirePermissions,
+  CurrentUser,
+  OrganizationId,
+} from '@gigachad-grc/shared';
+
+@Controller('example')
+@UseGuards(JwtAuthGuard)
+export class ExampleController {
+  @Get()
+  @RequirePermissions('example:read')
+  findAll(@OrganizationId() orgId: string, @CurrentUser() user: UserContext) {
+    // orgId and user are extracted from the authenticated request
+  }
+}
+```
+
+4. Build shared before your service: `cd services/shared && npm run build`


### PR DESCRIPTION
## Summary

- **Rewrite README** with a single, clear quick-start path (`./start.sh`), explicit system requirements (Docker Desktop, 8 GB RAM, 4 cores, 10 GB disk), step-by-step login instructions, and a detailed Manual Setup alternative with exact `openssl` commands and a required environment variables checklist.
- **Add Troubleshooting section** covering the exact error messages reported in [Discussion #178](https://github.com/grcengineering/gigachad-grc/discussions/178) (`GRAFANA_ADMIN_USER is required`) and [Discussion #10](https://github.com/grcengineering/gigachad-grc/discussions/10) (Keycloak redirect loop, recharts initialization error).
- **Fix `.env.example`**: add missing `GRAFANA_ADMIN_USER` and `GRAFANA_ADMIN_PASSWORD`, correct `KEYCLOAK_REALM` from `grc` to `gigachad-grc`, correct `MINIO_ROOT_USER` from `minioadmin` to `rustfsadmin`.
- **Condense README** from 1,267 lines to 281 lines by moving the 800+ line module-by-module API endpoint documentation into a summary table that links to `docs/API.md`.

## Test Plan

- [x] Verify `.env.example` now includes all variables required by `docker-compose.yml` (`:?` syntax)
- [x] Verify `KEYCLOAK_REALM` and `MINIO_ROOT_USER` match `start.sh` and `docker-compose.yml`
- [x] Verify all linked documentation files exist (`GETTING_STARTED.md`, `docs/QUICK_START.md`, `docs/DEMO.md`, `docs/TROUBLESHOOTING.md`, etc.)
- [x] README renders correctly in GitHub markdown preview


Made with [Cursor](https://cursor.com)