### PR TITLE
fix: resolve CodeQL empty password findings in Helm chart

### DIFF
--- a/helm/templates/deployment-controls.yaml
+++ b/helm/templates/deployment-controls.yaml
@@ -47,7 +47,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "gigachad-grc.secretName" . }}
                   key: encryption-key
-                  optional: true
             - name: JWT_SECRET
               valueFrom:
                 secretKeyRef:
@@ -63,7 +62,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "gigachad-grc.secretName" . }}
                   key: phishing-tracking-secret
-                  optional: true
             - name: BACKUP_RETENTION_DAYS
               value: {{ .Values.controls.env.backupRetentionDays | quote }}
             - name: DR_REMOTE_BACKUP_ENABLED

--- a/helm/templates/secret.yaml
+++ b/helm/templates/secret.yaml
@@ -7,29 +7,25 @@ metadata:
 type: Opaque
 data:
   {{- if .Values.postgresql.enabled }}
-  postgresql-password: {{ .Values.postgresql.auth.password | b64enc | quote }}
+  postgresql-password: {{ required "postgresql.auth.password is required" .Values.postgresql.auth.password | b64enc | quote }}
   {{- end }}
   {{- if .Values.redis.enabled }}
-  redis-password: {{ .Values.redis.auth.password | b64enc | quote }}
+  redis-password: {{ required "redis.auth.password is required" .Values.redis.auth.password | b64enc | quote }}
   {{- end }}
   {{- if .Values.rustfs.enabled }}
   s3-access-key: {{ .Values.rustfs.auth.rootUser | b64enc | quote }}
-  s3-secret-key: {{ .Values.rustfs.auth.rootPassword | b64enc | quote }}
+  s3-secret-key: {{ required "rustfs.auth.rootPassword is required" .Values.rustfs.auth.rootPassword | b64enc | quote }}
   {{- else if .Values.externalS3.accessKey }}
   s3-access-key: {{ .Values.externalS3.accessKey | b64enc | quote }}
   s3-secret-key: {{ .Values.externalS3.secretKey | b64enc | quote }}
   {{- end }}
   {{- if .Values.keycloak.enabled }}
-  keycloak-admin-password: {{ .Values.keycloak.auth.adminPassword | b64enc | quote }}
+  keycloak-admin-password: {{ required "keycloak.auth.adminPassword is required" .Values.keycloak.auth.adminPassword | b64enc | quote }}
   {{- end }}
-  {{- if .Values.controls.env.encryptionKey }}
-  encryption-key: {{ .Values.controls.env.encryptionKey | b64enc | quote }}
-  {{- end }}
+  encryption-key: {{ .Values.controls.env.encryptionKey | default (randAlphaNum 64) | b64enc | quote }}
   jwt-secret: {{ .Values.controls.env.jwtSecret | default (randAlphaNum 64) | b64enc | quote }}
   session-secret: {{ .Values.controls.env.sessionSecret | default (randAlphaNum 64) | b64enc | quote }}
-  {{- if .Values.controls.env.phishingTrackingSecret }}
-  phishing-tracking-secret: {{ .Values.controls.env.phishingTrackingSecret | b64enc | quote }}
-  {{- end }}
+  phishing-tracking-secret: {{ .Values.controls.env.phishingTrackingSecret | default (randAlphaNum 32) | b64enc | quote }}
   {{- if .Values.grafana.enabled }}
