### PR TITLE
fix(security): add npm overrides to service package.json for Docker builds

### DIFF
--- a/services/audit/package.json
+++ b/services/audit/package.json
@@ -44,5 +44,11 @@
     "@types/uuid": "^9.0.8",
     "prisma": "^5.22.0",
     "typescript": "^5.3.3"
+  },
+  "overrides": {
+    "fast-xml-parser": ">=5.5.7",
+    "path-to-regexp": ">=8.4.0",
+    "picomatch": ">=2.3.2",
+    "brace-expansion": ">=5.0.5"
   }
 }

--- a/services/controls/package.json
+++ b/services/controls/package.json
@@ -68,5 +68,11 @@
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.3.3"
+  },
+  "overrides": {
+    "fast-xml-parser": ">=5.5.7",
+    "path-to-regexp": ">=8.4.0",
+    "picomatch": ">=2.3.2",
+    "brace-expansion": ">=5.0.5"
   }
 }

--- a/services/frameworks/package.json
+++ b/services/frameworks/package.json
@@ -49,14 +49,26 @@
     "typescript": "^5.3.3"
   },
   "jest": {
-    "moduleFileExtensions": ["js", "json", "ts"],
+    "moduleFileExtensions": [
+      "js",
+      "json",
+      "ts"
+    ],
     "rootDir": "src",
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
-    "collectCoverageFrom": ["**/*.(t|j)s"],
+    "collectCoverageFrom": [
+      "**/*.(t|j)s"
+    ],
     "coverageDirectory": "../coverage",
     "testEnvironment": "node"
+  },
+  "overrides": {
+    "fast-xml-parser": ">=5.5.7",
+    "path-to-regexp": ">=8.4.0",
+    "picomatch": ">=2.3.2",
+    "brace-expansion": ">=5.0.5"
   }
 }

--- a/services/policies/package.json
+++ b/services/policies/package.json
@@ -36,5 +36,11 @@
     "@types/node": "^20.19.37",
     "prisma": "^5.22.0",
     "typescript": "^5.3.3"
+  },
+  "overrides": {
+    "fast-xml-parser": ">=5.5.7",
+    "path-to-regexp": ">=8.4.0",
+    "picomatch": ">=2.3.2",
+    "brace-expansion": ">=5.0.5"
   }
 }

--- a/services/shared/package.json
+++ b/services/shared/package.json
@@ -48,5 +48,11 @@
   "files": [
     "dist"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "overrides": {
+    "fast-xml-parser": ">=5.5.7",
+    "path-to-regexp": ">=8.4.0",
+    "picomatch": ">=2.3.2",
+    "brace-expansion": ">=5.0.5"
+  }
 }

--- a/services/tprm/package.json
+++ b/services/tprm/package.json
@@ -36,5 +36,11 @@
     "@types/node": "^20.19.37",
     "prisma": "^5.22.0",
     "typescript": "^5.3.3"
+  },
+  "overrides": {
+    "fast-xml-parser": ">=5.5.7",
+    "path-to-regexp": ">=8.4.0",
+    "picomatch": ">=2.3.2",
+    "brace-expansion": ">=5.0.5"
   }
 }

--- a/services/trust/package.json
+++ b/services/trust/package.json
@@ -40,5 +40,11 @@
     "@types/node": "^20.19.37",
     "prisma": "^5.22.0",
     "typescript": "^5.3.3"
+  },
+  "overrides": {
+    "fast-xml-parser": ">=5.5.7",
+    "path-to-regexp": ">=8.4.0",
+    "picomatch": ">=2.3.2",
+    "brace-expansion": ">=5.0.5"
   }
 }


### PR DESCRIPTION
## Summary

- Docker builds install dependencies in isolation (`npm install` without root lockfile), so transitive dependencies resolve to vulnerable versions even though the root workspace has them patched via overrides.
- Adds `overrides` to all 7 service `package.json` files (controls, frameworks, policies, tprm, trust, audit, shared) for the 4 packages with open code scanning alerts:
  - `fast-xml-parser >=5.5.7` (CVE-2026-33036 HIGH, CVE-2026-33349 MEDIUM)
  - `path-to-regexp >=8.4.0` (CVE-2026-4926 HIGH, CVE-2026-4923 MEDIUM)
  - `picomatch >=2.3.2` (CVE-2026-33671 HIGH, CVE-2026-33672 MEDIUM)
  - `brace-expansion >=5.0.5` (CVE-2026-33750 MEDIUM)

## Test plan

- [ ] All 6 Container Scan jobs pass (Trivy finds no HIGH/CRITICAL vulns)
- [ ] Security Summary job passes
- [ ] 17 open code scanning alerts auto-close after new SARIF uploads
- [ ] All existing passing jobs remain green (Backend Validations, Docker Build Checks, etc.)
- [ ] `npm audit` reports 0 vulnerabilities