### PR TITLE
fix: update node:20-alpine base image to resolve container CVEs

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -6,7 +6,7 @@
 # =============================================================================
 
 # Build stage
-FROM node:20-alpine@sha256:09e2b3d9726018aecf269bd35325f46bf75046a643a66d28360ec71132750ec8 AS builder
+FROM node:20-alpine@sha256:b88333c42c23fbd91596ebd7fd10de239cedab9617de04142dde7315e3bc0afa AS builder
 
 WORKDIR /app
 

--- a/services/audit/Dockerfile
+++ b/services/audit/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage - Using Docker Hardened Image
-FROM node:20-alpine@sha256:09e2b3d9726018aecf269bd35325f46bf75046a643a66d28360ec71132750ec8 AS builder
+FROM node:20-alpine@sha256:b88333c42c23fbd91596ebd7fd10de239cedab9617de04142dde7315e3bc0afa AS builder
 
 WORKDIR /app
 
@@ -40,7 +40,7 @@ RUN npx prisma generate --schema=../shared/prisma/schema.prisma
 RUN npm run build
 
 # Production stage - Using Docker Hardened Image
-FROM node:20-alpine@sha256:09e2b3d9726018aecf269bd35325f46bf75046a643a66d28360ec71132750ec8 AS production
+FROM node:20-alpine@sha256:b88333c42c23fbd91596ebd7fd10de239cedab9617de04142dde7315e3bc0afa AS production
 
 # Install OpenSSL for Prisma and patch npm's bundled tar (CVE-2026-26960)
 USER root

--- a/services/controls/Dockerfile
+++ b/services/controls/Dockerfile
@@ -5,7 +5,7 @@
 # =============================================================================
 
 # Build stage
-FROM node:20-alpine@sha256:09e2b3d9726018aecf269bd35325f46bf75046a643a66d28360ec71132750ec8 AS builder
+FROM node:20-alpine@sha256:b88333c42c23fbd91596ebd7fd10de239cedab9617de04142dde7315e3bc0afa AS builder
 
 WORKDIR /app
 
@@ -52,7 +52,7 @@ RUN ls -la node_modules/.prisma/client/ 2>/dev/null | head -5 || echo "Checking 
 RUN npm run build
 
 # Production stage
-FROM node:20-alpine@sha256:09e2b3d9726018aecf269bd35325f46bf75046a643a66d28360ec71132750ec8 AS production
+FROM node:20-alpine@sha256:b88333c42c23fbd91596ebd7fd10de239cedab9617de04142dde7315e3bc0afa AS production
 
 # Install OpenSSL for Prisma and patch npm's bundled tar (CVE-2026-26960)
 RUN apk add --no-cache openssl && npm update -g npm

--- a/services/frameworks/Dockerfile
+++ b/services/frameworks/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:20-alpine@sha256:09e2b3d9726018aecf269bd35325f46bf75046a643a66d28360ec71132750ec8 AS builder
+FROM node:20-alpine@sha256:b88333c42c23fbd91596ebd7fd10de239cedab9617de04142dde7315e3bc0afa AS builder
 
 WORKDIR /app
 
@@ -40,7 +40,7 @@ RUN npx prisma generate --schema=../shared/prisma/schema.prisma
 RUN npm run build
 
 # Production stage
-FROM node:20-alpine@sha256:09e2b3d9726018aecf269bd35325f46bf75046a643a66d28360ec71132750ec8 AS production
+FROM node:20-alpine@sha256:b88333c42c23fbd91596ebd7fd10de239cedab9617de04142dde7315e3bc0afa AS production
 
 # Install OpenSSL for Prisma and patch npm's bundled tar (CVE-2026-26960)
 RUN apk add --no-cache openssl && npm update -g npm

--- a/services/policies/Dockerfile
+++ b/services/policies/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage - Using Docker Hardened Image
-FROM node:20-alpine@sha256:09e2b3d9726018aecf269bd35325f46bf75046a643a66d28360ec71132750ec8 AS builder
+FROM node:20-alpine@sha256:b88333c42c23fbd91596ebd7fd10de239cedab9617de04142dde7315e3bc0afa AS builder
 
 WORKDIR /app
 
