### PR TITLE
fix(ci): resolve lockfile desync and replace expired StepSecurity actions

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -97,7 +97,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@183a1442edf41672e66566b7fc560e297a290896 # v2.1.1
 
       - name: Set up Docker Buildx
-        uses: step-security/setup-buildx-action@c60a792b446ef83310733d5cd9d0c8d6870d043f # v3.12.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Extract metadata
         id: meta
@@ -118,7 +118,7 @@ jobs:
           fi
 
       - name: Build and push
-        uses: step-security/docker-build-push-action@a8c3d08b23f8be6aeed43eb1a14ce6fe51284438 # v6.18.0
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
           file: ${{ steps.dockerfile.outputs.path }}

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -160,10 +160,10 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Docker Buildx
-        uses: step-security/setup-buildx-action@c60a792b446ef83310733d5cd9d0c8d6870d043f # v3.12.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Build Docker image
-        uses: step-security/docker-build-push-action@a8c3d08b23f8be6aeed43eb1a14ce6fe51284438 # v6.18.0
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
           file: services/${{ matrix.service }}/Dockerfile

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -165,10 +165,10 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Docker Buildx
-        uses: step-security/setup-buildx-action@c60a792b446ef83310733d5cd9d0c8d6870d043f # v3.12.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Build Docker image for scanning
-        uses: step-security/docker-build-push-action@a8c3d08b23f8be6aeed43eb1a14ce6fe51284438 # v6.18.0
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
           file: services/${{ matrix.service }}/Dockerfile

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "@heroicons/react": "^2.1.1",
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
-        "@okta/okta-react": "6.11.0",
         "@tanstack/react-query": "^5.95.2",
         "@tanstack/react-virtual": "^3.13.23",
         "@types/dompurify": "^3.2.0",
@@ -9227,14 +9226,14 @@
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.22.0.tgz",
       "integrity": "sha512-AUt44v3YJeggO2ZU5BkXI7M4hu9BF2zzH2iF2V5pyXT/lRTyWiElZ7It+bRH1EshoMRxHgpYg4VB6rCM+mG5jQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.22.0.tgz",
       "integrity": "sha512-UNjfslWhAt06kVL3CjkuYpHAWSO6L4kDCVPegV6itt7nD1kSJavd3vhgAEhjglLJJKEdJ7oIqDJ+yHk6qO8gPA==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -9248,14 +9247,14 @@
       "version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2.tgz",
       "integrity": "sha512-2PTmxFR2yHW/eB3uqWtcgRcgAbG1rwG9ZriSvQw+nnb7c4uCr3RAcGMb6/zfE88SKlC1Nj2ziUvc96Z379mHgQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.22.0.tgz",
       "integrity": "sha512-bkrD/Mc2fSvkQBV5EpoFcZ87AvOgDxbG99488a5cexp5Ccny+UM6MAe/UFkUC0wLYD9+9befNOqGiIJhhq+HbA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "5.22.0",
@@ -9267,7 +9266,7 @@
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.22.0.tgz",
       "integrity": "sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "5.22.0"
@@ -15922,6 +15921,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -21622,7 +21622,7 @@
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.22.0.tgz",
       "integrity": "sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@smithy/config-resolver": "^4.4.0",
     "multer": ">=2.1.0",
     "serialize-javascript": ">=7.0.3",
-    "file-type": "21.3.2",
+    "file-type": ">=21.3.4",
     "dompurify": "3.3.3",
     "handlebars": ">=4.7.9",
     "path-to-regexp": ">=8.4.0",


### PR DESCRIPTION
## Summary

- **Lockfile desync fix**: Updated `file-type` override in root `package.json` from pinned `21.3.2` to `>=21.3.4` to match the `services/shared` dependency requirement (`^21.3.4`), resolving `npm ci` failures ("Missing: file-type@21.3.4 from lock file") across all CI jobs.
- **StepSecurity replacement**: Replaced all 6 references to `step-security/setup-buildx-action` and `step-security/docker-build-push-action` (which fail with "Subscription is not valid") with official upstream `docker/setup-buildx-action@v4.0.0` and `docker/build-push-action@v7.0.0` across `security.yml`, `pr-validation.yml`, and `build-push.yml`.

## Files changed

| File | Change |
|------|--------|
| `package.json` | `file-type` override `21.3.2` → `>=21.3.4` |
| `package-lock.json` | Regenerated to reflect updated override |
| `.github/workflows/security.yml` | 2 action replacements (setup-buildx + build-push) |
| `.github/workflows/pr-validation.yml` | 2 action replacements (setup-buildx + build-push) |
| `.github/workflows/build-push.yml` | 2 action replacements (setup-buildx + build-push) |

## Test plan

- [ ] CI security scan jobs pass (no more `npm ci` lockfile errors)
- [ ] Container scan jobs pass (no more StepSecurity subscription errors)
- [ ] Docker build check jobs pass in PR validation
- [ ] `npm audit` reports 0 vulnerabilities