### PR TITLE
chore(deps): bump axios from 1.15.0 to 1.15.1

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,7 +32,7 @@
     "@tanstack/react-virtual": "^3.13.23",
     "@types/dompurify": "^3.2.0",
     "@types/react-grid-layout": "^1.3.6",
-    "axios": "^1.15.0",
+    "axios": "^1.15.1",
     "clsx": "^2.1.0",
     "date-fns": "^3.2.0",
     "dompurify": "^3.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "@tanstack/react-virtual": "^3.13.23",
         "@types/dompurify": "^3.2.0",
         "@types/react-grid-layout": "^1.3.6",
-        "axios": "^1.15.0",
+        "axios": "^1.15.1",
         "clsx": "^2.1.0",
         "date-fns": "^3.2.0",
         "dompurify": "^3.4.0",
@@ -99,6 +99,17 @@
         "i18next": "^23.7.16",
         "i18next-browser-languagedetector": "^7.2.0",
         "react-i18next": "^14.0.0"
+      }
+    },
+    "frontend/node_modules/axios": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
+      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "frontend/node_modules/js-sha256": {
@@ -25652,7 +25663,7 @@
         "@nestjs/swagger": "^11.3.2",
         "@nestjs/throttler": "^6.4.0",
         "@prisma/client": "^5.22.0",
-        "axios": "^1.15.0",
+        "axios": "^1.15.1",
         "bcrypt": "^6.0.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.15.1",
@@ -25671,6 +25682,17 @@
         "@types/uuid": "^9.0.8",
         "prisma": "^5.22.0",
         "typescript": "^5.3.3"
+      }
+    },
+    "services/audit/node_modules/axios": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
+      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "services/audit/node_modules/class-validator": {
@@ -25713,7 +25735,7 @@
         "@types/nodemailer": "^7.0.4",
         "@types/pdfkit": "^0.17.5",
         "@willsoto/nestjs-prometheus": "^6.0.0",
-        "axios": "^1.15.0",
+        "axios": "^1.15.1",
         "bullmq": "^5.75.2",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.15.1",
@@ -25749,6 +25771,17 @@
         "ts-node": "^10.9.2",
         "tsconfig-paths": "^4.2.0",
         "typescript": "^5.3.3"
+      }
+    },
+    "services/controls/node_modules/axios": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
+      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "services/controls/node_modules/class-validator": {
@@ -26043,7 +26076,7 @@
         "@nestjs/swagger": "^11.3.2",
         "@nestjs/throttler": "^6.4.0",
         "@prisma/client": "^5.22.0",
-        "axios": "^1.15.0",
+        "axios": "^1.15.1",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.15.1",
         "exceljs": "^4.4.0",
@@ -26059,6 +26092,17 @@
         "@types/node": "^20.19.39",
         "prisma": "^5.22.0",
         "typescript": "^5.3.3"
+      }
+    },
+    "services/trust/node_modules/axios": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
+      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "services/trust/node_modules/class-validator": {

--- a/services/audit/package.json
+++ b/services/audit/package.json
@@ -24,7 +24,7 @@
     "@nestjs/swagger": "^11.3.2",
     "@nestjs/throttler": "^6.4.0",
     "@prisma/client": "^5.22.0",
-    "axios": "^1.15.0",
+    "axios": "^1.15.1",
     "bcrypt": "^6.0.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.1",

--- a/services/controls/package.json
+++ b/services/controls/package.json
@@ -32,7 +32,7 @@
     "@types/nodemailer": "^7.0.4",
     "@types/pdfkit": "^0.17.5",
     "@willsoto/nestjs-prometheus": "^6.0.0",
-    "axios": "^1.15.0",
+    "axios": "^1.15.1",
     "bullmq": "^5.75.2",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.1",

--- a/services/trust/package.json
+++ b/services/trust/package.json
@@ -23,7 +23,7 @@
     "@nestjs/swagger": "^11.3.2",
     "@nestjs/throttler": "^6.4.0",
     "@prisma/client": "^5.22.0",
-    "axios": "^1.15.0",
+    "axios": "^1.15.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.1",
     "helmet": "^7.2.0",


### PR DESCRIPTION
## Summary

- Bumps axios from 1.15.0 to 1.15.1 across frontend, audit, controls, and trust services
- Supersedes #271 which has unresolvable lockfile conflicts
- Lockfile regenerated with npm 10 for CI compatibility