### PR TITLE
chore(supply-chain): Docker --ignore-scripts, RustFS pin, Helm tag required

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -254,9 +254,13 @@ services:
   # Object Storage - RustFS (S3-Compatible, Apache 2.0)
   # High-performance Rust-based object storage
   # https://github.com/rustfs/rustfs
+  # Pinned by digest so a compromised upstream `:latest` tag cannot
+  # silently swap the image at pull time. Reviewers: verify this digest
+  # matches the RustFS image currently running in production via
+  # `docker image inspect rustfs/rustfs --format '{{.RepoDigests}}'`.
   # ===========================================
   rustfs:
-    image: rustfs/rustfs:latest
+    image: rustfs/rustfs@sha256:8e467b32af3ff83e70c70dddb0c36b5e611f46e89a3075db8770aea4f30b2fe3
     container_name: grc-rustfs
     environment:
       RUSTFS_ROOT_USER: ${MINIO_ROOT_USER}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,9 +163,10 @@ services:
   # Object Storage - RustFS (S3-Compatible, Apache 2.0)
   # High-performance Rust-based object storage
   # https://github.com/rustfs/rustfs
+  # Pinned by digest to match docker-compose.prod.yml.
   # ===========================================
   rustfs:
-    image: rustfs/rustfs:latest
+    image: rustfs/rustfs@sha256:8e467b32af3ff83e70c70dddb0c36b5e611f46e89a3075db8770aea4f30b2fe3
     container_name: grc-rustfs
     # SECURITY: Prevent privilege escalation attacks
     security_opt:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -13,8 +13,11 @@ WORKDIR /app
 # Copy package files from frontend directory (context is repo root)
 COPY frontend/package*.json ./
 
-# Install ALL dependencies (including devDependencies) for build
-RUN npm install
+# Install ALL dependencies (including devDependencies) for build.
+# --ignore-scripts blocks postinstall hooks, the main supply-chain attack
+# vector via npm. The repo .npmrc sets ignore-scripts=true but isn't
+# COPY'd into the build context, so we pass the flag explicitly here.
+RUN npm install --ignore-scripts
 
 # Copy frontend source
 COPY frontend/ ./

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -50,14 +50,19 @@ app.kubernetes.io/component: {{ .component }}
 
 {{/*
 Full image reference with optional global registry prefix.
+The tag is `required` so a deployment without an explicit version pin
+fails at template time rather than silently rolling out `:` (or a
+cached stale image). Reach the error by looking at .image.repository
+in the message to identify which component is missing its tag.
 Usage: {{ include "gigachad-grc.image" (dict "image" .Values.controls.image "global" .Values.global) }}
 */}}
 {{- define "gigachad-grc.image" -}}
 {{- $registry := .global.imageRegistry | default "" -}}
+{{- $tag := required (printf "image.tag is required for repository %q (set <component>.image.tag=<version> in your values file or via --set)" .image.repository) .image.tag -}}
 {{- if $registry }}
-{{- printf "%s/%s:%s" $registry .image.repository .image.tag }}
+{{- printf "%s/%s:%s" $registry .image.repository $tag }}
 {{- else }}
-{{- printf "%s:%s" .image.repository .image.tag }}
+{{- printf "%s:%s" .image.repository $tag }}
 {{- end }}
 {{- end }}
 

--- a/helm/templates/rustfs.yaml
+++ b/helm/templates/rustfs.yaml
@@ -29,7 +29,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: rustfs
-          image: "{{ .Values.rustfs.image.repository }}:{{ .Values.rustfs.image.tag }}"
+          image: "{{ .Values.rustfs.image.repository }}:{{ required "rustfs.image.tag is required (pin to a specific version, e.g., a digest like 'sha256:8e467b…'; an empty tag would render as `rustfs/rustfs:` which fails to pull). See docker-compose.prod.yml for the SHA we are currently pinning." .Values.rustfs.image.tag }}"
           imagePullPolicy: {{ include "gigachad-grc.imagePullPolicy" .Values.rustfs.image }}
           securityContext:
             allowPrivilegeEscalation: false

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -17,16 +17,18 @@ global:
 # Each backend service follows the same structure. They share a database,
 # Redis cache, Keycloak auth, and RustFS storage.
 #
-# IMPORTANT: Pin image tags to specific versions for production (e.g., "v1.0.0").
-# The "latest" tag with IfNotPresent will cache stale images. If using "latest",
-# set pullPolicy to "Always".
+# IMPORTANT: image.tag is intentionally empty by default. You MUST set
+# a version pin (e.g., "v1.0.0") per service in your own values file or
+# via --set <component>.image.tag=<version>. The helm template will fail
+# with a clear "image.tag is required" error if a tag is left unset, so
+# an unintended `:latest` rollout can no longer happen by accident.
 
 controls:
   enabled: true
   replicaCount: 1
   image:
     repository: gigachad-grc/controls
