### PR TITLE
feat: add Helm chart for Kubernetes deployment

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -16,6 +16,9 @@ coverage/
 playwright-report/
 test-results/
 
+# Helm templates (Go template syntax)
+helm/templates/
+
 # Security tool configs (special syntax)
 .semgrep/
 .gitleaks.toml

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -29,6 +29,7 @@ The simplest and most cost-effective deployment option uses Supabase for databas
 ### Detailed Guide
 
 For complete step-by-step instructions, see:
+
 - **[Supabase + Vercel Migration Guide](deployment/supabase-vercel-migration.md)** - Full technical documentation
 - **[Cloud Deployment Guide](help/deployment/cloud-deployment.md)** - User-friendly overview
 
@@ -59,6 +60,7 @@ ENCRYPTION_KEY=your-32-byte-hex-key
 ### Steps
 
 1. Clone and configure:
+
 ```bash
 git clone https://github.com/grcengineering/gigachad-grc.git
 cd gigachad-grc
@@ -66,11 +68,13 @@ cp env.example .env
 ```
 
 2. Start services:
+
 ```bash
 docker-compose up -d
 ```
 
 3. Initialize database:
+
 ```bash
 # Wait for services to be healthy
 docker-compose ps
@@ -83,6 +87,7 @@ docker-compose exec frameworks npm run seed
 ```
 
 4. Access services:
+
 - Frontend: http://localhost:3000
 - Keycloak: http://localhost:8080
 - Traefik Dashboard: http://localhost:8090
@@ -92,6 +97,7 @@ docker-compose exec frameworks npm run seed
 ### Security Hardening
 
 1. Update environment variables:
+
 ```bash
 # Generate strong passwords
 POSTGRES_PASSWORD=$(openssl rand -base64 32)
@@ -102,6 +108,7 @@ ENCRYPTION_KEY=$(openssl rand -base64 32)
 ```
 
 2. Create production compose file:
+
 ```yaml
 # docker-compose.prod.yml
 version: '3.8'
@@ -110,16 +117,16 @@ services:
   traefik:
     image: docker.io/dockerhardened/traefik:3
     command:
-      - "--providers.docker=true"
-      - "--providers.docker.exposedbydefault=false"
-      - "--entrypoints.web.address=:80"
-      - "--entrypoints.websecure.address=:443"
-      - "--certificatesresolvers.letsencrypt.acme.tlschallenge=true"
-      - "--certificatesresolvers.letsencrypt.acme.email=admin@yourdomain.com"
-      - "--certificatesresolvers.letsencrypt.acme.storage=/etc/traefik/acme.json"
+      - '--providers.docker=true'
+      - '--providers.docker.exposedbydefault=false'
+      - '--entrypoints.web.address=:80'
+      - '--entrypoints.websecure.address=:443'
+      - '--certificatesresolvers.letsencrypt.acme.tlschallenge=true'
+      - '--certificatesresolvers.letsencrypt.acme.email=admin@yourdomain.com'
+      - '--certificatesresolvers.letsencrypt.acme.storage=/etc/traefik/acme.json'
     ports:
-      - "80:80"
-      - "443:443"
+      - '80:80'
+      - '443:443'
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - traefik_certs:/etc/traefik
@@ -139,7 +146,7 @@ services:
       - grc-network
     restart: always
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER}']
       interval: 10s
       timeout: 5s
       retries: 5
@@ -158,6 +165,7 @@ networks:
 ```
 
 3. Deploy:
+
 ```bash
 docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 ```
@@ -165,12 +173,13 @@ docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 ### TLS Configuration
 
 Add to Traefik labels for each service:
+
 ```yaml
 labels:
-  - "traefik.enable=true"
-  - "traefik.http.routers.myservice.rule=Host(`api.yourdomain.com`)"
-  - "traefik.http.routers.myservice.entrypoints=websecure"
-  - "traefik.http.routers.myservice.tls.certresolver=letsencrypt"
+  - 'traefik.enable=true'
+  - 'traefik.http.routers.myservice.rule=Host(`api.yourdomain.com`)'
+  - 'traefik.http.routers.myservice.entrypoints=websecure'
+  - 'traefik.http.routers.myservice.tls.certresolver=letsencrypt'
 ```
 
 ### Backup Strategy
@@ -189,95 +198,127 @@ docker run --rm -v gigachad-grc_postgres_data:/data -v $(pwd):/backup alpine tar
 
 ## Kubernetes
 
-### Helm Chart Structure
+A Helm chart is included at `helm/` for deploying GigaChad GRC to Kubernetes.
+
+### Prerequisites
+
+- Kubernetes 1.24+
+- Helm 3.x
+- Container images pushed to a registry accessible from your cluster
+
+### Quick Deploy
+
+```bash
+kubectl create namespace gigachad-grc
+
+helm install gigachad-grc ./helm \
+  -n gigachad-grc \
+  --set postgresql.auth.password="$(openssl rand -base64 24)" \
+  --set redis.auth.password="$(openssl rand -base64 24)" \
+  --set keycloak.auth.adminPassword="$(openssl rand -base64 24)" \
+  --set rustfs.auth.rootPassword="$(openssl rand -base64 24)" \
+  --set controls.env.encryptionKey="$(openssl rand -hex 32)" \
+  --set controls.env.phishingTrackingSecret="$(openssl rand -base64 24)"
+```
+
+### Using a Custom Values File
+
+Create a `my-values.yaml` to override defaults:
+
+```yaml
+global:
+  imageRegistry: 'ghcr.io/your-org'
+
+controls:
+  replicaCount: 2
+  image:
+    tag: 'v1.0.0'
+
+ingress:
+  enabled: true
+  className: nginx
+  host: grc.yourdomain.com
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  tls:
+    enabled: true
+    secretName: grc-tls
+
+frontend:
+  devAuth: 'false'
+```
+
+```bash
+helm install gigachad-grc ./helm -n gigachad-grc -f my-values.yaml
+```
+
+### Using External Infrastructure
+
+To use existing PostgreSQL, Redis, or S3 instead of the chart-managed instances:
+
+```yaml
+postgresql:
+  enabled: false
+externalDatabase:
+  url: 'postgresql://grc:password@your-rds.amazonaws.com:5432/gigachad_grc'
+
+redis:
+  enabled: false
+externalRedis:
+  url: 'redis://:password@your-elasticache.amazonaws.com:6379'
+
+rustfs:
+  enabled: false
+externalS3:
+  endpoint: 's3.amazonaws.com'
+  port: '443'
+  useSSL: 'true'
+  accessKey: 'AKIAIOSFODNN7EXAMPLE'
+  secretKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
+  bucket: 'grc-evidence'
+```
+
+### Chart Structure
 
 ```
 helm/
 ├── Chart.yaml
 ├── values.yaml
-├── templates/
-│   ├── _helpers.tpl
-│   ├── configmap.yaml
-│   ├── secret.yaml
-│   ├── deployment-controls.yaml
-│   ├── deployment-frameworks.yaml
-│   ├── deployment-frontend.yaml
-│   ├── service-controls.yaml
-│   ├── service-frameworks.yaml
-│   ├── service-frontend.yaml
-│   ├── ingress.yaml
-│   └── pvc.yaml
+└── templates/
+    ├── _helpers.tpl
+    ├── NOTES.txt
+    ├── secret.yaml
+    ├── serviceaccount.yaml
+    ├── ingress.yaml
+    ├── postgresql.yaml          # Optional StatefulSet
+    ├── redis.yaml               # Optional StatefulSet
+    ├── keycloak.yaml            # Optional Deployment
+    ├── rustfs.yaml              # Optional StatefulSet
+    ├── deployment-controls.yaml
+    ├── deployment-frameworks.yaml
+    ├── deployment-policies.yaml
+    ├── deployment-tprm.yaml
+    ├── deployment-trust.yaml
+    ├── deployment-audit.yaml
+    ├── deployment-frontend.yaml
+    ├── prometheus.yaml          # Optional
+    └── grafana.yaml             # Optional
 ```
 
-### Sample values.yaml
+### Monitoring
+
+Prometheus and Grafana are disabled by default. Enable them with:
 
 ```yaml
-# values.yaml
-replicaCount: 2
-
-image:
-  repository: your-registry/gigachad-grc
-  tag: latest
-  pullPolicy: Always
-
-database:
-  host: postgres.default.svc.cluster.local
-  port: 5432
-  name: gigachad_grc
-
-redis:
-  host: redis.default.svc.cluster.local
-  port: 6379
-
-keycloak:
-  url: https://auth.yourdomain.com
-  realm: gigachad-grc
-  clientId: grc-frontend
-
-rustfs:
-  endpoint: rustfs.default.svc.cluster.local
-  port: 9000
-  bucket: grc-evidence
-
-ingress:
+prometheus:
   enabled: true
-  className: nginx
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-  hosts:
-    - host: grc.yourdomain.com
-      paths:
-        - path: /
-          pathType: Prefix
-  tls:
-    - secretName: grc-tls
-      hosts:
-        - grc.yourdomain.com
-
-resources:
-  limits:
-    cpu: 500m
-    memory: 512Mi
-  requests:
-    cpu: 100m
-    memory: 256Mi
+grafana:
+  enabled: true
+  auth:
+    adminPassword: 'your-grafana-password'
 ```
 