-  grafana-admin-password: {{ .Values.grafana.auth.adminPassword | b64enc | quote }}
+  grafana-admin-password: {{ required "grafana.auth.adminPassword is required when grafana is enabled" .Values.grafana.auth.adminPassword | b64enc | quote }}
   {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -43,10 +43,14 @@ controls:
   affinity: {}
   # -- Controls-specific env vars
   env:
-    encryptionKey: ''
-    jwtSecret: ''
-    sessionSecret: ''
-    phishingTrackingSecret: ''
+    # -- Encryption key for data at rest. Auto-generated if not set.
+    encryptionKey:
+    # -- JWT signing secret. Auto-generated if not set.
+    jwtSecret:
+    # -- Session signing secret. Auto-generated if not set.
+    sessionSecret:
+    # -- Phishing tracking secret. Auto-generated if not set.
+    phishingTrackingSecret:
     backupRetentionDays: '30'
     drRemoteBackupEnabled: 'false'
     drRemoteBackupS3Bucket: ''
@@ -190,8 +194,8 @@ postgresql:
     pullPolicy: IfNotPresent
   auth:
     username: grc
-    # -- Password for the database user. MUST be set.
-    password: ''
+    # -- Password for the database user. MUST be set via --set postgresql.auth.password=<value>
+    password:
     database: gigachad_grc
     # -- Keycloak uses its own database on the same PostgreSQL instance
     keycloakDatabase: keycloak
@@ -228,8 +232,8 @@ redis:
     tag: '7-alpine'
     pullPolicy: IfNotPresent
   auth:
-    # -- Redis password. MUST be set.
-    password: ''
+    # -- Redis password. MUST be set via --set redis.auth.password=<value>
+    password:
   persistence:
     enabled: true
     size: 2Gi
@@ -263,8 +267,8 @@ keycloak:
     pullPolicy: IfNotPresent
   auth:
     adminUser: admin
-    # -- Keycloak admin password. MUST be set.
-    adminPassword: ''
+    # -- Keycloak admin password. MUST be set via --set keycloak.auth.adminPassword=<value>
+    adminPassword:
   realm: gigachad-grc
   # -- "dev" uses start-dev (no HTTPS required). "production" uses start (requires HTTPS/hostname config).
   mode: dev
@@ -294,8 +298,8 @@ rustfs:
     pullPolicy: IfNotPresent
   auth:
     rootUser: rustfsadmin
-    # -- RustFS root password. MUST be set.
-    rootPassword: ''
+    # -- RustFS root password. MUST be set via --set rustfs.auth.rootPassword=<value>
+    rootPassword:
   persistence:
     enabled: true
     size: 20Gi
@@ -353,8 +357,8 @@ grafana:
     pullPolicy: IfNotPresent
   auth:
     adminUser: admin
-    # -- Grafana admin password
-    adminPassword: ''
+    # -- Grafana admin password. MUST be set via --set grafana.auth.adminPassword=<value>
+    adminPassword:
   persistence:
     enabled: true
     size: 5Gi


### PR DESCRIPTION
## Summary

- Resolves the two **High** severity CodeQL findings from PR #180: "Empty password in configuration file" for PostgreSQL and Redis passwords in `helm/values.yaml`
- Replaces all empty string password defaults (`password: ''`) with `null` across PostgreSQL, Redis, Keycloak, RustFS, and Grafana
- Adds `required()` validation in `secret.yaml` so Helm fails fast with a clear error when passwords aren't provided
- Auto-generates encryption key, JWT secret, session secret, and phishing tracking secret if not explicitly set (previously only JWT and session were auto-generated)
- Removes `optional: true` from controls deployment secret refs since all keys are now guaranteed to exist

## Changes

| File | Change |
|------|--------|
| `helm/values.yaml` | Replace `password: ''` with `password:` (null) for all 7 credential fields |
| `helm/templates/secret.yaml` | Add `required()` for PostgreSQL, Redis, Keycloak, RustFS, Grafana passwords; add auto-generation for encryption key and phishing secret |
| `helm/templates/deployment-controls.yaml` | Remove `optional: true` from encryption-key and phishing-tracking-secret refs |

## Test plan

- `helm lint ./helm` passes (shows expected warnings about required values)
- `helm lint --strict ./helm --set <all passwords>` passes clean
- `helm template` without passwords fails with clear error: `postgresql.auth.password is required`
- `helm template` with all passwords renders complete valid YAML