### PR TITLE
fix(security): remove npm from production images and fix TPRM build

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -177,7 +177,6 @@ jobs:
           tags: grc-${{ matrix.service }}:scan
           cache-from: type=gha
           cache-to: type=gha,mode=max
-        continue-on-error: true
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # master

--- a/services/audit/Dockerfile
+++ b/services/audit/Dockerfile
@@ -42,9 +42,10 @@ RUN npm run build
 # Production stage - Using Docker Hardened Image
 FROM node:20-alpine@sha256:b88333c42c23fbd91596ebd7fd10de239cedab9617de04142dde7315e3bc0afa AS production
 
-# Patch OS-level CVEs (zlib CVE-2026-22184, CVE-2026-27171), install OpenSSL for Prisma
+# Patch OS-level CVEs, install OpenSSL for Prisma, remove npm (not needed at runtime)
 USER root
-RUN apk upgrade --no-cache && apk add --no-cache openssl && npm update -g npm
+RUN apk upgrade --no-cache && apk add --no-cache openssl && \
+    rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 
 WORKDIR /app
 

--- a/services/controls/Dockerfile
+++ b/services/controls/Dockerfile
@@ -54,8 +54,9 @@ RUN npm run build
 # Production stage
 FROM node:20-alpine@sha256:b88333c42c23fbd91596ebd7fd10de239cedab9617de04142dde7315e3bc0afa AS production
 
-# Patch OS-level CVEs (zlib CVE-2026-22184, CVE-2026-27171), install OpenSSL for Prisma
-RUN apk upgrade --no-cache && apk add --no-cache openssl && npm update -g npm
+# Patch OS-level CVEs, install OpenSSL for Prisma, remove npm (not needed at runtime)
+RUN apk upgrade --no-cache && apk add --no-cache openssl && \
+    rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 
 WORKDIR /app
 

--- a/services/controls/docker-entrypoint.sh
+++ b/services/controls/docker-entrypoint.sh
@@ -18,7 +18,7 @@ sleep 5
 # Run database migrations
 echo "[2/2] Synchronizing database schema..."
 cd /app
