### PR TITLE
fix(frontend): wire 4 pages to auth context; remove fake trend variance

### DIFF
--- a/frontend/src/pages/AssessmentDetail.tsx
+++ b/frontend/src/pages/AssessmentDetail.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { ArrowLeftIcon, TrashIcon, PencilIcon } from '@heroicons/react/24/outline';
 import { assessmentsApi, vendorsApi } from '../lib/api';
 import { VendorAssessment, Vendor } from '../lib/apiTypes';
+import { useAuth } from '@/contexts/AuthContext';
 
 interface AssessmentFormProps {
   assessment: VendorAssessment | null;
@@ -584,6 +585,7 @@ function AssessmentView({ assessment, onEdit, onDelete }: { assessment: VendorAs
 export default function AssessmentDetail() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const { user } = useAuth();
   const [assessment, setAssessment] = useState<VendorAssessment | null>(null);
   const [loading, setLoading] = useState(true);
   const [editing, setEditing] = useState(false);
@@ -610,8 +612,14 @@ export default function AssessmentDetail() {
 
   const handleSave = async (formData: Partial<VendorAssessment>) => {
     try {
-      // Get organizationId from localStorage with fallback to default org
-      const organizationId = localStorage.getItem('organizationId') || '8924f0c1-7bb1-4be8-84ee-ad8725c712bf';
+      // Organization ID must come from the authenticated user. Previously
+      // this fell back to a hardcoded UUID, which routed unauthenticated
+      // writes into a random tenant's data.
+      const organizationId = user?.organizationId;
+      if (!organizationId) {
+        console.error('Cannot save assessment: no authenticated user / organizationId');
+        return;
+      }
       
       // Clean up form data - remove empty strings and undefined values for optional fields
       const cleanedData: Record<string, unknown> = {

--- a/frontend/src/pages/KnowledgeBase.tsx
+++ b/frontend/src/pages/KnowledgeBase.tsx
@@ -52,6 +52,14 @@ export default function KnowledgeBase() {
   };
 
   const parseCsv = (csvText: string) => {
+    // Organization ID must come from the authenticated user. Previously this
+    // was hardcoded to 'default-org', which routed every CSV-imported entry
+    // into a fictitious tenant regardless of who was signed in.
+    const organizationId = user?.organizationId;
+    if (!organizationId) {
+      throw new Error('Cannot import knowledge-base entries: no authenticated user / organizationId');
+    }
+
     const lines = csvText.trim().split('\n');
     const headers = parseCsvLine(lines[0]);
 
@@ -61,7 +69,7 @@ export default function KnowledgeBase() {
 
       const values = parseCsvLine(lines[i]);
       const entry: any = {
-        organizationId: 'default-org',
+        organizationId,
       };
 
       headers.forEach((header, index) => {

--- a/frontend/src/pages/QuestionnaireDetail.tsx
+++ b/frontend/src/pages/QuestionnaireDetail.tsx
@@ -5,6 +5,7 @@ import { questionnairesApi } from '../lib/api';
 import { Button } from '@/components/Button';
 import { SkeletonDetailHeader, SkeletonDetailSection } from '@/components/Skeleton';
 import { KnowledgeBaseSearchPanel } from '@/components/trust/KnowledgeBaseSearchPanel';
+import { useAuth } from '@/contexts/AuthContext';
 import toast from 'react-hot-toast';
 import clsx from 'clsx';
 
@@ -33,6 +34,7 @@ interface Question {
 export default function QuestionnaireDetail() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const { user } = useAuth();
   const [questionnaire, setQuestionnaire] = useState<Questionnaire | null>(null);
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
@@ -98,12 +100,19 @@ export default function QuestionnaireDetail() {
   };
 
   const updateAnswer = async (questionId: string, answer: string) => {
+    // x-user-id used to be hardcoded to 'system', which meant every
+    // answer was attributed to a fake user — breaking audit trails for
+    // a compliance product. Use the authenticated user's id instead.
+    if (!user?.id) {
+      console.error('Cannot update answer: no authenticated user');
+      return;
+    }
     try {
       await fetch(`/api/questionnaires/questions/${questionId}`, {
         method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
-          'x-user-id': 'system',
+          'x-user-id': user.id,
         },
         body: JSON.stringify({
           answerText: answer,

--- a/frontend/src/pages/RiskReports.tsx
+++ b/frontend/src/pages/RiskReports.tsx
@@ -222,7 +222,18 @@ const getExportColumns = (reportType: ReportType) => {
   }
 };
 
-// Generate mock trend data based on actual risks
+// Approximate trend data derived from the current risk list. This is NOT
+// historical state — it filters the current risks by createdAt and applies
+// today's status to past months. A risk created in Jan that was open then
+// and mitigated in Mar will show as "mitigated" for both months. Accurate
+// trends require backend-recorded status snapshots, which the risks API
+// doesn't yet expose. Use this chart as a directional indicator only.
+//
+// Previously this function added `Math.random() * 3 - 1` "variance for
+// visual interest" to the openRisks and mitigatedRisks counts, which
+// fabricated synthetic noise on top of an already-approximate metric.
+// That variance has been removed; the numbers are now deterministic and
+// derived from real data.
 function generateTrendData(risks: Risk[], months: number = 6) {
   const now = new Date();
   const trendData = [];
@@ -235,7 +246,8 @@ function generateTrendData(risks: Risk[], months: number = 6) {
     const monthEnd = new Date(date.getFullYear(), date.getMonth() + 1, 0);
     const risksUpToDate = risks.filter((r) => new Date(r.createdAt) <= monthEnd);
 
-    // Calculate metrics
+    // Calculate metrics. NOTE: status fields reflect TODAY's state, not the
+    // state on `monthEnd`. See function-level comment.
     const openRisks = risksUpToDate.filter(
       (r) => r.status === 'open' || r.status === 'in_treatment'
     ).length;
@@ -246,14 +258,11 @@ function generateTrendData(risks: Risk[], months: number = 6) {
       (r) => r.inherentRisk === 'critical' || r.inherentRisk === 'high'
     ).length;
 
-    // Simulate some variance for visual interest (in real app, this would be actual historical data)
-    const variance = Math.floor(Math.random() * 3) - 1;
-
     trendData.push({
       month: monthName,
-      openRisks: Math.max(0, openRisks + variance),
-      mitigatedRisks: Math.max(0, mitigatedRisks + variance),
-      criticalHighRisks: Math.max(0, criticalHighRisks),
+      openRisks,
+      mitigatedRisks,
+      criticalHighRisks,
       totalRisks: risksUpToDate.length,
     });
   }
@@ -426,8 +435,12 @@ export default function RiskReports() {
       const response = await risksApi.list({
         ...(filters as any),
         limit: 1000,
-        // Note: In a real app, dateRange would be sent to backend
-        // For now, we'll filter client-side
+        // The risks list endpoint does not yet accept a date range. Until
+        // it does (RiskListParams in apiTypes.ts would need start/end), we
+        // filter by createdAt client-side below. This means we still pay
+        // for transferring the full list across the network — acceptable
+        // while the tenant risk-count cap is the 1000 limit above; revisit
+        // if larger tenants need this view.
       });
       return response.data;
     },


### PR DESCRIPTION
## Summary

Closes the 4 CRITICAL + 2 HIGH findings from the frontend audit of `frontend/src/pages/`. All six are real bugs in user-facing code on this compliance product; this PR fixes them in one combined change.

### CRITICAL — write paths attributed to a fake tenant/user

| File | Bug | Fix |
|---|---|---|
| `AssessmentDetail.tsx` | `organizationId` fell back to a hardcoded UUID (`8924f0c1-…`) when localStorage was empty, so saves from any unauthenticated session landed in a random tenant. | Derive from `useAuth()`; abort save with an error if no user. |
| `KnowledgeBase.tsx` | CSV bulk import hardcoded `organizationId: 'default-org'`, so every imported entry landed in a fictitious tenant regardless of the signed-in user. | Use the authenticated user's `organizationId`; throw if no user. |
| `QuestionnaireDetail.tsx` | `PATCH /questions/:id` sent `x-user-id: 'system'`, attributing every answer edit to a fake user. This breaks audit trails on a compliance product. | Use the authenticated user's `id`; abort the update if no user. |
| `RiskReports.tsx` (variance) | `generateTrendData()` added `Math.floor(Math.random() * 3) - 1` "variance for visual interest" to openRisks/mitigatedRisks counts, fabricating noise on top of an already-approximate metric. | Variance removed; counts are now deterministic. |

### HIGH — honest comments around remaining approximations

| File | Issue | Fix |
|---|---|---|
| `RiskReports.tsx` (trend basis) | The prior comment said "Generate mock trend data based on actual risks" but did not call out that status fields reflect *today's* state, not the state at each past month's end. | Function-level comment now explains the limitation explicitly and notes that real historical snapshots require backend-recorded status history (not yet exposed by the risks API). |
| `RiskReports.tsx` (date filter) | The prior comment said "In a real app, dateRange would be sent to backend / For now, we'll filter client-side" without saying *why* — there was no link to the missing backend contract. | Comment now explains that `RiskListParams` in `apiTypes.ts` doesn't yet accept start/end, so we filter on `createdAt` in the browser, and notes the 1000-record limit as the safety net for tenant size. |

## Why these matter

The auth-context fixes are not cosmetic. On a multi-tenant compliance product, write paths that fall back to a hardcoded tenant ID or a `'system'` user silently corrupt tenant isolation and audit trails — the two things a GRC product is sold on. None of the four sites had any check that the fallback path was actually unreachable; they were live in the default render path.

The variance removal in `RiskReports` is also load-bearing: a risk dashboard that injects random noise into its own numbers can't be defended in an audit, and a user comparing the chart to the underlying list will see disagreement.

## Test plan

- [x] `npx tsc --noEmit` in `frontend/` — passes with no errors
- [ ] Sign in as a user with a real `organizationId`; confirm assessment save, KB CSV import, and questionnaire answer edit all succeed and land under the correct tenant
- [ ] Sign out (or simulate `user=null`); confirm each of the three write paths logs a console error and does not fire a write
- [ ] Open the Risk Reports trend chart with the same data twice; confirm openRisks/mitigatedRisks counts are now identical run-to-run (no random variance)
- [ ] Confirm the date-range filter in Risk Reports still narrows results client-side as before

## Out of scope

- Backend support for `start`/`end` in `RiskListParams` (would let us push date filtering to the database). Tracked separately; comment in code now points at the missing contract.
- Backend-recorded risk-status snapshots (would let `generateTrendData` produce true historical trends instead of current-state-applied-to-past-months). Same — comment in code is honest about the gap.