### PR TITLE
fix(security): remediate lodash, xmldom, nodemailer, hono, and path-to-regexp vulnerabilities

### DIFF
--- a/mcp-servers/grc-ai-assistant/package-lock.json
+++ b/mcp-servers/grc-ai-assistant/package-lock.json
@@ -1287,9 +1287,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.8",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
-      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/mcp-servers/grc-compliance/package-lock.json
+++ b/mcp-servers/grc-compliance/package-lock.json
@@ -1218,9 +1218,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.8",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
-      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/mcp-servers/grc-evidence/package-lock.json
+++ b/mcp-servers/grc-evidence/package-lock.json
@@ -4353,9 +4353,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.8",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
-      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "@heroicons/react": "^2.1.1",
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
-        "@okta/okta-auth-js": "7.14.2",
         "@tanstack/react-query": "^5.95.2",
         "@tanstack/react-virtual": "^3.13.23",
         "@types/dompurify": "^3.2.0",
@@ -8975,6 +8974,15 @@
         }
       }
     },
+    "node_modules/@nestjs/swagger/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/@nestjs/testing": {
       "version": "11.1.17",
       "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-11.1.17.tgz",
@@ -11937,9 +11945,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
+      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -18963,9 +18971,8 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "license": "MIT"
     },
     "node_modules/lodash.clonedeep": {
@@ -20493,9 +20500,9 @@
       "license": "MIT"
     },
     "node_modules/nodemailer": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.4.tgz",
-      "integrity": "sha512-k+jf6N8PfQJ0Fe8ZhJlgqU5qJU44Lpvp2yvidH3vp1lPnVQMgi4yEEMPXg5eJS1gFIJTVq1NHBk7Ia9ARdSBdQ==",
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.5.tgz",
+      "integrity": "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
@@ -26045,7 +26052,7 @@
         "helmet": "^7.1.0",
         "isolated-vm": "^5.0.1",
         "js-yaml": "^4.1.0",
-        "nodemailer": "^8.0.4",
+        "nodemailer": "^8.0.5",
         "pdfkit": "^0.18.0",
         "prom-client": "^15.1.3",
         "reflect-metadata": "^0.1.14",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     },
     "minipass": "^7.1.2",
     "@isaacs/brace-expansion": "^5.0.0",
-    "lodash": "^4.17.23",
+    "lodash": ">=4.18.0",
     "fast-xml-parser": ">=5.5.7",
     "axios": "^1.13.5",
     "minimatch": "^10.2.3",
@@ -80,6 +80,8 @@
     "handlebars": ">=4.7.9",
     "path-to-regexp": ">=8.4.0",
     "picomatch": ">=2.3.2",
+    "@xmldom/xmldom": ">=0.8.12",
+    "nodemailer": ">=8.0.5",
     "yaml": ">=2.8.3",
     "@nestjs/cli": {
       "@angular-devkit/core": {

--- a/services/audit/package.json
+++ b/services/audit/package.json
@@ -49,6 +49,7 @@
     "fast-xml-parser": ">=5.5.7",
     "path-to-regexp": ">=8.4.0",
     "picomatch": ">=2.3.2",
-    "brace-expansion": ">=5.0.5"
+    "brace-expansion": ">=5.0.5",
+    "lodash": ">=4.18.0"
   }
 }

--- a/services/controls/package.json
+++ b/services/controls/package.json
@@ -43,7 +43,7 @@
     "helmet": "^7.1.0",
     "isolated-vm": "^5.0.1",
     "js-yaml": "^4.1.0",
-    "nodemailer": "^8.0.4",
+    "nodemailer": "^8.0.5",
     "pdfkit": "^0.18.0",
     "prom-client": "^15.1.3",
     "reflect-metadata": "^0.1.14",
@@ -73,6 +73,7 @@
     "fast-xml-parser": ">=5.5.7",
     "path-to-regexp": ">=8.4.0",
     "picomatch": ">=2.3.2",
-    "brace-expansion": ">=5.0.5"
+    "brace-expansion": ">=5.0.5",
+    "lodash": ">=4.18.0"
   }
 }

