### PR TITLE
fix(deps): bump fast-xml-parser override to >=5.7.0 (GHSA-gh4j-gqv2-49f6)

### DIFF
--- a/mcp-servers/grc-evidence/package-lock.json
+++ b/mcp-servers/grc-evidence/package-lock.json
@@ -1967,6 +1967,18 @@
         }
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@octokit/auth-token": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
@@ -3934,9 +3946,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
       "funding": [
         {
           "type": "github",
@@ -3949,9 +3961,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.9",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.9.tgz",
-      "integrity": "sha512-jldvxr1MC6rtiZKgrFnDSvT8xuH+eJqxqOBThUVjYrxssYTo1avZLGql5l0a0BAERR01CadYzZ83kVEkbyDg+g==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
       "funding": [
         {
           "type": "github",
@@ -3960,9 +3972,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.2"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -4950,9 +4963,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
-      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "funding": [
         {
           "type": "github",
@@ -5481,9 +5494,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
-      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
       "funding": [
         {
           "type": "github",

--- a/mcp-servers/grc-evidence/package.json
+++ b/mcp-servers/grc-evidence/package.json
@@ -33,7 +33,7 @@
     "tsx": "^4.0.0"
   },
   "overrides": {
-    "fast-xml-parser": ">=5.5.7",
+    "fast-xml-parser": ">=5.7.0",
     "basic-ftp": ">=5.3.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15576,7 +15576,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "minipass": "^7.1.2",
     "@isaacs/brace-expansion": "^5.0.0",
     "lodash": ">=4.18.0",
-    "fast-xml-parser": ">=5.5.7",
+    "fast-xml-parser": ">=5.7.0",
     "axios": "^1.13.5",
     "minimatch": "^10.2.3",
     "rollup": "^4.59.0",

--- a/services/shared/package.json
+++ b/services/shared/package.json
@@ -50,7 +50,7 @@
   ],
   "license": "MIT",
   "overrides": {
-    "fast-xml-parser": ">=5.5.7",
+    "fast-xml-parser": ">=5.7.0",
     "path-to-regexp": ">=8.4.0",
     "picomatch": ">=2.3.2",
     "brace-expansion": ">=5.0.5",


### PR DESCRIPTION
## Summary
- Bumps the `fast-xml-parser` override floor from `>=5.5.7` to `>=5.7.0` in the root, `services/shared`, and `mcp-servers/grc-evidence` `package.json` files. The 5.7.0 release patches GHSA-gh4j-gqv2-49f6 (XMLBuilder XML comment / CDATA injection via unescaped delimiters).
- Refreshes `mcp-servers/grc-evidence/package-lock.json` so the resolved `fast-xml-parser` jumps from 5.5.9 → 5.7.2 (with consistent transitive bumps for `fast-xml-builder`, `path-expression-matcher`, `strnum`, plus the new `@nodable/entities` dep). Closes Dependabot alert #216.
- Root `package-lock.json` already resolved to 5.7.1 under the previous override; the override bump is forward-protection only and the lockfile diff is a single benign npm metadata normalization.

## Related security/quality work in this batch (no code change required)
- **Dependabot alerts #213/#214/#215 (uuid `<14.0.0`)** — dismissed as `tolerable_risk`. Codebase only invokes `uuid.v4()` (verified across `services/shared`, `services/audit`, `services/controls`, `mcp-servers`); GHSA-w5hq-g745-h8pq impacts only `v3`/`v5`/`v6` buffer-bounds. Cannot upgrade to v14 yet because uuid v12+ removed CommonJS support and the backend services compile TS to `module: commonjs` on Node 20.
- **Trivy code-scanning alerts #306/#307/#308 (uuid)** — dismissed with the same rationale.
- **Dependabot PR #279 (`uuid 9 → 14`)** — closed; would have broken the CommonJS backend at runtime and addresses an advisory the codebase is not exposed to.

## Test plan
- [ ] PR Validation workflow (`Frontend Validation`, `Backend Validation (*)`, `Docker Build Check (*)`) passes on the bumped lockfile.
- [ ] Security workflow (`Dependency Scan`, `Container Scan (*)`, `License Compliance`, `Security Summary`) passes.
- [ ] Confirm Dependabot alert #216 closes automatically once the merge commit is scanned.