-### Deploy to Kubernetes
-
-```bash
-# Create namespace
-kubectl create namespace gigachad-grc
-
-# Create secrets
-kubectl create secret generic grc-secrets \
-  --from-literal=POSTGRES_PASSWORD=your-password \
-  --from-literal=REDIS_PASSWORD=your-password \
-  -n gigachad-grc
-
-# Install with Helm
-helm install gigachad-grc ./helm -n gigachad-grc -f values.yaml
-```
+For full configuration options, see `helm/values.yaml`.
 
 ## Module Extraction
 
@@ -286,6 +327,7 @@ Each service can be deployed independently.
 ### Extract Controls Service
 
 1. Copy necessary files:
+
 ```bash
 mkdir my-controls-service
 cp -r services/controls/* my-controls-service/
@@ -294,6 +336,7 @@ cp services/shared/prisma/schema.prisma my-controls-service/prisma/
 ```
 
 2. Update Dockerfile:
+
 ```dockerfile
 FROM node:20-alpine
 
@@ -318,6 +361,7 @@ CMD ["node", "dist/main"]
 ```
 
 3. Configure environment:
+
 ```env
 DATABASE_URL=postgresql://user:pass@host:5432/db
 REDIS_URL=redis://host:6379
@@ -327,6 +371,7 @@ MINIO_ENDPOINT=storage.yourdomain.com
 ```
 
 4. Build and run:
+
 ```bash
 docker build -t my-controls-service .
 docker run -p 3001:3001 --env-file .env my-controls-service
@@ -346,12 +391,14 @@ npx prisma migrate dev --name controls-init --schema=./prisma/schema-controls.pr
 ### Health Checks
 
 Each service exposes health endpoints:
+
 - `GET /health` - Basic health check
 - `GET /health/ready` - Readiness (includes DB connection)
 
 ### Prometheus Metrics
 
 Add to each service:
+
 ```typescript
 // main.ts
 import { PrometheusModule } from '@willsoto/nestjs-prometheus';
@@ -366,6 +413,7 @@ import { PrometheusModule } from '@willsoto/nestjs-prometheus';
 ### Logging
 
 Configure structured logging:
+
 ```typescript
 // Use the shared logger
 import { getLogger } from '@gigachad-grc/shared';
@@ -379,6 +427,7 @@ logger.info('Service started', { port: 3001 });
 ### Common Issues
 
 **Database connection failed:**
+
 ```bash
 # Check if postgres is running
 docker-compose ps postgres
@@ -391,12 +440,14 @@ docker-compose exec postgres psql -U grc -d gigachad_grc
 ```
 
 **Keycloak not redirecting:**
+
 ```bash
 # Check Keycloak realm configuration
 # Ensure redirect URIs match your frontend URL
 ```
 
 **RustFS/S3 access denied:**
+
 ```bash
 # Verify RustFS is running
 docker-compose ps rustfs