-    tag: latest
+    tag: ''
     pullPolicy: IfNotPresent
   port: 3001
   resources:
@@ -60,7 +62,7 @@ frameworks:
   replicaCount: 1
   image:
     repository: gigachad-grc/frameworks
-    tag: latest
+    tag: ''
     pullPolicy: IfNotPresent
   port: 3002
   resources:
@@ -80,7 +82,7 @@ policies:
   replicaCount: 1
   image:
     repository: gigachad-grc/policies
-    tag: latest
+    tag: ''
     pullPolicy: IfNotPresent
   port: 3004
   resources:
@@ -100,7 +102,7 @@ tprm:
   replicaCount: 1
   image:
     repository: gigachad-grc/tprm
-    tag: latest
+    tag: ''
     pullPolicy: IfNotPresent
   port: 3005
   resources:
@@ -120,7 +122,7 @@ trust:
   replicaCount: 1
   image:
     repository: gigachad-grc/trust
-    tag: latest
+    tag: ''
     pullPolicy: IfNotPresent
   port: 3006
   resources:
@@ -140,7 +142,7 @@ audit:
   replicaCount: 1
   image:
     repository: gigachad-grc/audit
-    tag: latest
+    tag: ''
     pullPolicy: IfNotPresent
   port: 3007
   resources:
@@ -164,7 +166,7 @@ frontend:
   replicaCount: 1
   image:
     repository: gigachad-grc/frontend
-    tag: latest
+    tag: ''
     pullPolicy: IfNotPresent
   port: 80
   resources:
@@ -294,7 +296,7 @@ rustfs:
   enabled: true
   image:
     repository: rustfs/rustfs
-    tag: latest
+    tag: ''
     pullPolicy: IfNotPresent
   auth:
     rootUser: rustfsadmin

--- a/services/audit/Dockerfile
+++ b/services/audit/Dockerfile
@@ -13,9 +13,13 @@ COPY services/audit/package*.json ./
 # Install without running postinstall
 RUN npm install --ignore-scripts --legacy-peer-deps
 
-# Copy shared source and build it
+# Copy shared source and build it. --ignore-scripts blocks postinstall
+# hooks; the explicit `npx prisma generate` below replaces what the
+# shared library's postinstall would have done. The repo .npmrc sets
+# ignore-scripts=true but isn't COPY'd into the build context, so we
+# pass the flag explicitly here.
 WORKDIR /app/shared
-RUN npm install
+RUN npm install --ignore-scripts --legacy-peer-deps
 RUN npm run build
 
 # Build audit service

--- a/services/controls/Dockerfile
+++ b/services/controls/Dockerfile
@@ -19,9 +19,13 @@ COPY services/controls/package*.json ./
 # Install without running postinstall
 RUN npm install --ignore-scripts --legacy-peer-deps
 
-# Copy shared source and build it
+# Copy shared source and build it. --ignore-scripts blocks postinstall
+# hooks; the explicit `npx prisma generate` below replaces what the
+# shared library's postinstall would have done. The repo .npmrc sets
+# ignore-scripts=true but isn't COPY'd into the build context, so we
+# pass the flag explicitly here.
 WORKDIR /app/shared
-RUN npm install
+RUN npm install --ignore-scripts --legacy-peer-deps
 RUN npm run build
 
 # Build controls service

--- a/services/frameworks/Dockerfile
+++ b/services/frameworks/Dockerfile
@@ -13,9 +13,13 @@ COPY services/frameworks/package*.json ./
 # Install without running postinstall
 RUN npm install --ignore-scripts --legacy-peer-deps
 
-# Copy shared source and build it
+# Copy shared source and build it. --ignore-scripts blocks postinstall
+# hooks; the explicit `npx prisma generate` below replaces what the
+# shared library's postinstall would have done. The repo .npmrc sets
+# ignore-scripts=true but isn't COPY'd into the build context, so we
+# pass the flag explicitly here.
 WORKDIR /app/shared
-RUN npm install
+RUN npm install --ignore-scripts --legacy-peer-deps
 RUN npm run build
 
 # Build frameworks service

--- a/services/policies/Dockerfile
+++ b/services/policies/Dockerfile
@@ -13,9 +13,13 @@ COPY services/policies/package*.json ./
 # Install without running postinstall
 RUN npm install --ignore-scripts --legacy-peer-deps
 
-# Copy shared source and build it
+# Copy shared source and build it. --ignore-scripts blocks postinstall
+# hooks; the explicit `npx prisma generate` below replaces what the
+# shared library's postinstall would have done. The repo .npmrc sets
+# ignore-scripts=true but isn't COPY'd into the build context, so we
+# pass the flag explicitly here.
 WORKDIR /app/shared
-RUN npm install
+RUN npm install --ignore-scripts --legacy-peer-deps
 RUN npm run build
 
 # Build policies service

--- a/services/tprm/Dockerfile
+++ b/services/tprm/Dockerfile
@@ -13,9 +13,13 @@ COPY services/tprm/package*.json ./
 # Install without running postinstall
 RUN npm install --ignore-scripts --legacy-peer-deps
 
