### PR TITLE
fix(deps): bump fast-xml-parser override to >=5.7.0

### DIFF
--- a/mcp-servers/grc-evidence/package.json
+++ b/mcp-servers/grc-evidence/package.json
@@ -33,7 +33,7 @@
     "tsx": "^4.0.0"
   },
   "overrides": {
-    "fast-xml-parser": ">=5.5.7",
+    "fast-xml-parser": ">=5.7.0",
     "basic-ftp": ">=5.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "minipass": "^7.1.2",
     "@isaacs/brace-expansion": "^5.0.0",
     "lodash": ">=4.18.0",
-    "fast-xml-parser": ">=5.5.7",
+    "fast-xml-parser": ">=5.7.0",
     "fast-xml-builder": ">=1.2.0",
     "fast-uri": ">=3.1.2",
     "axios": ">=1.15.2",


### PR DESCRIPTION
## Summary
Bumps the `fast-xml-parser` npm override floor from `>=5.5.7` to `>=5.7.0` in the root `package.json` and `mcp-servers/grc-evidence/package.json`. Closes [GHSA-gh4j-gqv2-49f6](https://github.com/advisories/GHSA-gh4j-gqv2-49f6) (XMLBuilder XML comment / CDATA injection via unescaped delimiters), fixed in 5.7.0.

## Why this PR exists
- The lockfile rewrite in #293 already resolved `fast-xml-parser` to 5.8.0 across the workspace, so runtime exposure is gone today.
- The override floors in `package.json` were still pinned at `>=5.5.7`, allowing a future install to land on a pre-5.7.0 release. This commit lifts the floors as forward-protection.
- No lockfile changes are required (resolved versions already satisfy `>=5.7.0`).

Supersedes #281, which carried the same intent but became conflicted after #293.

## Test plan
- [ ] PR Validation passes (no functional changes).
- [ ] Security workflow passes (no new audit findings).
- [ ] Resolved `fast-xml-parser` version remains 5.8.0 in both root and `mcp-servers/grc-evidence` lockfiles.