@@ -434,6 +485,3 @@ docker-compose down -v
 docker-compose build --no-cache
 docker-compose up -d
 ```
-
-
-

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: gigachad-grc
+description: A comprehensive Governance, Risk, and Compliance (GRC) platform
+type: application
+version: 0.1.0
+appVersion: '1.0.0'
+home: https://github.com/grcengineering/gigachad-grc
+sources:
+  - https://github.com/grcengineering/gigachad-grc
+maintainers:
+  - name: GRC Engineering
+    url: https://github.com/grcengineering
+keywords:
+  - grc
+  - governance
+  - risk
+  - compliance
+  - security
+  - soc2
+  - iso27001

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,0 +1,38 @@
+GigaChad GRC has been deployed to namespace {{ .Release.Namespace }}.
+
+{{- if .Values.ingress.enabled }}
+
+Access the platform at:
+  {{- if .Values.ingress.tls.enabled }}
+  https://{{ .Values.ingress.host }}
+  {{- else }}
+  http://{{ .Values.ingress.host }}
+  {{- end }}
+{{- else }}
+
+To access the frontend, run:
+  kubectl port-forward svc/{{ include "gigachad-grc.fullname" . }}-frontend 3000:80 -n {{ .Release.Namespace }}
+  Then open http://localhost:3000
+
+To access the Controls API (Swagger):
+  kubectl port-forward svc/{{ include "gigachad-grc.fullname" . }}-controls 3001:{{ .Values.controls.port }} -n {{ .Release.Namespace }}
+  Then open http://localhost:3001/api/docs
+{{- end }}
+
+{{- if .Values.keycloak.enabled }}
+
+Keycloak Admin Console:
+  kubectl port-forward svc/{{ include "gigachad-grc.fullname" . }}-keycloak 8080:8080 -n {{ .Release.Namespace }}
+  Then open http://localhost:8080
+  Username: {{ .Values.keycloak.auth.adminUser }}
+  Password: (set in your values file)
+{{- end }}
+
+Deployed services:
+  {{- if .Values.controls.enabled }}  - Controls  (port {{ .Values.controls.port }}){{ end }}
+  {{- if .Values.frameworks.enabled }}  - Frameworks (port {{ .Values.frameworks.port }}){{ end }}
+  {{- if .Values.policies.enabled }}  - Policies  (port {{ .Values.policies.port }}){{ end }}
+  {{- if .Values.tprm.enabled }}  - TPRM      (port {{ .Values.tprm.port }}){{ end }}
+  {{- if .Values.trust.enabled }}  - Trust     (port {{ .Values.trust.port }}){{ end }}
+  {{- if .Values.audit.enabled }}  - Audit     (port {{ .Values.audit.port }}){{ end }}
+  {{- if .Values.frontend.enabled }}  - Frontend  (port 80){{ end }}

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -62,6 +62,14 @@ Usage: {{ include "gigachad-grc.image" (dict "image" .Values.controls.image "glo
 {{- end }}
 
 {{/*
+Image pull policy: use Always if tag is "latest", otherwise use the configured policy.
+Usage: {{ include "gigachad-grc.imagePullPolicy" .Values.controls.image }}
+*/}}
+{{- define "gigachad-grc.imagePullPolicy" -}}
+{{- if eq .tag "latest" }}Always{{- else }}{{ .pullPolicy | default "IfNotPresent" }}{{- end }}
+{{- end }}
+
+{{/*
 Service account name.
 */}}
 {{- define "gigachad-grc.serviceAccountName" -}}

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,0 +1,231 @@
+{{/*
+Chart name, truncated to 63 characters.
+*/}}
+{{- define "gigachad-grc.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Fully qualified app name, truncated to 63 characters.
+*/}}
+{{- define "gigachad-grc.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Chart label value.
+*/}}
+{{- define "gigachad-grc.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels applied to all resources.
+*/}}
+{{- define "gigachad-grc.labels" -}}
+helm.sh/chart: {{ include "gigachad-grc.chart" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: gigachad-grc
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+
+{{/*
+Selector labels for a specific component.
+Usage: {{ include "gigachad-grc.selectorLabels" (dict "context" . "component" "controls") }}
+*/}}
+{{- define "gigachad-grc.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "gigachad-grc.name" .context }}
+app.kubernetes.io/instance: {{ .context.Release.Name }}
+app.kubernetes.io/component: {{ .component }}
+{{- end }}
+
+{{/*
+Full image reference with optional global registry prefix.
+Usage: {{ include "gigachad-grc.image" (dict "image" .Values.controls.image "global" .Values.global) }}
+*/}}
+{{- define "gigachad-grc.image" -}}
+{{- $registry := .global.imageRegistry | default "" -}}
+{{- if $registry }}
+{{- printf "%s/%s:%s" $registry .image.repository .image.tag }}
+{{- else }}
+{{- printf "%s:%s" .image.repository .image.tag }}
+{{- end }}
+{{- end }}
+
+{{/*
+Service account name.
+*/}}
+{{- define "gigachad-grc.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "gigachad-grc.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+PostgreSQL host: internal service or external.
+*/}}
+{{- define "gigachad-grc.postgresql.host" -}}
+{{- if .Values.postgresql.enabled }}
+{{- printf "%s-postgresql" (include "gigachad-grc.fullname" .) }}
+{{- else }}
+{{- .Values.externalDatabase.host | default "localhost" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Full DATABASE_URL connection string.
+*/}}
+{{- define "gigachad-grc.databaseUrl" -}}
+{{- if .Values.externalDatabase.url }}
+{{- .Values.externalDatabase.url }}
+{{- else }}
+{{- printf "postgresql://%s:$(POSTGRES_PASSWORD)@%s:5432/%s" .Values.postgresql.auth.username (include "gigachad-grc.postgresql.host" .) .Values.postgresql.auth.database }}
+{{- end }}
+{{- end }}
+
+{{/*
+Redis host: internal service or external.
+*/}}
+{{- define "gigachad-grc.redis.host" -}}
+{{- if .Values.redis.enabled }}
+{{- printf "%s-redis" (include "gigachad-grc.fullname" .) }}
+{{- else }}
+{{- .Values.externalRedis.host | default "localhost" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Full REDIS_URL connection string.
+*/}}
+{{- define "gigachad-grc.redisUrl" -}}
+{{- if .Values.externalRedis.url }}
+{{- .Values.externalRedis.url }}
+{{- else }}
+{{- printf "redis://:$(REDIS_PASSWORD)@%s:6379" (include "gigachad-grc.redis.host" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Keycloak internal URL.
+*/}}
+{{- define "gigachad-grc.keycloak.url" -}}
+{{- printf "http://%s-keycloak:8080" (include "gigachad-grc.fullname" .) }}
+{{- end }}
+
+{{/*
+RustFS / S3 endpoint.
+*/}}
+{{- define "gigachad-grc.s3.endpoint" -}}
+{{- if .Values.rustfs.enabled }}
+{{- printf "%s-rustfs" (include "gigachad-grc.fullname" .) }}
+{{- else }}
+{{- .Values.externalS3.endpoint }}
+{{- end }}
+{{- end }}
+
+{{/*
+S3 port.
+*/}}
+{{- define "gigachad-grc.s3.port" -}}
+{{- if .Values.rustfs.enabled }}
+{{- "9000" }}
+{{- else }}
+{{- .Values.externalS3.port | default "443" }}
+{{- end }}
+{{- end }}
+
+{{/*
+S3 SSL setting.
+*/}}
+{{- define "gigachad-grc.s3.useSSL" -}}
+{{- if .Values.rustfs.enabled }}
+{{- "false" }}
+{{- else }}
+{{- .Values.externalS3.useSSL | default "true" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Secret name for the chart.
+*/}}
+{{- define "gigachad-grc.secretName" -}}
+{{- printf "%s-secrets" (include "gigachad-grc.fullname" .) }}
+{{- end }}
+
+{{/*
+ConfigMap name for the chart.
+*/}}
+{{- define "gigachad-grc.configMapName" -}}
+{{- printf "%s-config" (include "gigachad-grc.fullname" .) }}
+{{- end }}
+
+{{/*
+Common environment variables injected into all backend services.
+*/}}
+{{- define "gigachad-grc.backendEnv" -}}
+- name: NODE_ENV
+  value: production
+- name: POSTGRES_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "gigachad-grc.secretName" . }}
+      key: postgresql-password
+- name: DATABASE_URL
+  value: {{ include "gigachad-grc.databaseUrl" . }}
+- name: REDIS_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "gigachad-grc.secretName" . }}
+      key: redis-password
+- name: REDIS_URL
+  value: {{ include "gigachad-grc.redisUrl" . }}
+- name: S3_ENDPOINT
+  value: {{ include "gigachad-grc.s3.endpoint" . }}
+- name: S3_PORT
+  value: {{ include "gigachad-grc.s3.port" . | quote }}
+- name: S3_USE_SSL
+  value: {{ include "gigachad-grc.s3.useSSL" . | quote }}
+- name: S3_ACCESS_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "gigachad-grc.secretName" . }}
+      key: s3-access-key
+- name: S3_SECRET_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "gigachad-grc.secretName" . }}
+      key: s3-secret-key
+- name: MINIO_ENDPOINT
+  value: {{ include "gigachad-grc.s3.endpoint" . }}
+- name: MINIO_PORT
+  value: {{ include "gigachad-grc.s3.port" . | quote }}
+- name: MINIO_USE_SSL
+  value: {{ include "gigachad-grc.s3.useSSL" . | quote }}
+- name: MINIO_ACCESS_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "gigachad-grc.secretName" . }}
+      key: s3-access-key
+- name: MINIO_SECRET_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "gigachad-grc.secretName" . }}
+      key: s3-secret-key
+{{- if .Values.keycloak.enabled }}
+- name: KEYCLOAK_URL
+  value: {{ include "gigachad-grc.keycloak.url" . }}
+- name: KEYCLOAK_REALM
+  value: {{ .Values.keycloak.realm | quote }}
+{{- end }}
+{{- end }}

--- a/helm/templates/deployment-audit.yaml
+++ b/helm/templates/deployment-audit.yaml
@@ -1,0 +1,89 @@
+{{- if .Values.audit.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "gigachad-grc.fullname" . }}-audit
+  labels:
+    {{- include "gigachad-grc.labels" . | nindent 4 }}
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "audit") | nindent 4 }}
+spec:
+  replicas: {{ .Values.audit.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "audit") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "gigachad-grc.labels" . | nindent 8 }}
+        {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "audit") | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "gigachad-grc.serviceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: audit
+          image: {{ include "gigachad-grc.image" (dict "image" .Values.audit.image "global" .Values.global) }}
+          imagePullPolicy: {{ .Values.audit.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+          ports:
+            - containerPort: {{ .Values.audit.port }}
+              name: http
+              protocol: TCP
+          env:
+            - name: PORT
+              value: {{ .Values.audit.port | quote }}
+            {{- include "gigachad-grc.backendEnv" . | nindent 12 }}
+            {{- with .Values.audit.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+          resources:
+            {{- toYaml .Values.audit.resources | nindent 12 }}
+      {{- with .Values.audit.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.audit.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.audit.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gigachad-grc.fullname" . }}-audit
+  labels:
+    {{- include "gigachad-grc.labels" . | nindent 4 }}
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "audit") | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.audit.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "audit") | nindent 4 }}
+{{- end }}

--- a/helm/templates/deployment-audit.yaml
+++ b/helm/templates/deployment-audit.yaml
@@ -27,9 +27,13 @@ spec:
       containers:
         - name: audit
           image: {{ include "gigachad-grc.image" (dict "image" .Values.audit.image "global" .Values.global) }}
-          imagePullPolicy: {{ .Values.audit.image.pullPolicy }}
+          imagePullPolicy: {{ include "gigachad-grc.imagePullPolicy" .Values.audit.image }}
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           ports:
             - containerPort: {{ .Values.audit.port }}
               name: http
@@ -57,6 +61,14 @@ spec:
             timeoutSeconds: 5
           resources:
             {{- toYaml .Values.audit.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 64Mi
       {{- with .Values.audit.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/templates/deployment-controls.yaml
+++ b/helm/templates/deployment-controls.yaml
@@ -27,9 +27,13 @@ spec:
       containers:
         - name: controls
           image: {{ include "gigachad-grc.image" (dict "image" .Values.controls.image "global" .Values.global) }}
-          imagePullPolicy: {{ .Values.controls.image.pullPolicy }}
+          imagePullPolicy: {{ include "gigachad-grc.imagePullPolicy" .Values.controls.image }}
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           ports:
             - containerPort: {{ .Values.controls.port }}
               name: http
@@ -49,13 +53,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "gigachad-grc.secretName" . }}
                   key: jwt-secret
-                  optional: true
             - name: SESSION_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ include "gigachad-grc.secretName" . }}
                   key: session-secret
-                  optional: true
             - name: PHISHING_TRACKING_SECRET
               valueFrom:
                 secretKeyRef:
@@ -89,6 +91,14 @@ spec:
             timeoutSeconds: 5
           resources:
             {{- toYaml .Values.controls.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 64Mi
       {{- with .Values.controls.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/templates/deployment-controls.yaml
+++ b/helm/templates/deployment-controls.yaml
@@ -1,0 +1,121 @@
+{{- if .Values.controls.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "gigachad-grc.fullname" . }}-controls
+  labels:
+    {{- include "gigachad-grc.labels" . | nindent 4 }}
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "controls") | nindent 4 }}
+spec:
+  replicas: {{ .Values.controls.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "controls") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "gigachad-grc.labels" . | nindent 8 }}
+        {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "controls") | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "gigachad-grc.serviceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: controls
+          image: {{ include "gigachad-grc.image" (dict "image" .Values.controls.image "global" .Values.global) }}
+          imagePullPolicy: {{ .Values.controls.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+          ports:
+            - containerPort: {{ .Values.controls.port }}
+              name: http
+              protocol: TCP
+          env:
+            - name: PORT
+              value: {{ .Values.controls.port | quote }}
+            {{- include "gigachad-grc.backendEnv" . | nindent 12 }}
+            - name: ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "gigachad-grc.secretName" . }}
+                  key: encryption-key
+                  optional: true
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "gigachad-grc.secretName" . }}
+                  key: jwt-secret
+                  optional: true
+            - name: SESSION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "gigachad-grc.secretName" . }}
+                  key: session-secret
+                  optional: true
+            - name: PHISHING_TRACKING_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "gigachad-grc.secretName" . }}
+                  key: phishing-tracking-secret
+                  optional: true
+            - name: BACKUP_RETENTION_DAYS
+              value: {{ .Values.controls.env.backupRetentionDays | quote }}
+            - name: DR_REMOTE_BACKUP_ENABLED
+              value: {{ .Values.controls.env.drRemoteBackupEnabled | quote }}
+            {{- if .Values.controls.env.drRemoteBackupS3Bucket }}
+            - name: DR_REMOTE_BACKUP_S3_BUCKET
+              value: {{ .Values.controls.env.drRemoteBackupS3Bucket | quote }}
+            {{- end }}
+            {{- with .Values.controls.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+          resources:
+            {{- toYaml .Values.controls.resources | nindent 12 }}
+      {{- with .Values.controls.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controls.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controls.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gigachad-grc.fullname" . }}-controls
+  labels:
+    {{- include "gigachad-grc.labels" . | nindent 4 }}
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "controls") | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.controls.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "controls") | nindent 4 }}
+{{- end }}

--- a/helm/templates/deployment-frameworks.yaml
+++ b/helm/templates/deployment-frameworks.yaml
@@ -1,0 +1,89 @@
+{{- if .Values.frameworks.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "gigachad-grc.fullname" . }}-frameworks
+  labels:
+    {{- include "gigachad-grc.labels" . | nindent 4 }}
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "frameworks") | nindent 4 }}
+spec:
+  replicas: {{ .Values.frameworks.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "frameworks") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "gigachad-grc.labels" . | nindent 8 }}
+        {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "frameworks") | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "gigachad-grc.serviceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: frameworks
+          image: {{ include "gigachad-grc.image" (dict "image" .Values.frameworks.image "global" .Values.global) }}
+          imagePullPolicy: {{ .Values.frameworks.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+          ports:
+            - containerPort: {{ .Values.frameworks.port }}
+              name: http
+              protocol: TCP
+          env:
+            - name: PORT
+              value: {{ .Values.frameworks.port | quote }}
+            {{- include "gigachad-grc.backendEnv" . | nindent 12 }}
+            {{- with .Values.frameworks.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+          resources:
+            {{- toYaml .Values.frameworks.resources | nindent 12 }}
+      {{- with .Values.frameworks.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.frameworks.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.frameworks.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gigachad-grc.fullname" . }}-frameworks
+  labels:
+    {{- include "gigachad-grc.labels" . | nindent 4 }}
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "frameworks") | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.frameworks.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "frameworks") | nindent 4 }}
+{{- end }}

--- a/helm/templates/deployment-frameworks.yaml
+++ b/helm/templates/deployment-frameworks.yaml
@@ -27,9 +27,13 @@ spec:
       containers:
         - name: frameworks
           image: {{ include "gigachad-grc.image" (dict "image" .Values.frameworks.image "global" .Values.global) }}
-          imagePullPolicy: {{ .Values.frameworks.image.pullPolicy }}
+          imagePullPolicy: {{ include "gigachad-grc.imagePullPolicy" .Values.frameworks.image }}
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           ports:
             - containerPort: {{ .Values.frameworks.port }}
               name: http
@@ -57,6 +61,14 @@ spec:
             timeoutSeconds: 5
           resources:
             {{- toYaml .Values.frameworks.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 64Mi
       {{- with .Values.frameworks.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/templates/deployment-frontend.yaml
+++ b/helm/templates/deployment-frontend.yaml
@@ -1,0 +1,88 @@
+{{- if .Values.frontend.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "gigachad-grc.fullname" . }}-frontend
+  labels:
+    {{- include "gigachad-grc.labels" . | nindent 4 }}
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "frontend") | nindent 4 }}
+spec:
+  replicas: {{ .Values.frontend.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "frontend") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "gigachad-grc.labels" . | nindent 8 }}
+        {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "frontend") | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "gigachad-grc.serviceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: frontend
+          image: {{ include "gigachad-grc.image" (dict "image" .Values.frontend.image "global" .Values.global) }}
+          imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+          ports:
+            - containerPort: {{ .Values.frontend.port }}
+              name: http
+              protocol: TCP
+          env:
+            - name: VITE_ENABLE_DEV_AUTH
+              value: {{ .Values.frontend.devAuth | quote }}
+            {{- with .Values.frontend.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 3
+          resources:
+            {{- toYaml .Values.frontend.resources | nindent 12 }}
+      {{- with .Values.frontend.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.frontend.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.frontend.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gigachad-grc.fullname" . }}-frontend
+  labels:
+    {{- include "gigachad-grc.labels" . | nindent 4 }}
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "frontend") | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "frontend") | nindent 4 }}
+{{- end }}

--- a/helm/templates/deployment-frontend.yaml
+++ b/helm/templates/deployment-frontend.yaml
@@ -27,9 +27,12 @@ spec:
       containers:
         - name: frontend
           image: {{ include "gigachad-grc.image" (dict "image" .Values.frontend.image "global" .Values.global) }}
-          imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
+          imagePullPolicy: {{ include "gigachad-grc.imagePullPolicy" .Values.frontend.image }}
           securityContext:
             allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           ports:
             - containerPort: {{ .Values.frontend.port }}
               name: http

--- a/helm/templates/deployment-policies.yaml
+++ b/helm/templates/deployment-policies.yaml
@@ -27,9 +27,13 @@ spec:
       containers:
         - name: policies
           image: {{ include "gigachad-grc.image" (dict "image" .Values.policies.image "global" .Values.global) }}
-          imagePullPolicy: {{ .Values.policies.image.pullPolicy }}
+          imagePullPolicy: {{ include "gigachad-grc.imagePullPolicy" .Values.policies.image }}
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           ports:
             - containerPort: {{ .Values.policies.port }}
               name: http
@@ -57,6 +61,14 @@ spec:
             timeoutSeconds: 5
           resources:
             {{- toYaml .Values.policies.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 64Mi
       {{- with .Values.policies.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/templates/deployment-policies.yaml
+++ b/helm/templates/deployment-policies.yaml
@@ -1,0 +1,89 @@
+{{- if .Values.policies.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "gigachad-grc.fullname" . }}-policies
+  labels:
+    {{- include "gigachad-grc.labels" . | nindent 4 }}
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "policies") | nindent 4 }}
+spec:
+  replicas: {{ .Values.policies.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "policies") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "gigachad-grc.labels" . | nindent 8 }}
+        {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "policies") | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "gigachad-grc.serviceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: policies
+          image: {{ include "gigachad-grc.image" (dict "image" .Values.policies.image "global" .Values.global) }}
+          imagePullPolicy: {{ .Values.policies.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+          ports:
+            - containerPort: {{ .Values.policies.port }}
+              name: http
+              protocol: TCP
+          env:
+            - name: PORT
+              value: {{ .Values.policies.port | quote }}
+            {{- include "gigachad-grc.backendEnv" . | nindent 12 }}
+            {{- with .Values.policies.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+          resources:
+            {{- toYaml .Values.policies.resources | nindent 12 }}
+      {{- with .Values.policies.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.policies.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.policies.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gigachad-grc.fullname" . }}-policies
+  labels:
+    {{- include "gigachad-grc.labels" . | nindent 4 }}
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "policies") | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.policies.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "policies") | nindent 4 }}
+{{- end }}

--- a/helm/templates/deployment-tprm.yaml
+++ b/helm/templates/deployment-tprm.yaml
@@ -1,0 +1,89 @@
+{{- if .Values.tprm.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "gigachad-grc.fullname" . }}-tprm
+  labels:
+    {{- include "gigachad-grc.labels" . | nindent 4 }}
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "tprm") | nindent 4 }}
+spec:
+  replicas: {{ .Values.tprm.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "tprm") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "gigachad-grc.labels" . | nindent 8 }}
+        {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "tprm") | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "gigachad-grc.serviceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: tprm
+          image: {{ include "gigachad-grc.image" (dict "image" .Values.tprm.image "global" .Values.global) }}
+          imagePullPolicy: {{ .Values.tprm.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+          ports:
+            - containerPort: {{ .Values.tprm.port }}
+              name: http
+              protocol: TCP
+          env:
+            - name: PORT
+              value: {{ .Values.tprm.port | quote }}
+            {{- include "gigachad-grc.backendEnv" . | nindent 12 }}
+            {{- with .Values.tprm.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+          resources:
+            {{- toYaml .Values.tprm.resources | nindent 12 }}
+      {{- with .Values.tprm.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tprm.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tprm.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gigachad-grc.fullname" . }}-tprm
+  labels:
+    {{- include "gigachad-grc.labels" . | nindent 4 }}
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "tprm") | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.tprm.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "tprm") | nindent 4 }}
+{{- end }}

--- a/helm/templates/deployment-tprm.yaml
+++ b/helm/templates/deployment-tprm.yaml
@@ -27,9 +27,13 @@ spec:
       containers:
         - name: tprm
           image: {{ include "gigachad-grc.image" (dict "image" .Values.tprm.image "global" .Values.global) }}
-          imagePullPolicy: {{ .Values.tprm.image.pullPolicy }}
+          imagePullPolicy: {{ include "gigachad-grc.imagePullPolicy" .Values.tprm.image }}
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           ports:
             - containerPort: {{ .Values.tprm.port }}
               name: http
@@ -57,6 +61,14 @@ spec:
             timeoutSeconds: 5
           resources:
             {{- toYaml .Values.tprm.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 64Mi
       {{- with .Values.tprm.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/templates/deployment-trust.yaml
+++ b/helm/templates/deployment-trust.yaml
@@ -27,9 +27,13 @@ spec:
       containers:
         - name: trust
           image: {{ include "gigachad-grc.image" (dict "image" .Values.trust.image "global" .Values.global) }}
-          imagePullPolicy: {{ .Values.trust.image.pullPolicy }}
+          imagePullPolicy: {{ include "gigachad-grc.imagePullPolicy" .Values.trust.image }}
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           ports:
             - containerPort: {{ .Values.trust.port }}
               name: http
@@ -57,6 +61,14 @@ spec:
             timeoutSeconds: 5
           resources:
             {{- toYaml .Values.trust.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 64Mi
       {{- with .Values.trust.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/templates/deployment-trust.yaml
+++ b/helm/templates/deployment-trust.yaml
@@ -1,0 +1,89 @@
+{{- if .Values.trust.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "gigachad-grc.fullname" . }}-trust
+  labels:
+    {{- include "gigachad-grc.labels" . | nindent 4 }}
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "trust") | nindent 4 }}
+spec:
+  replicas: {{ .Values.trust.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "trust") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "gigachad-grc.labels" . | nindent 8 }}
+        {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "trust") | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "gigachad-grc.serviceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: trust
+          image: {{ include "gigachad-grc.image" (dict "image" .Values.trust.image "global" .Values.global) }}
+          imagePullPolicy: {{ .Values.trust.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+          ports:
+            - containerPort: {{ .Values.trust.port }}
+              name: http
+              protocol: TCP
+          env:
+            - name: PORT
+              value: {{ .Values.trust.port | quote }}
+            {{- include "gigachad-grc.backendEnv" . | nindent 12 }}
+            {{- with .Values.trust.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+          resources:
+            {{- toYaml .Values.trust.resources | nindent 12 }}
+      {{- with .Values.trust.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.trust.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.trust.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gigachad-grc.fullname" . }}-trust
+  labels:
+    {{- include "gigachad-grc.labels" . | nindent 4 }}
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "trust") | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.trust.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "trust") | nindent 4 }}
+{{- end }}

--- a/helm/templates/grafana.yaml
+++ b/helm/templates/grafana.yaml
@@ -1,0 +1,125 @@
+{{- if .Values.grafana.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "gigachad-grc.fullname" . }}-grafana
+  labels:
+    {{- include "gigachad-grc.labels" . | nindent 4 }}
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "grafana") | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "grafana") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "gigachad-grc.labels" . | nindent 8 }}
+        {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "grafana") | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "gigachad-grc.serviceAccountName" . }}
+      securityContext:
+        fsGroup: 472
+        runAsUser: 472
+        runAsNonRoot: true
+      containers:
+        - name: grafana
+          image: "{{ .Values.grafana.image.repository }}:{{ .Values.grafana.image.tag }}"
+          imagePullPolicy: {{ .Values.grafana.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+          ports:
+            - containerPort: 3000
+              name: http
+              protocol: TCP
+          env:
+            - name: GF_SECURITY_ADMIN_USER
+              value: {{ .Values.grafana.auth.adminUser | quote }}
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "gigachad-grc.secretName" . }}
+                  key: grafana-admin-password
+            - name: GF_USERS_ALLOW_SIGN_UP
+              value: "false"
+            - name: GF_AUTH_ANONYMOUS_ENABLED
+              value: "false"
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            {{- toYaml .Values.grafana.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/grafana
+      {{- with .Values.grafana.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.grafana.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.grafana.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        {{- if .Values.grafana.persistence.enabled }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "gigachad-grc.fullname" . }}-grafana
+        {{- else }}
+        - name: data
+          emptyDir: {}
+        {{- end }}
+---
+{{- if .Values.grafana.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "gigachad-grc.fullname" . }}-grafana
+  labels:
+    {{- include "gigachad-grc.labels" . | nindent 4 }}
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "grafana") | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- if or .Values.grafana.persistence.storageClass .Values.global.storageClass }}
+  storageClassName: {{ .Values.grafana.persistence.storageClass | default .Values.global.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.grafana.persistence.size }}
+---
+{{- end }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gigachad-grc.fullname" . }}-grafana
+  labels:
+    {{- include "gigachad-grc.labels" . | nindent 4 }}
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "grafana") | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 3000
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "grafana") | nindent 4 }}
+{{- end }}

--- a/helm/templates/grafana.yaml
+++ b/helm/templates/grafana.yaml
@@ -29,9 +29,12 @@ spec:
       containers:
         - name: grafana
           image: "{{ .Values.grafana.image.repository }}:{{ .Values.grafana.image.tag }}"
-          imagePullPolicy: {{ .Values.grafana.image.pullPolicy }}
+          imagePullPolicy: {{ include "gigachad-grc.imagePullPolicy" .Values.grafana.image }}
           securityContext:
             allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           ports:
             - containerPort: 3000
               name: http

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -1,0 +1,201 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "gigachad-grc.fullname" . }}
+  labels:
+    {{- include "gigachad-grc.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          # Frontend (catch-all, lowest priority)
+          {{- if .Values.frontend.enabled }}
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "gigachad-grc.fullname" . }}-frontend
+                port:
+                  number: 80
+          {{- end }}
+          # Controls API routes
+          {{- if .Values.controls.enabled }}
+          - path: /api/controls
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "gigachad-grc.fullname" . }}-controls
+                port:
+                  number: {{ .Values.controls.port }}
+          - path: /api/evidence
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "gigachad-grc.fullname" . }}-controls
+                port:
+                  number: {{ .Values.controls.port }}
+          - path: /api/risks
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "gigachad-grc.fullname" . }}-controls
+                port:
+                  number: {{ .Values.controls.port }}
+          - path: /api/risk-config
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "gigachad-grc.fullname" . }}-controls
+                port:
+                  number: {{ .Values.controls.port }}
+          - path: /api/risk-tasks
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "gigachad-grc.fullname" . }}-controls
+                port:
+                  number: {{ .Values.controls.port }}
+          - path: /api/workspaces
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "gigachad-grc.fullname" . }}-controls
+                port:
+                  number: {{ .Values.controls.port }}
+          - path: /api/bcdr
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "gigachad-grc.fullname" . }}-controls
+                port:
+                  number: {{ .Values.controls.port }}
+          {{- end }}
+          # Frameworks API routes
+          {{- if .Values.frameworks.enabled }}
+          - path: /api/frameworks
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "gigachad-grc.fullname" . }}-frameworks
+                port:
+                  number: {{ .Values.frameworks.port }}
+          {{- end }}
+          # Policies API routes
+          {{- if .Values.policies.enabled }}
+          - path: /api/policies
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "gigachad-grc.fullname" . }}-policies
+                port:
+                  number: {{ .Values.policies.port }}
+          {{- end }}
+          # TPRM API routes
+          {{- if .Values.tprm.enabled }}
+          - path: /api/vendors
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "gigachad-grc.fullname" . }}-tprm
+                port:
+                  number: {{ .Values.tprm.port }}
+          - path: /api/assessments
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "gigachad-grc.fullname" . }}-tprm
+                port:
+                  number: {{ .Values.tprm.port }}
+          - path: /api/contracts
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "gigachad-grc.fullname" . }}-tprm
+                port:
+                  number: {{ .Values.tprm.port }}
+          - path: /api/tprm-config
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "gigachad-grc.fullname" . }}-tprm
+                port:
+                  number: {{ .Values.tprm.port }}
+          {{- end }}
+          # Trust API routes
+          {{- if .Values.trust.enabled }}
+          - path: /api/questionnaires
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "gigachad-grc.fullname" . }}-trust
+                port:
+                  number: {{ .Values.trust.port }}
+          - path: /api/knowledge-base
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "gigachad-grc.fullname" . }}-trust
+                port:
+                  number: {{ .Values.trust.port }}
+          - path: /api/trust-center
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "gigachad-grc.fullname" . }}-trust
+                port:
+                  number: {{ .Values.trust.port }}
+          {{- end }}
+          # Audit API routes
+          {{- if .Values.audit.enabled }}
+          - path: /api/audits
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "gigachad-grc.fullname" . }}-audit
+                port:
+                  number: {{ .Values.audit.port }}
+          - path: /api/audit-requests
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "gigachad-grc.fullname" . }}-audit
+                port:
+                  number: {{ .Values.audit.port }}
+          - path: /api/findings
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "gigachad-grc.fullname" . }}-audit
+                port:
+                  number: {{ .Values.audit.port }}
+          - path: /api/audit-portal
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "gigachad-grc.fullname" . }}-audit
+                port:
+                  number: {{ .Values.audit.port }}
+          - path: /api/audit
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "gigachad-grc.fullname" . }}-audit
+                port:
+                  number: {{ .Values.audit.port }}
+          {{- end }}
+{{- end }}

--- a/helm/templates/keycloak.yaml
+++ b/helm/templates/keycloak.yaml
@@ -1,0 +1,110 @@
+{{- if .Values.keycloak.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "gigachad-grc.fullname" . }}-keycloak
+  labels:
+    {{- include "gigachad-grc.labels" . | nindent 4 }}
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "keycloak") | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "keycloak") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "gigachad-grc.labels" . | nindent 8 }}
+        {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "keycloak") | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "gigachad-grc.serviceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: keycloak
+          image: "{{ .Values.keycloak.image.repository }}:{{ .Values.keycloak.image.tag }}"
+          imagePullPolicy: {{ .Values.keycloak.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+          args:
+            - start-dev
+            - --import-realm
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          env:
+            - name: KC_DB
+              value: postgres
+            - name: KC_DB_URL
+              value: "jdbc:postgresql://{{ include "gigachad-grc.postgresql.host" . }}:5432/{{ .Values.postgresql.auth.keycloakDatabase }}"
+            - name: KC_DB_USERNAME
+              value: {{ .Values.postgresql.auth.username | quote }}
+            - name: KC_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "gigachad-grc.secretName" . }}
+                  key: postgresql-password
+            - name: KC_HOSTNAME_STRICT
+              value: "false"
+            - name: KC_HOSTNAME_STRICT_HTTPS
+              value: "false"
+            - name: KC_HTTP_ENABLED
+              value: "true"
+            - name: KEYCLOAK_ADMIN
+              value: {{ .Values.keycloak.auth.adminUser | quote }}
+            - name: KEYCLOAK_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "gigachad-grc.secretName" . }}
+                  key: keycloak-admin-password
+          readinessProbe:
+            httpGet:
+              path: /realms/master
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /realms/master
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+          resources:
+            {{- toYaml .Values.keycloak.resources | nindent 12 }}
+      {{- with .Values.keycloak.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.keycloak.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.keycloak.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gigachad-grc.fullname" . }}-keycloak
+  labels:
+    {{- include "gigachad-grc.labels" . | nindent 4 }}
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "keycloak") | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "keycloak") | nindent 4 }}
+{{- end }}

--- a/helm/templates/keycloak.yaml
+++ b/helm/templates/keycloak.yaml
@@ -27,11 +27,18 @@ spec:
       containers:
         - name: keycloak
           image: "{{ .Values.keycloak.image.repository }}:{{ .Values.keycloak.image.tag }}"
-          imagePullPolicy: {{ .Values.keycloak.image.pullPolicy }}
+          imagePullPolicy: {{ include "gigachad-grc.imagePullPolicy" .Values.keycloak.image }}
           securityContext:
             allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           args:
+            {{- if eq .Values.keycloak.mode "production" }}
+            - start
+            {{- else }}
             - start-dev
+            {{- end }}
             - --import-realm
           ports:
             - containerPort: 8080
@@ -49,12 +56,25 @@ spec:
                 secretKeyRef:
                   name: {{ include "gigachad-grc.secretName" . }}
                   key: postgresql-password
+            {{- if eq .Values.keycloak.mode "production" }}
+            {{- if .Values.keycloak.hostname }}
+            - name: KC_HOSTNAME
+              value: {{ .Values.keycloak.hostname | quote }}
+            {{- end }}
+            - name: KC_HOSTNAME_STRICT
+              value: "true"
+            - name: KC_HOSTNAME_STRICT_HTTPS
+              value: "true"
+            - name: KC_HTTP_ENABLED
+              value: "false"
+            {{- else }}
             - name: KC_HOSTNAME_STRICT
               value: "false"
             - name: KC_HOSTNAME_STRICT_HTTPS
               value: "false"
             - name: KC_HTTP_ENABLED
               value: "true"
+            {{- end }}
             - name: KEYCLOAK_ADMIN
               value: {{ .Values.keycloak.auth.adminUser | quote }}
             - name: KEYCLOAK_ADMIN_PASSWORD

--- a/helm/templates/postgresql.yaml
+++ b/helm/templates/postgresql.yaml
@@ -30,9 +30,12 @@ spec:
       containers:
         - name: postgresql
           image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
-          imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
+          imagePullPolicy: {{ include "gigachad-grc.imagePullPolicy" .Values.postgresql.image }}
           securityContext:
             allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           ports:
             - containerPort: 5432
               name: postgresql

--- a/helm/templates/postgresql.yaml
+++ b/helm/templates/postgresql.yaml
@@ -1,0 +1,126 @@
+{{- if .Values.postgresql.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "gigachad-grc.fullname" . }}-postgresql
+  labels:
+    {{- include "gigachad-grc.labels" . | nindent 4 }}
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "postgresql") | nindent 4 }}
+spec:
+  serviceName: {{ include "gigachad-grc.fullname" . }}-postgresql
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "postgresql") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "gigachad-grc.labels" . | nindent 8 }}
+        {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "postgresql") | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "gigachad-grc.serviceAccountName" . }}
+      securityContext:
+        fsGroup: 999
+        runAsUser: 999
+        runAsNonRoot: true
+      containers:
+        - name: postgresql
+          image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+          imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+          ports:
+            - containerPort: 5432
+              name: postgresql
+              protocol: TCP
+          env:
+            - name: POSTGRES_USER
+              value: {{ .Values.postgresql.auth.username | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "gigachad-grc.secretName" . }}
+                  key: postgresql-password
+            - name: POSTGRES_DB
+              value: {{ .Values.postgresql.auth.database | quote }}
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - {{ .Values.postgresql.auth.username | quote }}
+                - -d
+                - {{ .Values.postgresql.auth.database | quote }}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - {{ .Values.postgresql.auth.username | quote }}
+                - -d
+                - {{ .Values.postgresql.auth.database | quote }}
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            {{- toYaml .Values.postgresql.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+      {{- with .Values.postgresql.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgresql.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgresql.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- if .Values.postgresql.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- if or .Values.postgresql.persistence.storageClass .Values.global.storageClass }}
+        storageClassName: {{ .Values.postgresql.persistence.storageClass | default .Values.global.storageClass }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.postgresql.persistence.size }}
+  {{- else }}
+      volumes:
+        - name: data
+          emptyDir: {}
+  {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gigachad-grc.fullname" . }}-postgresql
+  labels:
+    {{- include "gigachad-grc.labels" . | nindent 4 }}
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "postgresql") | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5432
+      targetPort: postgresql
+      protocol: TCP
+      name: postgresql
+  selector:
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "postgresql") | nindent 4 }}
+{{- end }}

--- a/helm/templates/prometheus.yaml
+++ b/helm/templates/prometheus.yaml
@@ -30,9 +30,12 @@ spec:
       containers:
         - name: prometheus
           image: "{{ .Values.prometheus.image.repository }}:{{ .Values.prometheus.image.tag }}"
-          imagePullPolicy: {{ .Values.prometheus.image.pullPolicy }}
+          imagePullPolicy: {{ include "gigachad-grc.imagePullPolicy" .Values.prometheus.image }}
           securityContext:
             allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           args:
             - --config.file=/etc/prometheus/prometheus.yml
             - --storage.tsdb.path=/prometheus

--- a/helm/templates/prometheus.yaml
+++ b/helm/templates/prometheus.yaml
@@ -1,0 +1,108 @@
+{{- if .Values.prometheus.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "gigachad-grc.fullname" . }}-prometheus
+  labels:
+    {{- include "gigachad-grc.labels" . | nindent 4 }}
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "prometheus") | nindent 4 }}
+spec:
+  serviceName: {{ include "gigachad-grc.fullname" . }}-prometheus
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "prometheus") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "gigachad-grc.labels" . | nindent 8 }}
+        {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "prometheus") | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "gigachad-grc.serviceAccountName" . }}
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 65534
+        runAsNonRoot: true
+      containers:
+        - name: prometheus
+          image: "{{ .Values.prometheus.image.repository }}:{{ .Values.prometheus.image.tag }}"
+          imagePullPolicy: {{ .Values.prometheus.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+          args:
+            - --config.file=/etc/prometheus/prometheus.yml
+            - --storage.tsdb.path=/prometheus
+            - --web.enable-lifecycle
+          ports:
+            - containerPort: 9090
+              name: http
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 15
+          resources:
+            {{- toYaml .Values.prometheus.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /prometheus
+      {{- with .Values.prometheus.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.prometheus.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.prometheus.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- if .Values.prometheus.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- if or .Values.prometheus.persistence.storageClass .Values.global.storageClass }}
+        storageClassName: {{ .Values.prometheus.persistence.storageClass | default .Values.global.storageClass }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.prometheus.persistence.size }}
+  {{- else }}
+      volumes:
+        - name: data
+          emptyDir: {}
+  {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gigachad-grc.fullname" . }}-prometheus
+  labels:
+    {{- include "gigachad-grc.labels" . | nindent 4 }}
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "prometheus") | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9090
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "prometheus") | nindent 4 }}
+{{- end }}

--- a/helm/templates/redis.yaml
+++ b/helm/templates/redis.yaml
@@ -30,9 +30,12 @@ spec:
       containers:
         - name: redis
           image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
-          imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
+          imagePullPolicy: {{ include "gigachad-grc.imagePullPolicy" .Values.redis.image }}
           securityContext:
             allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           command:
             - redis-server
             - --appendonly

--- a/helm/templates/redis.yaml
+++ b/helm/templates/redis.yaml
@@ -1,0 +1,122 @@
+{{- if .Values.redis.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "gigachad-grc.fullname" . }}-redis
+  labels:
+    {{- include "gigachad-grc.labels" . | nindent 4 }}
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "redis") | nindent 4 }}
+spec:
+  serviceName: {{ include "gigachad-grc.fullname" . }}-redis
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "redis") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "gigachad-grc.labels" . | nindent 8 }}
+        {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "redis") | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "gigachad-grc.serviceAccountName" . }}
+      securityContext:
+        fsGroup: 999
+        runAsUser: 999
+        runAsNonRoot: true
+      containers:
+        - name: redis
+          image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+          imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+          command:
+            - redis-server
+            - --appendonly
+            - "yes"
+            - --requirepass
+            - $(REDIS_PASSWORD)
+          ports:
+            - containerPort: 6379
+              name: redis
+              protocol: TCP
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "gigachad-grc.secretName" . }}
+                  key: redis-password
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - redis-cli -a $REDIS_PASSWORD ping | grep PONG
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - redis-cli -a $REDIS_PASSWORD ping | grep PONG
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            {{- toYaml .Values.redis.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      {{- with .Values.redis.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.redis.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.redis.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- if .Values.redis.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- if or .Values.redis.persistence.storageClass .Values.global.storageClass }}
+        storageClassName: {{ .Values.redis.persistence.storageClass | default .Values.global.storageClass }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.redis.persistence.size }}
+  {{- else }}
+      volumes:
+        - name: data
+          emptyDir: {}
+  {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gigachad-grc.fullname" . }}-redis
+  labels:
+    {{- include "gigachad-grc.labels" . | nindent 4 }}
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "redis") | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 6379
+      targetPort: redis
+      protocol: TCP
+      name: redis
+  selector:
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "redis") | nindent 4 }}
+{{- end }}

--- a/helm/templates/rustfs.yaml
+++ b/helm/templates/rustfs.yaml
@@ -23,12 +23,19 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "gigachad-grc.serviceAccountName" . }}
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+        runAsNonRoot: true
       containers:
         - name: rustfs
           image: "{{ .Values.rustfs.image.repository }}:{{ .Values.rustfs.image.tag }}"
-          imagePullPolicy: {{ .Values.rustfs.image.pullPolicy }}
+          imagePullPolicy: {{ include "gigachad-grc.imagePullPolicy" .Values.rustfs.image }}
           securityContext:
             allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           ports:
             - containerPort: 9000
               name: s3

--- a/helm/templates/rustfs.yaml
+++ b/helm/templates/rustfs.yaml
@@ -1,0 +1,120 @@
+{{- if .Values.rustfs.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "gigachad-grc.fullname" . }}-rustfs
+  labels:
+    {{- include "gigachad-grc.labels" . | nindent 4 }}
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "rustfs") | nindent 4 }}
+spec:
+  serviceName: {{ include "gigachad-grc.fullname" . }}-rustfs
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "rustfs") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "gigachad-grc.labels" . | nindent 8 }}
+        {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "rustfs") | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "gigachad-grc.serviceAccountName" . }}
+      containers:
+        - name: rustfs
+          image: "{{ .Values.rustfs.image.repository }}:{{ .Values.rustfs.image.tag }}"
+          imagePullPolicy: {{ .Values.rustfs.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+          ports:
+            - containerPort: 9000
+              name: s3
+              protocol: TCP
+            - containerPort: 9001
+              name: console
+              protocol: TCP
+          env:
+            - name: RUSTFS_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "gigachad-grc.secretName" . }}
+                  key: s3-access-key
+            - name: RUSTFS_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "gigachad-grc.secretName" . }}
+                  key: s3-secret-key
+          readinessProbe:
+            httpGet:
+              path: /rustfs/console/index.html
+              port: console
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 20
+          livenessProbe:
+            httpGet:
+              path: /rustfs/console/index.html
+              port: console
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 20
+          resources:
+            {{- toYaml .Values.rustfs.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      {{- with .Values.rustfs.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.rustfs.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.rustfs.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- if .Values.rustfs.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- if or .Values.rustfs.persistence.storageClass .Values.global.storageClass }}
+        storageClassName: {{ .Values.rustfs.persistence.storageClass | default .Values.global.storageClass }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.rustfs.persistence.size }}
+  {{- else }}
+      volumes:
+        - name: data
+          emptyDir: {}
+  {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gigachad-grc.fullname" . }}-rustfs
+  labels:
+    {{- include "gigachad-grc.labels" . | nindent 4 }}
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "rustfs") | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9000
+      targetPort: s3
+      protocol: TCP
+      name: s3
+    - port: 9001
+      targetPort: console
+      protocol: TCP
+      name: console
+  selector:
+    {{- include "gigachad-grc.selectorLabels" (dict "context" . "component" "rustfs") | nindent 4 }}
+{{- end }}

--- a/helm/templates/secret.yaml
+++ b/helm/templates/secret.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "gigachad-grc.secretName" . }}
+  labels:
+    {{- include "gigachad-grc.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- if .Values.postgresql.enabled }}
+  postgresql-password: {{ .Values.postgresql.auth.password | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.redis.enabled }}
+  redis-password: {{ .Values.redis.auth.password | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.rustfs.enabled }}
+  s3-access-key: {{ .Values.rustfs.auth.rootUser | b64enc | quote }}
+  s3-secret-key: {{ .Values.rustfs.auth.rootPassword | b64enc | quote }}
+  {{- else if .Values.externalS3.accessKey }}
+  s3-access-key: {{ .Values.externalS3.accessKey | b64enc | quote }}
+  s3-secret-key: {{ .Values.externalS3.secretKey | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.keycloak.enabled }}
+  keycloak-admin-password: {{ .Values.keycloak.auth.adminPassword | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.controls.env.encryptionKey }}
+  encryption-key: {{ .Values.controls.env.encryptionKey | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.controls.env.jwtSecret }}
+  jwt-secret: {{ .Values.controls.env.jwtSecret | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.controls.env.sessionSecret }}
+  session-secret: {{ .Values.controls.env.sessionSecret | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.controls.env.phishingTrackingSecret }}
+  phishing-tracking-secret: {{ .Values.controls.env.phishingTrackingSecret | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.grafana.enabled }}
+  grafana-admin-password: {{ .Values.grafana.auth.adminPassword | b64enc | quote }}
+  {{- end }}

--- a/helm/templates/secret.yaml
+++ b/helm/templates/secret.yaml
@@ -25,12 +25,8 @@ data:
   {{- if .Values.controls.env.encryptionKey }}
   encryption-key: {{ .Values.controls.env.encryptionKey | b64enc | quote }}
   {{- end }}
-  {{- if .Values.controls.env.jwtSecret }}
-  jwt-secret: {{ .Values.controls.env.jwtSecret | b64enc | quote }}
-  {{- end }}
-  {{- if .Values.controls.env.sessionSecret }}
-  session-secret: {{ .Values.controls.env.sessionSecret | b64enc | quote }}
-  {{- end }}
+  jwt-secret: {{ .Values.controls.env.jwtSecret | default (randAlphaNum 64) | b64enc | quote }}
+  session-secret: {{ .Values.controls.env.sessionSecret | default (randAlphaNum 64) | b64enc | quote }}
   {{- if .Values.controls.env.phishingTrackingSecret }}
   phishing-tracking-secret: {{ .Values.controls.env.phishingTrackingSecret | b64enc | quote }}
   {{- end }}

--- a/helm/templates/serviceaccount.yaml
+++ b/helm/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "gigachad-grc.serviceAccountName" . }}
+  labels:
+    {{- include "gigachad-grc.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,388 @@
+# GigaChad GRC Helm Chart - Default Values
+# Override these in your own values file or via --set flags
+
+# -- Global settings applied to all components
+global:
+  # -- Container image registry prefix (e.g., "ghcr.io/grcengineering")
+  imageRegistry: ''
+  # -- Image pull secrets for private registries
+  imagePullSecrets: []
+  # -- Storage class for all PVCs (empty = cluster default)
+  storageClass: ''
+
+# =============================================================================
+# Backend Services
+# =============================================================================
+
+# Each backend service follows the same structure. They share a database,
+# Redis cache, Keycloak auth, and RustFS storage.
+
+controls:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: gigachad-grc/controls
+    tag: latest
+    pullPolicy: IfNotPresent
+  port: 3001
+  resources:
+    limits:
+      cpu: '1'
+      memory: 512Mi
+    requests:
+      cpu: 250m
+      memory: 128Mi
+  # -- Extra environment variables (list of {name, value} or {name, valueFrom})
+  extraEnv: []
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  # -- Controls-specific env vars
+  env:
+    encryptionKey: ''
+    jwtSecret: ''
+    sessionSecret: ''
+    phishingTrackingSecret: ''
+    backupRetentionDays: '30'
+    drRemoteBackupEnabled: 'false'
+    drRemoteBackupS3Bucket: ''
+
+frameworks:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: gigachad-grc/frameworks
+    tag: latest
+    pullPolicy: IfNotPresent
+  port: 3002
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  extraEnv: []
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+policies:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: gigachad-grc/policies
+    tag: latest
+    pullPolicy: IfNotPresent
+  port: 3004
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  extraEnv: []
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+tprm:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: gigachad-grc/tprm
+    tag: latest
+    pullPolicy: IfNotPresent
+  port: 3005
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  extraEnv: []
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+trust:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: gigachad-grc/trust
+    tag: latest
+    pullPolicy: IfNotPresent
+  port: 3006
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  extraEnv: []
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+audit:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: gigachad-grc/audit
+    tag: latest
+    pullPolicy: IfNotPresent
+  port: 3007
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  extraEnv: []
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# =============================================================================
+# Frontend
+# =============================================================================
+
+frontend:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: gigachad-grc/frontend
+    tag: latest
+    pullPolicy: IfNotPresent
+  port: 80
+  resources:
+    limits:
+      cpu: 250m
+      memory: 128Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
+  extraEnv: []
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  # -- Set to "true" to enable dev login bypass (no Keycloak required)
+  devAuth: 'false'
+
+# =============================================================================
+# Infrastructure - PostgreSQL
+# =============================================================================
+
+postgresql:
+  # -- Deploy PostgreSQL within the chart. Set to false to use an external database.
+  enabled: true
+  image:
+    repository: postgres
+    tag: '16-alpine'
+    pullPolicy: IfNotPresent
+  auth:
+    username: grc
+    # -- Password for the database user. MUST be set.
+    password: ''
+    database: gigachad_grc
+    # -- Keycloak uses its own database on the same PostgreSQL instance
+    keycloakDatabase: keycloak
+  persistence:
+    enabled: true
+    size: 10Gi
+    # -- Storage class (empty = cluster default)
+    storageClass: ''
+  resources:
+    limits:
+      cpu: '2'
+      memory: 1Gi
+    requests:
+      cpu: 500m
+      memory: 256Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# -- Use an external PostgreSQL database instead of deploying one
+externalDatabase:
+  # -- Full connection string: postgresql://user:pass@host:5432/dbname
+  url: ''
+
+# =============================================================================
+# Infrastructure - Redis
+# =============================================================================
+
+redis:
+  # -- Deploy Redis within the chart. Set to false to use an external Redis.
+  enabled: true
+  image:
+    repository: redis
+    tag: '7-alpine'
+    pullPolicy: IfNotPresent
+  auth:
+    # -- Redis password. MUST be set.
+    password: ''
+  persistence:
+    enabled: true
+    size: 2Gi
+    storageClass: ''
+  resources:
+    limits:
+      cpu: '1'
+      memory: 512Mi
+    requests:
+      cpu: 250m
+      memory: 128Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# -- Use an external Redis instead of deploying one
+externalRedis:
+  # -- Full connection string: redis://:password@host:6379
+  url: ''
+
+# =============================================================================
+# Infrastructure - Keycloak
+# =============================================================================
+
+keycloak:
+  # -- Deploy Keycloak within the chart. Set to false if using external IdP or dev auth only.
+  enabled: true
+  image:
+    repository: quay.io/keycloak/keycloak
+    tag: '25.0'
+    pullPolicy: IfNotPresent
+  auth:
+    adminUser: admin
+    # -- Keycloak admin password. MUST be set.
+    adminPassword: ''
+  realm: gigachad-grc
+  resources:
+    limits:
+      cpu: '1'
+      memory: 1Gi
+    requests:
+      cpu: 250m
+      memory: 512Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# =============================================================================
+# Infrastructure - RustFS (S3-compatible object storage)
+# =============================================================================
+
+rustfs:
+  # -- Deploy RustFS within the chart. Set to false to use external S3.
+  enabled: true
+  image:
+    repository: rustfs/rustfs
+    tag: latest
+    pullPolicy: IfNotPresent
+  auth:
+    rootUser: rustfsadmin
+    # -- RustFS root password. MUST be set.
+    rootPassword: ''
+  persistence:
+    enabled: true
+    size: 20Gi
+    storageClass: ''
+  resources:
+    limits:
+      cpu: '1'
+      memory: 512Mi
+    requests:
+      cpu: 250m
+      memory: 128Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# -- Use external S3-compatible storage instead of RustFS
+externalS3:
+  endpoint: ''
+  port: '443'
+  useSSL: 'true'
+  accessKey: ''
+  secretKey: ''
+  bucket: grc-evidence
+
+# =============================================================================
+# Monitoring (optional)
+# =============================================================================
+
+prometheus:
+  enabled: false
+  image:
+    repository: prom/prometheus
+    tag: 'v2.47.1'
+    pullPolicy: IfNotPresent
+  persistence:
+    enabled: true
+    size: 10Gi
+    storageClass: ''
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+grafana:
+  enabled: false
+  image:
+    repository: grafana/grafana
+    tag: '10.2.0'
+    pullPolicy: IfNotPresent
+  auth:
+    adminUser: admin
+    # -- Grafana admin password
+    adminPassword: ''
+  persistence:
+    enabled: true
+    size: 5Gi
+    storageClass: ''
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# =============================================================================
+# Ingress
+# =============================================================================
+
+ingress:
+  enabled: false
+  className: nginx
+  annotations: {}
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
+    # nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+  # -- Hostname for the GRC platform
+  host: grc.example.com
+  tls:
+    enabled: false
+    secretName: grc-tls
+
+# =============================================================================
+# Service Account
+# =============================================================================
+
+serviceAccount:
+  create: true
+  name: ''
+  annotations: {}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -16,6 +16,10 @@ global:
 
 # Each backend service follows the same structure. They share a database,
 # Redis cache, Keycloak auth, and RustFS storage.
+#
+# IMPORTANT: Pin image tags to specific versions for production (e.g., "v1.0.0").
+# The "latest" tag with IfNotPresent will cache stale images. If using "latest",
+# set pullPolicy to "Always".
 
 controls:
   enabled: true
@@ -262,6 +266,10 @@ keycloak:
     # -- Keycloak admin password. MUST be set.
     adminPassword: ''
   realm: gigachad-grc
+  # -- "dev" uses start-dev (no HTTPS required). "production" uses start (requires HTTPS/hostname config).
+  mode: dev
+  # -- Hostname for production mode (required when mode=production)
+  hostname: ''
   resources:
     limits:
       cpu: '1'


### PR DESCRIPTION
## Summary

- Adds a complete Helm chart at `helm/` for deploying GigaChad GRC to Kubernetes, addressing [Discussion #84](https://github.com/grcengineering/gigachad-grc/discussions/84)
- 18 templates covering all application services, infrastructure (PostgreSQL, Redis, Keycloak, RustFS), and optional monitoring (Prometheus, Grafana)
- Full `values.yaml` with per-service configuration: replica counts, resource limits, image overrides, external infrastructure support
- Ingress template with complete API route mapping matching the existing Traefik configuration
- Updates `docs/DEPLOYMENT.md` Kubernetes section with real usage examples (quick deploy, custom values, external infrastructure)
- Adds `helm/templates/` to `.prettierignore` (Go template syntax is incompatible with Prettier)

## What's Included

| Template | Type | Purpose |
|----------|------|---------|
| `postgresql.yaml` | StatefulSet + Service | Optional managed PostgreSQL (disable to use external RDS/Cloud SQL) |
| `redis.yaml` | StatefulSet + Service | Optional managed Redis (disable to use external ElastiCache) |
| `keycloak.yaml` | Deployment + Service | Optional Keycloak IdP |
| `rustfs.yaml` | StatefulSet + Service | Optional S3-compatible storage (disable to use external S3) |
| `deployment-{controls,frameworks,policies,tprm,trust,audit}.yaml` | Deployment + Service | Backend microservices |
| `deployment-frontend.yaml` | Deployment + Service | React SPA (nginx) |
| `ingress.yaml` | Ingress | Full API path routing to all services |
| `secret.yaml` | Secret | Centralized secret management |
| `prometheus.yaml` / `grafana.yaml` | StatefulSet/Deployment + Service | Optional monitoring stack |

## Test Plan

- [ ] `helm template gigachad-grc ./helm` renders without errors
- [ ] `helm lint ./helm` passes
- [ ] Deploy to a test cluster with `helm install gigachad-grc ./helm -n test --set postgresql.auth.password=test --set redis.auth.password=test --set keycloak.auth.adminPassword=test --set rustfs.auth.rootPassword=test --set controls.env.encryptionKey=test --set controls.env.phishingTrackingSecret=test`
- [ ] Verify all pods reach Running state
- [ ] Verify ingress routes traffic correctly
- [ ] Test with external PostgreSQL/Redis by disabling built-in and setting `externalDatabase.url` / `externalRedis.url`

Closes #84

Made with [Cursor](https://cursor.com)