-# Copy shared source and build it
+# Copy shared source and build it. --ignore-scripts blocks postinstall
+# hooks; the explicit `npx prisma generate` below replaces what the
+# shared library's postinstall would have done. The repo .npmrc sets
+# ignore-scripts=true but isn't COPY'd into the build context, so we
+# pass the flag explicitly here.
 WORKDIR /app/shared
-RUN npm install
+RUN npm install --ignore-scripts --legacy-peer-deps
 RUN npm run build
 
 # Build TPRM service

--- a/services/trust/Dockerfile
+++ b/services/trust/Dockerfile
@@ -13,9 +13,13 @@ COPY services/trust/package*.json ./
 # Install without running postinstall
 RUN npm install --ignore-scripts --legacy-peer-deps
 
-# Copy shared source and build it
+# Copy shared source and build it. --ignore-scripts blocks postinstall
+# hooks; the explicit `npx prisma generate` below replaces what the
+# shared library's postinstall would have done. The repo .npmrc sets
+# ignore-scripts=true but isn't COPY'd into the build context, so we
+# pass the flag explicitly here.
 WORKDIR /app/shared
-RUN npm install
+RUN npm install --ignore-scripts --legacy-peer-deps
 RUN npm run build
 
 # Build Trust service


### PR DESCRIPTION
## Summary

Three supply-chain hardening fixes that came out of the deep audit. Pure config/build change, no application logic touched.

### 1. npm lifecycle scripts in Docker builds

The repo `.npmrc` sets `ignore-scripts=true`, but it is NOT COPY'd into the Dockerfile build contexts, so the global setting is silently bypassed at image build time.

Each service Dockerfile runs `npm install` twice:
- First for the service's own deps — already passes \`--ignore-scripts --legacy-peer-deps\`
- Second for the shared/Prisma library — did NOT pass \`--ignore-scripts\`

A malicious dependency in the shared package tree could therefore execute its `postinstall` during image build, which is the most common npm supply-chain attack vector (e.g., the recent `event-stream`, `ua-parser-js`, `node-ipc` incidents).

**Fix:** pass `--ignore-scripts --legacy-peer-deps` to the shared-lib `npm install` in each of `services/{audit,controls,frameworks,policies,tprm,trust}/Dockerfile`. The explicit `npx prisma generate` that already runs afterward replaces what `postinstall` would have done, so functionality is unchanged. `frontend/Dockerfile`'s `npm install` is also updated.

### 2. Pin third-party RustFS image by digest

`rustfs/rustfs:latest` in `docker-compose.prod.yml` and `docker-compose.yml` lets a compromised upstream `:latest` tag silently swap the image at pull time. Pinned to `sha256:8e467b32af3ff83e70c70dddb0c36b5e611f46e89a3075db8770aea4f30b2fe3` (matches the image currently cached locally).

**Reviewers:** before merge, please verify against the production-deployed digest with:
\`\`\`bash
docker image inspect rustfs/rustfs --format '{{.RepoDigests}}'
\`\`\`
If it differs, swap to that digest and re-push.

### 3. Require explicit image.tag in Helm

`helm/values.yaml` defaulted 8 image tags to `latest` with `IfNotPresent` pull policy — a stale-cache trap, an audit smell, and (per the file's own warning comment) a known-bad default. Now:

- All 8 defaults are empty strings.
- `helm/templates/_helpers.tpl` `required`s the tag, so `helm install` fails at template time with a clear `image.tag is required for repository X` error if any tag is unset.
- `helm/templates/rustfs.yaml` (which inline-renders rather than going through the helper) also `required`s its tag and points reviewers at the docker-compose digest.

## Verification

- [x] Ran `helm template ./helm --set postgresql.auth.password=… --set rustfs.image.tag=… --set <all 7 services>.image.tag=v0.1.0` → renders cleanly; all `image:` lines show the expected pinned tags.
- [x] Ran `helm template ./helm` with various tags unset → fails with the new `required` error message pointing at the missing component.
- [x] Re-read all 7 Dockerfile diffs to confirm the `npx prisma generate` step still runs explicitly after the now-script-blocked `npm install` (so Prisma client generation is preserved).
- [ ] `docker compose -f docker-compose.prod.yml build` end-to-end (CI will run this).
- [ ] Build logs include `--ignore-scripts` on every npm install step.

## Out of scope (documented in audit, deferred)

- IDE flagged the base `node:20-alpine` image digest as stale with 11 high CVEs. Out of scope for this PR — the digest pin in those Dockerfiles is intentional reproducibility; refreshing it is its own change with its own test impact.
- `VITE_ENABLE_DEV_AUTH` build-arg guard (so it cannot be flipped on for prod builds) is application-layer, deferred to a follow-up PR.
- Backup scheduler's docker.sock mount also flagged in the audit; needs a separate design.