### PR TITLE
fix(deploy): resolve Dockerfile parse error and add troubleshooting docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ cd gigachad-grc
 
 1. Checks that Docker is installed and running
 2. Generates a `.env` file with secure random secrets (if one doesn't exist)
-3. Builds and starts all containers with `docker compose up`
+3. Builds and starts all containers with `docker compose up -d --build`
 4. Opens your browser to `http://localhost:3000`
 
 **First run takes 3-5 minutes** while Docker builds the images. Subsequent starts take ~30 seconds.
@@ -151,6 +151,20 @@ This was a Vite code-splitting issue that has been fixed. Pull the latest code:
 ```bash
 git pull origin main
 ./start.sh
+```
+
+### `pull access denied for grc-trust` (or other service)
+
+```
+pull access denied for grc-trust, repository does not exist or may require 'docker login'
+```
+
+All application services (controls, frameworks, trust, etc.) are built locally from Dockerfiles -- they don't exist on Docker Hub. This error means Docker tried to pull the image instead of building it, which happens when you run `docker compose up` without the `--build` flag.
+
+**Fix:** Use `./start.sh` (which includes `--build` automatically), or run:
+
+```bash
+docker compose up -d --build
 ```
 
 ### Port already in use

--- a/deploy/Dockerfile.backup-scheduler
+++ b/deploy/Dockerfile.backup-scheduler
@@ -32,34 +32,8 @@ RUN chmod +x /app/*.sh
 # Set timezone (default to UTC, override with TZ env var)
 ENV TZ=UTC
 
-# Create entrypoint script
-RUN cat > /app/entrypoint.sh << 'EOF'
-#!/bin/bash
-set -e
-
-echo "GigaChad GRC Backup Scheduler starting..."
-echo "Timezone: ${TZ:-UTC}"
-echo "Backup retention: ${BACKUP_RETENTION_DAYS:-90} days"
-echo "Remote backup: ${DR_REMOTE_BACKUP_ENABLED:-false}"
-
-# Update timezone if specified
-if [ -n "$TZ" ]; then
-    ln -snf /usr/share/zoneinfo/$TZ /etc/localtime
-    echo $TZ > /etc/timezone
-fi
-
-# Substitute environment variables in crontab
-envsubst < /etc/crontabs/root > /tmp/crontab.tmp && mv /tmp/crontab.tmp /etc/crontabs/root
-
-# Create log files
-touch /var/log/cron/backup.log /var/log/cron/verify.log /var/log/cron/cleanup.log
-
-echo "Backup schedule configured. Starting cron daemon..."
-
-# Run cron in foreground
-exec crond -f -l 2
-EOF
-
+# Copy entrypoint script
+COPY entrypoint-backup.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
 
 # Volume for backups

--- a/deploy/entrypoint-backup.sh
+++ b/deploy/entrypoint-backup.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+echo "GigaChad GRC Backup Scheduler starting..."
+echo "Timezone: ${TZ:-UTC}"
+echo "Backup retention: ${BACKUP_RETENTION_DAYS:-90} days"
+echo "Remote backup: ${DR_REMOTE_BACKUP_ENABLED:-false}"
+
+# Update timezone if specified
+if [ -n "$TZ" ]; then
+    ln -snf /usr/share/zoneinfo/$TZ /etc/localtime
+    echo $TZ > /etc/timezone
+fi
+
+# Substitute environment variables in crontab
+envsubst < /etc/crontabs/root > /tmp/crontab.tmp && mv /tmp/crontab.tmp /etc/crontabs/root
+
+# Create log files
+touch /var/log/cron/backup.log /var/log/cron/verify.log /var/log/cron/cleanup.log
+
+echo "Backup schedule configured. Starting cron daemon..."
+
+# Run cron in foreground
+exec crond -f -l 2


### PR DESCRIPTION
## Summary

- **Fix backup-scheduler Dockerfile build failure**: The `Dockerfile.backup-scheduler` used a shell heredoc (`RUN cat << 'EOF'`) to inline the entrypoint script, which Docker's parser rejects (it interprets each heredoc line as a Dockerfile instruction, causing `unknown instruction: set`). Extracted the script into `deploy/entrypoint-backup.sh` and `COPY` it in, matching the pattern used for the other scripts in the same image.
- **Add "pull access denied" troubleshooting entry**: Documents the error users hit when running `docker compose up` without the `--build` flag, and points them to `./start.sh` or the correct manual command.
- **Fix Quick Start description**: The README said `start.sh` runs `docker compose up` but it actually runs `docker compose up -d --build`. Updated to show the accurate command.

## Test plan

- [ ] Run `docker compose up -d --build` with the prod compose file and verify backup-scheduler builds successfully
- [ ] Verify `./start.sh` still works end-to-end with the default compose file
- [ ] Confirm the new troubleshooting section renders correctly in the README