### PR TITLE
fix(frontend): finish tenant-scoping cleanup missed in PR #298

### DIFF
--- a/frontend/src/components/trust/AIAnswerAssistant.tsx
+++ b/frontend/src/components/trust/AIAnswerAssistant.tsx
@@ -30,7 +30,7 @@ export function AIAnswerAssistant({
   className,
 }: AIAnswerAssistantProps) {
   const { user } = useAuth();
-  const organizationId = user?.organizationId || 'default-org';
+  const organizationId = user?.organizationId;
   const [suggestion, setSuggestion] = useState<AnswerSuggestion | null>(null);
   const [isExpanded, setIsExpanded] = useState(false);
   const [aiEnabled, setAiEnabled] = useState<boolean | null>(null);
@@ -38,6 +38,7 @@ export function AIAnswerAssistant({
   // Check if AI is enabled
   const checkAiMutation = useMutation({
     mutationFn: async () => {
+      if (!organizationId) throw new Error('Not signed in');
       const response = await trustConfigApi.get(organizationId);
       return response.data.aiSettings?.enabled === true;
     },
@@ -52,6 +53,7 @@ export function AIAnswerAssistant({
   // Generate draft answer
   const draftMutation = useMutation({
     mutationFn: async () => {
+      if (!organizationId) throw new Error('Not signed in');
       const response = await trustAiApi.draftAnswer(organizationId, questionText);
       return response.data;
     },
@@ -67,6 +69,7 @@ export function AIAnswerAssistant({
   // Improve existing answer
   const improveMutation = useMutation({
     mutationFn: async () => {
+      if (!organizationId) throw new Error('Not signed in');
       if (!currentAnswer) throw new Error('No current answer to improve');
       const response = await trustAiApi.improveAnswer(organizationId, questionText, currentAnswer);
       return response.data;

--- a/frontend/src/components/trust/KnowledgeBaseSearchPanel.tsx
+++ b/frontend/src/components/trust/KnowledgeBaseSearchPanel.tsx
@@ -37,12 +37,17 @@ export function KnowledgeBaseSearchPanel({
   const [autoSearched, setAutoSearched] = useState(false);
   const [selectedEntry, setSelectedEntry] = useState<KnowledgeBaseEntry | null>(null);
 
-  const organizationId = user?.organizationId || 'default-org';
+  const organizationId = user?.organizationId;
 
   // Debounced search
   const searchKnowledgeBase = useCallback(async (query: string) => {
     if (!query.trim() || query.length < 3) {
       setResults([]);
+      return;
+    }
+    if (!organizationId) {
+      // Panel can't search without a tenant context; parent handles the
+      // sign-in prompt at the page level.
       return;
     }
 

--- a/frontend/src/components/trust/TrustAnalystQueueWidget.tsx
+++ b/frontend/src/components/trust/TrustAnalystQueueWidget.tsx
@@ -19,17 +19,26 @@ interface TrustAnalystQueueWidgetProps {
 
 export function TrustAnalystQueueWidget({ className }: TrustAnalystQueueWidgetProps) {
   const { user } = useAuth();
-  const organizationId = user?.organizationId || 'default-org';
+  const organizationId = user?.organizationId;
 
   const { data: queue, isLoading, error } = useQuery({
     queryKey: ['questionnaire-dashboard-queue', organizationId],
     queryFn: async () => {
-      const response = await questionnairesApi.getDashboardQueue(organizationId);
+      const response = await questionnairesApi.getDashboardQueue(organizationId!);
       return response.data;
     },
     refetchInterval: 60000, // Refresh every minute
     staleTime: 30000,
+    enabled: !!organizationId,
   });
+
+  if (!organizationId) {
+    return (
+      <div className={clsx('bg-surface-900 border border-surface-800 rounded-xl p-6', className)}>
+        <p className="text-surface-400 text-sm">Sign in to view your questionnaire queue.</p>
+      </div>
+    );
+  }
 
   if (isLoading) {
     return (

--- a/frontend/src/pages/AnswerTemplates.tsx
+++ b/frontend/src/pages/AnswerTemplates.tsx
@@ -15,6 +15,7 @@ import {
 import { answerTemplatesApi, AnswerTemplate, CreateAnswerTemplateData } from '../lib/api';
 import { useAuth } from '../contexts/AuthContext';
 import { Button } from '@/components/Button';
+import { EmptyState } from '@/components/EmptyState';
 import toast from 'react-hot-toast';
 import clsx from 'clsx';
 
@@ -30,8 +31,8 @@ const CATEGORIES = [
 export default function AnswerTemplates() {
   const { user } = useAuth();
   const queryClient = useQueryClient();
-  const organizationId = user?.organizationId || 'default-org';
-  
+  const organizationId = user?.organizationId;
+
   const [searchQuery, setSearchQuery] = useState('');
   const [categoryFilter, setCategoryFilter] = useState<string>('');
   const [showArchived, setShowArchived] = useState(false);
@@ -43,13 +44,14 @@ export default function AnswerTemplates() {
     queryKey: ['answer-templates', organizationId, categoryFilter, showArchived, searchQuery],
     queryFn: async () => {
       const response = await answerTemplatesApi.list({
-        organizationId,
+        organizationId: organizationId!,
         category: categoryFilter || undefined,
         status: showArchived ? 'archived' : 'active',
         search: searchQuery || undefined,
       });
       return response.data;
     },
+    enabled: !!organizationId,
   });
 
   const createMutation = useMutation({
@@ -113,6 +115,16 @@ export default function AnswerTemplates() {
     const cat = CATEGORIES.find(c => c.value === category);
     return cat?.color || 'bg-surface-700 text-surface-300';
   };
+
+  if (!organizationId) {
+    return (
+      <EmptyState
+        variant="warning"
+        title="Sign in required"
+        description="You need to be signed in to view or manage answer templates."
+      />
+    );
+  }
 
   return (
     <div className="space-y-6">

--- a/frontend/src/pages/AuditFindings.tsx
+++ b/frontend/src/pages/AuditFindings.tsx
@@ -16,6 +16,7 @@ import { Modal } from '@/components/Modal';
 import { EmptyState } from '@/components/EmptyState';
 import { SkeletonTable } from '@/components/Skeleton';
 import { auditFindingsApi, auditsApi, usersApi } from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
 import { useToast } from '@/hooks/useToast';
 import { useSelection, BulkActionsBar, SelectCheckbox } from '@/components/BulkActions';
 
@@ -511,6 +512,8 @@ interface FindingFormProps {
 }
 
 function FindingForm({ finding, audits, users, onSubmit, onDelete, isLoading }: FindingFormProps) {
+  const { user } = useAuth();
+  const toast = useToast();
   const [formData, setFormData] = useState({
     auditId: finding?.auditId || '',
     title: finding?.title || '',
@@ -531,10 +534,16 @@ function FindingForm({ finding, audits, users, onSubmit, onDelete, isLoading }: 
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    const orgId = localStorage.getItem('organizationId') || '';
+    // organizationId must come from the authenticated user. Previously this
+    // pulled from localStorage with an empty-string default, letting saves
+    // slip through without tenant scoping.
+    if (!user?.organizationId) {
+      toast.error('Cannot save finding: not signed in');
+      return;
+    }
     onSubmit({
       ...formData,
-      organizationId: orgId,
+      organizationId: user.organizationId,
       targetDate: formData.targetDate || undefined,
     });
   };

--- a/frontend/src/pages/KnowledgeBaseDetail.tsx
+++ b/frontend/src/pages/KnowledgeBaseDetail.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { useMutation, useQueryClient, useQuery } from '@tanstack/react-query';
 import { ArrowLeftIcon, PencilIcon, TrashIcon, XMarkIcon } from '@heroicons/react/24/outline';
 import { knowledgeBaseApi } from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
 import { Button } from '@/components/Button';
 import { SkeletonDetailHeader, SkeletonDetailSection } from '@/components/Skeleton';
 import toast from 'react-hot-toast';
@@ -28,6 +29,7 @@ export default function KnowledgeBaseDetail() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const { user } = useAuth();
 
   const [editing, setEditing] = useState(id === 'new');
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
@@ -60,8 +62,14 @@ export default function KnowledgeBaseDetail() {
 
   const createMutation = useMutation({
     mutationFn: async (data: Partial<KnowledgeEntry>) => {
-      const organizationId = localStorage.getItem('organizationId') || '8924f0c1-7bb1-4be8-84ee-ad8725c712bf';
-      const payload = { ...data, organizationId };
+      // Organization ID must come from the authenticated user. Previously
+      // this fell back to a hardcoded UUID, routing unauthenticated writes
+      // into a random tenant. handleSave guards against null user before
+      // calling .mutate, so this assertion is a defensive backstop.
+      if (!user?.organizationId) {
+        throw new Error('Cannot create knowledge-base entry: not signed in');
+      }
+      const payload = { ...data, organizationId: user.organizationId };
       const response = await knowledgeBaseApi.create(payload as any);
       return response.data;
     },
@@ -111,6 +119,10 @@ export default function KnowledgeBaseDetail() {
       return;
     }
     if (id === 'new') {
+      if (!user?.organizationId) {
+        toast.error('Cannot save entry: not signed in');
+        return;
+      }
       createMutation.mutate(formData);
     } else {
       updateMutation.mutate(formData);

--- a/frontend/src/pages/QuestionnaireDetail.tsx
+++ b/frontend/src/pages/QuestionnaireDetail.tsx
@@ -104,7 +104,7 @@ export default function QuestionnaireDetail() {
     // answer was attributed to a fake user — breaking audit trails for
     // a compliance product. Use the authenticated user's id instead.
     if (!user?.id) {
-      console.error('Cannot update answer: no authenticated user');
+      toast.error('Cannot update answer: not signed in');
       return;
     }
     try {
@@ -176,6 +176,16 @@ export default function QuestionnaireDetail() {
 
   const handleSubmitNewQuestionnaire = async (e: React.FormEvent) => {
     e.preventDefault();
+
+    // Both the user id (audit-trail attribution) and the organization id
+    // (tenant scoping) must come from the authenticated user. Previously
+    // these were hardcoded to 'system' and 'default-org', which attributed
+    // every questionnaire to a fake user in a fictitious tenant.
+    if (!user?.id || !user?.organizationId) {
+      toast.error('Cannot create questionnaire: not signed in');
+      return;
+    }
+
     setSubmitting(true);
 
     try {
@@ -190,10 +200,10 @@ export default function QuestionnaireDetail() {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'x-user-id': 'system',
+          'x-user-id': user.id,
         },
         body: JSON.stringify({
-          organizationId: 'default-org',
+          organizationId: user.organizationId,
           title: formData.title,
           requesterName: formData.requesterName,
           requesterEmail: formData.requesterEmail,
@@ -213,7 +223,7 @@ export default function QuestionnaireDetail() {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            'x-user-id': 'system',
+            'x-user-id': user.id,
           },
           body: JSON.stringify({
             questionnaireId: newQuestionnaire.id,

--- a/frontend/src/pages/TrustAnalytics.tsx
+++ b/frontend/src/pages/TrustAnalytics.tsx
@@ -9,28 +9,41 @@ import {
 } from '@heroicons/react/24/outline';
 import { questionnairesApi, knowledgeBaseApi } from '../lib/api';
 import { useAuth } from '../contexts/AuthContext';
+import { EmptyState } from '@/components/EmptyState';
 import { LazyRechartsWrapper } from '@/components/charts/LazyCharts';
 import clsx from 'clsx';
 
 export default function TrustAnalytics() {
   const { user } = useAuth();
-  const organizationId = user?.organizationId || 'default-org';
+  const organizationId = user?.organizationId;
 
   const { data: analytics, isLoading } = useQuery({
     queryKey: ['questionnaire-analytics', organizationId],
     queryFn: async () => {
-      const response = await questionnairesApi.getAnalytics(organizationId);
+      const response = await questionnairesApi.getAnalytics(organizationId!);
       return response.data;
     },
+    enabled: !!organizationId,
   });
 
   const { data: kbStats } = useQuery({
     queryKey: ['kb-stats', organizationId],
     queryFn: async () => {
-      const response = await knowledgeBaseApi.getStats(organizationId);
+      const response = await knowledgeBaseApi.getStats(organizationId!);
       return response.data;
     },
+    enabled: !!organizationId,
   });
+
+  if (!organizationId) {
+    return (
+      <EmptyState
+        variant="warning"
+        title="Sign in required"
+        description="You need to be signed in to view trust analytics."
+      />
+    );
+  }
 
   if (isLoading) {
     return (

--- a/frontend/src/pages/TrustConfiguration.tsx
+++ b/frontend/src/pages/TrustConfiguration.tsx
@@ -13,6 +13,7 @@ import {
 import { trustConfigApi, TrustConfiguration as TrustConfigType } from '../lib/api';
 import { useAuth } from '../contexts/AuthContext';
 import { Button } from '@/components/Button';
+import { EmptyState } from '@/components/EmptyState';
 import toast from 'react-hot-toast';
 import clsx from 'clsx';
 
@@ -29,19 +30,21 @@ const TABS: { id: TabId; label: string; icon: React.ComponentType<{ className?: 
 export default function TrustConfiguration() {
   const { user } = useAuth();
   const queryClient = useQueryClient();
-  const organizationId = user?.organizationId || 'default-org';
+  const organizationId = user?.organizationId;
   const [activeTab, setActiveTab] = useState<TabId>('sla');
 
   const { data: config, isLoading } = useQuery({
     queryKey: ['trust-config', organizationId],
     queryFn: async () => {
-      const response = await trustConfigApi.get(organizationId);
+      const response = await trustConfigApi.get(organizationId!);
       return response.data;
     },
+    enabled: !!organizationId,
   });
 
   const updateMutation = useMutation({
     mutationFn: async (data: Partial<TrustConfigType>) => {
+      if (!organizationId) throw new Error('Not signed in');
       const response = await trustConfigApi.update(data, organizationId);
       return response.data;
     },
@@ -56,6 +59,7 @@ export default function TrustConfiguration() {
 
   const resetMutation = useMutation({
     mutationFn: async () => {
+      if (!organizationId) throw new Error('Not signed in');
       const response = await trustConfigApi.reset(organizationId);
       return response.data;
     },
@@ -67,6 +71,16 @@ export default function TrustConfiguration() {
       toast.error('Failed to reset configuration');
     },
   });
+
+  if (!organizationId) {
+    return (
+      <EmptyState
+        variant="warning"
+        title="Sign in required"
+        description="You need to be signed in to view or change Trust Configuration."
+      />
+    );
+  }
 
   if (isLoading) {
     return (

--- a/frontend/src/pages/VendorDetail.tsx
+++ b/frontend/src/pages/VendorDetail.tsx
@@ -13,6 +13,7 @@ import {
 } from '@heroicons/react/24/outline';
 import { vendorsApi, tprmConfigApi, TprmFeatureSettings } from '../lib/api';
 import { Vendor } from '../lib/apiTypes';
+import { useAuth } from '@/contexts/AuthContext';
 import { Button } from '@/components/Button';
 import { SkeletonDetailHeader, SkeletonDetailSection } from '@/components/Skeleton';
 import { ConfirmModal } from '@/components/Modal';
@@ -241,8 +242,9 @@ function VendorForm({
   onSave: (data: Partial<Vendor>) => void;
   onCancel: () => void;
 }) {
+  const { user } = useAuth();
   const [formData, setFormData] = useState({
-    organizationId: vendor?.organizationId || localStorage.getItem('organizationId') || '',
+    organizationId: vendor?.organizationId || user?.organizationId || '',
     vendorId: vendor?.vendorId || `VND-${Date.now()}`,
     name: vendor?.name || '',
     legalName: vendor?.legalName || '',
@@ -259,6 +261,13 @@ function VendorForm({
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    // organizationId must come from the authenticated user or the existing
+    // vendor record. Previously this fell back to localStorage with an empty
+    // string default, which let unauthenticated saves slip through.
+    if (!formData.organizationId) {
+      toast.error('Cannot save vendor: not signed in');
+      return;
+    }
     onSave(formData);
   };
 


### PR DESCRIPTION
## Summary

A follow-up deep audit found that PR #298 fixed only a subset of the tenant-scoping / audit-trail defects. This PR closes the rest of them across 10 files.

Two flavors of problem:

1. **Identical bugs on adjacent code paths.** PR #298 fixed `QuestionnaireDetail`'s `updateAnswer` but not its `handleSubmitNewQuestionnaire` (which still sent `'x-user-id': 'system'` twice and `organizationId: 'default-org'`). PR #298 removed the hardcoded UUID fallback in `AssessmentDetail` but `KnowledgeBaseDetail.tsx:63` still had the same hardcoded UUID. PR #298 added a `useAuth()` guard but `VendorDetail` and `AuditFindings` still wrote with a localStorage-derived `organizationId` and an empty-string fallback.

2. **Wider read-side fallback pattern.** Six other components (`TrustConfiguration`, `AnswerTemplates`, `TrustAnalytics`, `TrustAnalystQueueWidget`, `KnowledgeBaseSearchPanel`, `AIAnswerAssistant`) used `user?.organizationId || 'default-org'`. When the auth context was null, every read silently targeted a fake `'default-org'` tenant. This isn't user-data leakage on its own (the backend gates on tenant), but it produces wrong UI + silent failures, and it primes the same antipattern for future writes.

### Files

| File | Class | Fix |
|---|---|---|
| `frontend/src/pages/QuestionnaireDetail.tsx` | CRITICAL | New-questionnaire create path now uses `user.id` / `user.organizationId`, guarded |
| `frontend/src/pages/KnowledgeBaseDetail.tsx` | CRITICAL | Removed hardcoded UUID fallback in `createMutation`; uses `useAuth()` |
| `frontend/src/pages/VendorDetail.tsx` | HIGH | `VendorForm` pulls org from `useAuth()`; refuses submit if no org |
| `frontend/src/pages/AuditFindings.tsx` | HIGH | `FindingForm` pulls org from `useAuth()`; refuses submit if no org |
| `frontend/src/pages/TrustConfiguration.tsx` | HIGH | Drops `'default-org'` fallback, gates queries on `!!organizationId`, EmptyState when unauthenticated |
| `frontend/src/pages/AnswerTemplates.tsx` | HIGH | Same pattern as TrustConfiguration |
| `frontend/src/pages/TrustAnalytics.tsx` | HIGH | Same pattern as TrustConfiguration |
| `frontend/src/components/trust/TrustAnalystQueueWidget.tsx` | HIGH | Inline "Sign in to view" tile (widget-sized) |
| `frontend/src/components/trust/KnowledgeBaseSearchPanel.tsx` | HIGH | Modal panel: early-return from search; parent handles sign-in prompt |
| `frontend/src/components/trust/AIAnswerAssistant.tsx` | HIGH | Three mutations now throw "Not signed in" instead of calling API with fake org |

## Why these matter

`'default-org'` and `'system'` are not real identifiers; on a multi-tenant GRC product they create writes whose tenant attribution and audit-trail user-id are *plausibly correct but wrong*. They are exactly the kind of defect a compliance product is sold to prevent. They will not page anyone — they just write incorrect rows.

## Test plan

- [x] `npx tsc --noEmit` in `frontend/` — passes
- [x] `grep -rn "'default-org'\|8924f0c1\|'x-user-id': 'system'" frontend/src/` — only matches are the explanatory comments in `KnowledgeBase.tsx` and `QuestionnaireDetail.tsx`, and the dev-login UUID in `AuthContext.tsx:314` (gated by `import.meta.env.DEV || VITE_ENABLE_DEV_AUTH==='true'`, addressed separately)
- [ ] Sign in as a real tenant user; create a new questionnaire (with parsed questions), create a new knowledge-base entry, save a vendor, save an audit finding. Confirm each lands under the authenticated user's org and is attributed to `user.id`.
- [ ] Sign out (or clear `localStorage` + reload). Verify the 6 read-side pages render the "Sign in required" state and do NOT fire a network call that includes `organizationId=default-org`. Verify the 4 write paths refuse to submit and toast an error.

## Out of scope

- `AuthContext.tsx:314` dev-login UUID — gated by env flag; will be hardened in a follow-up PR alongside the Dockerfile build-arg guard that prevents `VITE_ENABLE_DEV_AUTH=true` in prod builds.
- `TrustCenterSettings.tsx:252` puts `organizationId` in a public URL. The backend already gates on `trustCenter.isPublic`; flagging for re-review but not changing here.