@@ -40,7 +40,7 @@ RUN npx prisma generate --schema=../shared/prisma/schema.prisma
 RUN npm run build
 
 # Production stage - Using Docker Hardened Image
-FROM node:20-alpine@sha256:09e2b3d9726018aecf269bd35325f46bf75046a643a66d28360ec71132750ec8 AS production
+FROM node:20-alpine@sha256:b88333c42c23fbd91596ebd7fd10de239cedab9617de04142dde7315e3bc0afa AS production
 
 # Install OpenSSL for Prisma and patch npm's bundled tar (CVE-2026-26960)
 USER root

--- a/services/tprm/Dockerfile
+++ b/services/tprm/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage - Using Docker Hardened Image
-FROM node:20-alpine@sha256:09e2b3d9726018aecf269bd35325f46bf75046a643a66d28360ec71132750ec8 AS builder
+FROM node:20-alpine@sha256:b88333c42c23fbd91596ebd7fd10de239cedab9617de04142dde7315e3bc0afa AS builder
 
 WORKDIR /app
 
@@ -40,7 +40,7 @@ RUN npx prisma generate --schema=../shared/prisma/schema.prisma
 RUN npm run build
 
 # Production stage - Using Docker Hardened Image
-FROM node:20-alpine@sha256:09e2b3d9726018aecf269bd35325f46bf75046a643a66d28360ec71132750ec8 AS production
+FROM node:20-alpine@sha256:b88333c42c23fbd91596ebd7fd10de239cedab9617de04142dde7315e3bc0afa AS production
 
 # Install OpenSSL for Prisma and patch npm's bundled tar (CVE-2026-26960)
 USER root

--- a/services/trust/Dockerfile
+++ b/services/trust/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage - Using Docker Hardened Image
-FROM node:20-alpine@sha256:09e2b3d9726018aecf269bd35325f46bf75046a643a66d28360ec71132750ec8 AS builder
+FROM node:20-alpine@sha256:b88333c42c23fbd91596ebd7fd10de239cedab9617de04142dde7315e3bc0afa AS builder
 
 WORKDIR /app
 
@@ -40,7 +40,7 @@ RUN npx prisma generate --schema=../shared/prisma/schema.prisma
 RUN npm run build
 
 # Production stage - Using Docker Hardened Image
-FROM node:20-alpine@sha256:09e2b3d9726018aecf269bd35325f46bf75046a643a66d28360ec71132750ec8 AS production
+FROM node:20-alpine@sha256:b88333c42c23fbd91596ebd7fd10de239cedab9617de04142dde7315e3bc0afa AS production
 
 # Install OpenSSL for Prisma and patch npm's bundled tar (CVE-2026-26960)
 USER root


### PR DESCRIPTION
## Summary

- Updates the pinned `node:20-alpine` Docker image digest across all 7 Dockerfiles (13 FROM statements) to the latest release containing patched system libraries
- Resolves **11 open code scanning alerts** from container scanning

## CVEs Resolved

| CVE | Severity | Description | Component |
|-----|----------|-------------|-----------|
| CVE-2026-22184 | **Critical** | zlib arbitrary code execution via buffer overflow in untgz utility | zlib (system lib) |
| CVE-2026-27171 | Medium | zlib denial of service via infinite loop in CRC32 combine functions | zlib (system lib) |
| CVE-2026-29786 | High | tar hardlink path traversal | npm bundled tar |

## Image Update

| | Old | New |
|---|-----|-----|
| Digest | `sha256:09e2b3d9...` | `sha256:b88333c4...` |
| Node | 20.x | 20.20.1 |
| zlib | vulnerable | 1.3.1-r2 (patched) |

## Files Changed

All production Dockerfiles updated (builder + production stages):
- `services/controls/Dockerfile`
- `services/frameworks/Dockerfile`
- `services/policies/Dockerfile`
- `services/tprm/Dockerfile`
- `services/trust/Dockerfile`
- `services/audit/Dockerfile`
- `frontend/Dockerfile`

## Test plan

- Container scans should pass clean for zlib and tar CVEs
- Docker builds validated by existing CI pipeline
- No application code changes -- only base image digest update