--- a/services/frameworks/package.json
+++ b/services/frameworks/package.json
@@ -69,6 +69,7 @@
     "fast-xml-parser": ">=5.5.7",
     "path-to-regexp": ">=8.4.0",
     "picomatch": ">=2.3.2",
-    "brace-expansion": ">=5.0.5"
+    "brace-expansion": ">=5.0.5",
+    "lodash": ">=4.18.0"
   }
 }

--- a/services/policies/package.json
+++ b/services/policies/package.json
@@ -41,6 +41,7 @@
     "fast-xml-parser": ">=5.5.7",
     "path-to-regexp": ">=8.4.0",
     "picomatch": ">=2.3.2",
-    "brace-expansion": ">=5.0.5"
+    "brace-expansion": ">=5.0.5",
+    "lodash": ">=4.18.0"
   }
 }

--- a/services/shared/package.json
+++ b/services/shared/package.json
@@ -53,6 +53,7 @@
     "fast-xml-parser": ">=5.5.7",
     "path-to-regexp": ">=8.4.0",
     "picomatch": ">=2.3.2",
-    "brace-expansion": ">=5.0.5"
+    "brace-expansion": ">=5.0.5",
+    "lodash": ">=4.18.0"
   }
 }

--- a/services/tprm/package.json
+++ b/services/tprm/package.json
@@ -41,6 +41,7 @@
     "fast-xml-parser": ">=5.5.7",
     "path-to-regexp": ">=8.4.0",
     "picomatch": ">=2.3.2",
-    "brace-expansion": ">=5.0.5"
+    "brace-expansion": ">=5.0.5",
+    "lodash": ">=4.18.0"
   }
 }

--- a/services/trust/package.json
+++ b/services/trust/package.json
@@ -45,6 +45,7 @@
     "fast-xml-parser": ">=5.5.7",
     "path-to-regexp": ">=8.4.0",
     "picomatch": ">=2.3.2",
-    "brace-expansion": ">=5.0.5"
+    "brace-expansion": ">=5.0.5",
+    "lodash": ">=4.18.0"
   }
 }


### PR DESCRIPTION
## Summary
Addresses all remaining npm audit findings and Dependabot security alerts across the entire project.

**Vulnerabilities fixed:**
| Package | Severity | CVE/Advisory | Fix |
|---------|----------|-------------|-----|
| lodash <= 4.17.23 | HIGH | CVE-2026-4800, CVE-2026-2950 | Override to >=4.18.0 |
| @xmldom/xmldom < 0.8.12 | HIGH | GHSA-wh4c-j3r5-mjhp | Override to >=0.8.12 |
| path-to-regexp 8.3.0 | HIGH | GHSA-j3q9-mxjg-w52f, GHSA-27v5-c462-wpq7 | Fix nested @nestjs/swagger copy to 8.4.2 |
| nodemailer <= 8.0.4 | MEDIUM | GHSA-vvjj-xcjg-gr5g | Bump to ^8.0.5 in controls |
| hono < 4.12.12 | MEDIUM | 5 CVEs (15 alerts) | Update lockfiles in 3 MCP servers |

**Results:** `npm audit` returns 0 vulnerabilities across root workspace and all 3 MCP servers.

## Changes
- Root `package.json`: updated lodash override from `^4.17.23` to `>=4.18.0`, added `@xmldom/xmldom` and `nodemailer` overrides
- All 7 service `package.json` files: added `lodash` override for isolated Docker builds
- `services/controls/package.json`: bumped nodemailer direct dependency to `^8.0.5`
- `package-lock.json`: lodash 4.17.23 → 4.18.1, @nestjs/swagger's path-to-regexp 8.3.0 → 8.4.2
- 3 MCP server lockfiles: hono updated to 4.12.12

## Test plan
- [ ] `npm audit` passes with 0 vulnerabilities
- [ ] Dependency Scan CI job passes
- [ ] Security Scanning CI job passes
- [ ] All backend services build and start correctly
- [ ] Dependabot alerts auto-close after merge