-npx prisma db push --schema=/app/shared/prisma/schema.prisma --accept-data-loss --skip-generate 2>&1 || {
+./node_modules/.bin/prisma db push --schema=/app/shared/prisma/schema.prisma --accept-data-loss --skip-generate 2>&1 || {
   echo "  Note: Schema may already be up to date."
 }
 

--- a/services/frameworks/Dockerfile
+++ b/services/frameworks/Dockerfile
@@ -42,8 +42,9 @@ RUN npm run build
 # Production stage
 FROM node:20-alpine@sha256:b88333c42c23fbd91596ebd7fd10de239cedab9617de04142dde7315e3bc0afa AS production
 
-# Patch OS-level CVEs (zlib CVE-2026-22184, CVE-2026-27171), install OpenSSL for Prisma
-RUN apk upgrade --no-cache && apk add --no-cache openssl && npm update -g npm
+# Patch OS-level CVEs, install OpenSSL for Prisma, remove npm (not needed at runtime)
+RUN apk upgrade --no-cache && apk add --no-cache openssl && \
+    rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 
 WORKDIR /app
 

--- a/services/policies/Dockerfile
+++ b/services/policies/Dockerfile
@@ -42,9 +42,10 @@ RUN npm run build
 # Production stage - Using Docker Hardened Image
 FROM node:20-alpine@sha256:b88333c42c23fbd91596ebd7fd10de239cedab9617de04142dde7315e3bc0afa AS production
 
-# Patch OS-level CVEs (zlib CVE-2026-22184, CVE-2026-27171), install OpenSSL for Prisma
+# Patch OS-level CVEs, install OpenSSL for Prisma, remove npm (not needed at runtime)
 USER root
-RUN apk upgrade --no-cache && apk add --no-cache openssl && npm update -g npm
+RUN apk upgrade --no-cache && apk add --no-cache openssl && \
+    rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 
 WORKDIR /app
 

--- a/services/tprm/Dockerfile
+++ b/services/tprm/Dockerfile
@@ -42,9 +42,10 @@ RUN npm run build
 # Production stage - Using Docker Hardened Image
 FROM node:20-alpine@sha256:b88333c42c23fbd91596ebd7fd10de239cedab9617de04142dde7315e3bc0afa AS production
 
-# Patch OS-level CVEs (zlib CVE-2026-22184, CVE-2026-27171), install OpenSSL for Prisma
+# Patch OS-level CVEs, install OpenSSL for Prisma, remove npm (not needed at runtime)
 USER root
-RUN apk upgrade --no-cache && apk add --no-cache openssl && npm update -g npm
+RUN apk upgrade --no-cache && apk add --no-cache openssl && \
+    rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 
 WORKDIR /app
 

--- a/services/tprm/src/security-scanner/collectors/ssl-collector.ts
+++ b/services/tprm/src/security-scanner/collectors/ssl-collector.ts
@@ -98,7 +98,10 @@ export class SSLCollector {
           const cert = socket.getPeerCertificate();
           if (cert && cert.valid_to) {
             result.enabled = true;
-            result.issuer = cert.issuer?.CN || cert.issuer?.O || 'Unknown';
+            const cn = cert.issuer?.CN;
+            const org = cert.issuer?.O;
+            result.issuer =
+              (Array.isArray(cn) ? cn[0] : cn) || (Array.isArray(org) ? org[0] : org) || 'Unknown';
             result.expiry = cert.valid_to;
 
             // Calculate days until expiry

--- a/services/trust/Dockerfile
+++ b/services/trust/Dockerfile
@@ -42,9 +42,10 @@ RUN npm run build
 # Production stage - Using Docker Hardened Image
 FROM node:20-alpine@sha256:b88333c42c23fbd91596ebd7fd10de239cedab9617de04142dde7315e3bc0afa AS production
 
-# Patch OS-level CVEs (zlib CVE-2026-22184, CVE-2026-27171), install OpenSSL for Prisma
+# Patch OS-level CVEs, install OpenSSL for Prisma, remove npm (not needed at runtime)
 USER root
-RUN apk upgrade --no-cache && apk add --no-cache openssl && npm update -g npm
+RUN apk upgrade --no-cache && apk add --no-cache openssl && \
+    rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- **Remove npm from all 6 production Docker images** — npm is not needed at runtime (`node dist/main` is the only process), but the system npm bundled with node:20-alpine contains vulnerable picomatch (CVE-2026-33671 HIGH, CVE-2026-33672) and brace-expansion (CVE-2026-33750) in `/usr/local/lib/node_modules/npm/` that cannot be patched via application-level overrides. Removing npm eliminates these vulnerabilities entirely and reduces attack surface.
- **Fix TPRM TypeScript build failure** — `ssl-collector.ts:101` had a type error where `cert.issuer.CN` can be `string | string[]` per Node.js TLS types, causing the Docker build to fail and the container scan to error out.
- **Update controls entrypoint** — changed `npx prisma` to `./node_modules/.bin/prisma` since npm is no longer available in production images.
- **Remove `continue-on-error: true` from Container Scan Docker build step** — build failures were being silently swallowed, causing misleading "unable to find image" errors from Trivy instead of surfacing the actual build error.

## What was failing
All 6 Container Scan jobs fail because Trivy detects HIGH-severity picomatch CVE-2026-33671 in the base image's npm installation (`usr/local/lib/node_modules/npm/node_modules/tinyglobby/node_modules/picomatch`). TPRM additionally fails at the Docker build step due to a TypeScript compilation error.

## Test plan
- [ ] All 6 Container Scan jobs should pass (no more picomatch/brace-expansion findings in system npm)
- [ ] TPRM Docker build succeeds (TypeScript error fixed)
- [ ] Controls service starts correctly with `./node_modules/.bin/prisma` entrypoint
- [ ] Security Summary job passes