### PR TITLE
fix: remove password keys from values.yaml to resolve CodeQL findings

### DIFF
--- a/helm/templates/secret.yaml
+++ b/helm/templates/secret.yaml
@@ -7,25 +7,25 @@ metadata:
 type: Opaque
 data:
   {{- if .Values.postgresql.enabled }}
-  postgresql-password: {{ required "postgresql.auth.password is required" .Values.postgresql.auth.password | b64enc | quote }}
+  postgresql-password: {{ required "postgresql.auth.password is required -- set via --set postgresql.auth.password=<value>" (dig "auth" "password" "" .Values.postgresql) | b64enc | quote }}
   {{- end }}
   {{- if .Values.redis.enabled }}
-  redis-password: {{ required "redis.auth.password is required" .Values.redis.auth.password | b64enc | quote }}
+  redis-password: {{ required "redis.auth.password is required -- set via --set redis.auth.password=<value>" (dig "auth" "password" "" .Values.redis) | b64enc | quote }}
   {{- end }}
   {{- if .Values.rustfs.enabled }}
   s3-access-key: {{ .Values.rustfs.auth.rootUser | b64enc | quote }}
-  s3-secret-key: {{ required "rustfs.auth.rootPassword is required" .Values.rustfs.auth.rootPassword | b64enc | quote }}
+  s3-secret-key: {{ required "rustfs.auth.rootPassword is required -- set via --set rustfs.auth.rootPassword=<value>" (dig "auth" "rootPassword" "" .Values.rustfs) | b64enc | quote }}
   {{- else if .Values.externalS3.accessKey }}
   s3-access-key: {{ .Values.externalS3.accessKey | b64enc | quote }}
   s3-secret-key: {{ .Values.externalS3.secretKey | b64enc | quote }}
   {{- end }}
   {{- if .Values.keycloak.enabled }}
-  keycloak-admin-password: {{ required "keycloak.auth.adminPassword is required" .Values.keycloak.auth.adminPassword | b64enc | quote }}
+  keycloak-admin-password: {{ required "keycloak.auth.adminPassword is required -- set via --set keycloak.auth.adminPassword=<value>" (dig "auth" "adminPassword" "" .Values.keycloak) | b64enc | quote }}
   {{- end }}
-  encryption-key: {{ .Values.controls.env.encryptionKey | default (randAlphaNum 64) | b64enc | quote }}
-  jwt-secret: {{ .Values.controls.env.jwtSecret | default (randAlphaNum 64) | b64enc | quote }}
-  session-secret: {{ .Values.controls.env.sessionSecret | default (randAlphaNum 64) | b64enc | quote }}
-  phishing-tracking-secret: {{ .Values.controls.env.phishingTrackingSecret | default (randAlphaNum 32) | b64enc | quote }}
+  encryption-key: {{ dig "env" "encryptionKey" "" .Values.controls | default (randAlphaNum 64) | b64enc | quote }}
+  jwt-secret: {{ dig "env" "jwtSecret" "" .Values.controls | default (randAlphaNum 64) | b64enc | quote }}
+  session-secret: {{ dig "env" "sessionSecret" "" .Values.controls | default (randAlphaNum 64) | b64enc | quote }}
+  phishing-tracking-secret: {{ dig "env" "phishingTrackingSecret" "" .Values.controls | default (randAlphaNum 32) | b64enc | quote }}
   {{- if .Values.grafana.enabled }}
-  grafana-admin-password: {{ required "grafana.auth.adminPassword is required when grafana is enabled" .Values.grafana.auth.adminPassword | b64enc | quote }}
+  grafana-admin-password: {{ required "grafana.auth.adminPassword is required -- set via --set grafana.auth.adminPassword=<value>" (dig "auth" "adminPassword" "" .Values.grafana) | b64enc | quote }}
   {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -195,7 +195,7 @@ postgresql:
   auth:
     username: grc
     # -- Password for the database user. MUST be set via --set postgresql.auth.password=<value>
-    password:
+    # password: (intentionally omitted -- required() enforced in templates)
     database: gigachad_grc
     # -- Keycloak uses its own database on the same PostgreSQL instance
     keycloakDatabase: keycloak
@@ -233,7 +233,7 @@ redis:
     pullPolicy: IfNotPresent
   auth:
     # -- Redis password. MUST be set via --set redis.auth.password=<value>
-    password:
+    # password: (intentionally omitted -- required() enforced in templates)
   persistence:
     enabled: true
     size: 2Gi
@@ -268,7 +268,7 @@ keycloak:
   auth:
     adminUser: admin
     # -- Keycloak admin password. MUST be set via --set keycloak.auth.adminPassword=<value>
-    adminPassword:
+    # adminPassword: (intentionally omitted -- required() enforced in templates)
   realm: gigachad-grc
   # -- "dev" uses start-dev (no HTTPS required). "production" uses start (requires HTTPS/hostname config).
   mode: dev
@@ -299,7 +299,7 @@ rustfs:
   auth:
     rootUser: rustfsadmin
     # -- RustFS root password. MUST be set via --set rustfs.auth.rootPassword=<value>
-    rootPassword:
+    # rootPassword: (intentionally omitted -- required() enforced in templates)
   persistence:
     enabled: true
     size: 20Gi
@@ -358,7 +358,7 @@ grafana:
   auth:
     adminUser: admin
     # -- Grafana admin password. MUST be set via --set grafana.auth.adminPassword=<value>
-    adminPassword:
+    # adminPassword: (intentionally omitted -- required() enforced in templates)
   persistence:
     enabled: true
     size: 5Gi


### PR DESCRIPTION
## Summary

- Removes all password/secret YAML keys from `helm/values.yaml` entirely to resolve CodeQL "empty password in configuration file" alerts
- Previous fix (PR #189) changed `password: ''` to `password:` (null), but CodeQL treats YAML null the same as empty string
- Updates `helm/templates/secret.yaml` to use Helm `dig()` for nil-safe value traversal since the keys no longer exist in defaults

## What changed

**`helm/values.yaml`**: All 5 password keys (`postgresql.auth.password`, `redis.auth.password`, `keycloak.auth.adminPassword`, `rustfs.auth.rootPassword`, `grafana.auth.adminPassword`) removed and replaced with comments explaining they must be set via `--set`

**`helm/templates/secret.yaml`**: All `.Values.x.auth.password` references replaced with `dig "auth" "password" "" .Values.x` to safely handle the missing keys without nil pointer errors

## Test plan

- `helm lint ./helm` passes (shows expected warnings about required values)
- `helm lint --strict` with passwords provided passes clean
- `helm template` with passwords renders valid YAML
- No password-related YAML keys exist for CodeQL to flag

Resolves code scanning alerts #259, #260.