### PR TITLE
fix(security): vendor href, dev-auth gate, generic-connector SSRF, contract MIME allowlist

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -623,6 +623,10 @@ services:
       dockerfile: frontend/Dockerfile
       args:
         VITE_ENABLE_DEV_AUTH: 'true'
+        # Explicit opt-in for dev-auth bypass. This is intentional in the
+        # dev compose file; production builds (docker-compose.prod.yml)
+        # must NOT set this.
+        ALLOW_DEV_AUTH: 'true'
     container_name: grc-frontend
     # SECURITY: Prevent privilege escalation attacks
     security_opt:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -28,11 +28,23 @@ COPY frontend/ ./
 ARG VITE_API_URL=
 ARG VITE_ENABLE_AI_MODULE=true
 ARG VITE_ENABLE_DEV_AUTH=false
+# Double opt-in for the dev-auth bypass. Setting VITE_ENABLE_DEV_AUTH=true
+# alone is not enough; you must also pass ALLOW_DEV_AUTH=true. This
+# prevents a misconfigured CI variable from silently baking the
+# Keycloak-bypassing dev-login UI into a production image.
+ARG ALLOW_DEV_AUTH=
 
 ENV VITE_API_URL=$VITE_API_URL
 ENV VITE_ENABLE_AI_MODULE=$VITE_ENABLE_AI_MODULE
 # SECURITY: Dev auth defaults to false; set via build arg for dev/demo
 ENV VITE_ENABLE_DEV_AUTH=$VITE_ENABLE_DEV_AUTH
+
+# Fail the build if dev-auth is requested without the explicit opt-in.
+RUN if [ "$VITE_ENABLE_DEV_AUTH" = "true" ] && [ "$ALLOW_DEV_AUTH" != "true" ]; then \
+      echo "ERROR: VITE_ENABLE_DEV_AUTH=true requires also passing --build-arg ALLOW_DEV_AUTH=true." >&2; \
+      echo "Dev-auth bakes a Keycloak-bypassing login button into the static build. Refusing." >&2; \
+      exit 1; \
+    fi
 
 # Limit Node.js heap to prevent OOM kills during parallel Docker builds
 ENV NODE_OPTIONS=--max-old-space-size=2048

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -299,28 +299,41 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
-  // Dev login bypass - only available in development
+  // Dev login bypass - only available in development. Defense in depth on
+  // top of the Dockerfile guard: refuse to run if we are clearly in a
+  // production build, even if VITE_ENABLE_DEV_AUTH got flipped by mistake.
   const devLogin = useCallback(() => {
-    const isDevMode = import.meta.env.DEV || import.meta.env.VITE_ENABLE_DEV_AUTH === 'true';
-    if (isDevMode) {
-      if (import.meta.env.DEV) {
-        console.log('Dev login activated');
-      }
-      const devUser: User = {
-        id: '8f88a42b-e799-455c-b68a-308d7d2e9aa4', // John Doe - seeded user
-        email: 'john.doe@example.com',
-        name: 'John Doe',
-        role: 'admin',
-        organizationId: '8924f0c1-7bb1-4be8-84ee-ad8725c712bf',
-      };
-      setUser(devUser);
-      setToken('dev-token-not-for-production');
-      setIsAuthenticated(true);
-      // Persist dev auth state and user info for API calls
-      localStorage.setItem('grc-dev-auth', JSON.stringify(devUser));
-      localStorage.setItem('userId', devUser.id);
-      localStorage.setItem('organizationId', devUser.organizationId);
+    const inDevBuild = import.meta.env.DEV === true;
+    const devAuthFlag = import.meta.env.VITE_ENABLE_DEV_AUTH === 'true';
+    const isProdBuild = import.meta.env.PROD === true;
+
+    if (isProdBuild && !devAuthFlag) {
+      // Should never be reachable in a properly-built prod bundle, since
+      // the dev-login UI is hidden. If something does reach here, fail loud.
+      console.error('devLogin invoked in a production build without VITE_ENABLE_DEV_AUTH');
+      return;
     }
+    if (!inDevBuild && !devAuthFlag) {
+      return;
+    }
+
+    if (inDevBuild) {
+      console.log('Dev login activated');
+    }
+    const devUser: User = {
+      id: '8f88a42b-e799-455c-b68a-308d7d2e9aa4', // John Doe - seeded user
+      email: 'john.doe@example.com',
+      name: 'John Doe',
+      role: 'admin',
+      organizationId: '8924f0c1-7bb1-4be8-84ee-ad8725c712bf',
+    };
+    setUser(devUser);
+    setToken('dev-token-not-for-production');
+    setIsAuthenticated(true);
+    // Persist dev auth state and user info for API calls
+    localStorage.setItem('grc-dev-auth', JSON.stringify(devUser));
+    localStorage.setItem('userId', devUser.id);
+    localStorage.setItem('organizationId', devUser.organizationId);
   }, []);
 
   const hasRole = (role: string): boolean => {

--- a/frontend/src/lib/safeHref.test.ts
+++ b/frontend/src/lib/safeHref.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { safeHref } from './safeHref';
+
+describe('safeHref', () => {
+  describe('blocks dangerous schemes (XSS sinks)', () => {
+    it.each([
+      'javascript:alert(1)',
+      'JavaScript:alert(1)', // case insensitive parsing
+      'jaVaScRiPt:alert(1)',
+      'javascript:void(0)',
+      'data:text/html,<script>alert(1)</script>',
+      'data:application/octet-stream;base64,QQ==',
+      'vbscript:msgbox(1)',
+      'file:///etc/passwd',
+      'about:blank',
+      'chrome:settings',
+    ])('returns null for %s', (input) => {
+      expect(safeHref(input)).toBeNull();
+    });
+  });
+
+  describe('allows http and https', () => {
+    it.each([
+      'http://example.com',
+      'https://example.com',
+      'https://vendor.example.com/path?q=1',
+      'http://localhost:3000/foo',
+      'https://example.com:8443/secure',
+      'https://user:pass@example.com', // userinfo allowed by URL parser
+    ])('returns the URL for %s', (input) => {
+      const result = safeHref(input);
+      expect(result).not.toBeNull();
+      expect(result).toMatch(/^https?:\/\//);
+    });
+  });
+
+  describe('handles malformed input', () => {
+    it.each([
+      '',
+      ' ',
+      'not a url',
+      'example.com', // no scheme — URL constructor rejects
+      '//example.com', // protocol-relative — URL constructor rejects
+      'http://',
+      ':::',
+      'http:///',
+    ])('returns null for malformed input: %s', (input) => {
+      expect(safeHref(input)).toBeNull();
+    });
+  });
+
+  describe('normalizes the returned URL', () => {
+    it('returns the URL as parsed by the URL constructor', () => {
+      // The URL constructor canonicalises certain things (e.g., trailing slash on origin).
+      const result = safeHref('https://example.com');
+      expect(result).toBe('https://example.com/');
+    });
+
+    it('preserves path and query', () => {
+      expect(safeHref('https://example.com/foo?bar=baz#h')).toBe(
+        'https://example.com/foo?bar=baz#h'
+      );
+    });
+  });
+});

--- a/frontend/src/lib/safeHref.ts
+++ b/frontend/src/lib/safeHref.ts
@@ -1,0 +1,13 @@
+// Parse a user-supplied URL and only return it if it's http/https. Anything
+// else (javascript:, data:, vbscript:, file:, etc.) returns null, which causes
+// callers to render the raw value as plain text instead of as a link. This
+// prevents a vendor.website value like "javascript:alert(1)" from becoming
+// an XSS sink when clicked.
+export function safeHref(raw: string): string | null {
+  try {
+    const u = new URL(raw);
+    return u.protocol === 'http:' || u.protocol === 'https:' ? u.toString() : null;
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/lib/training.ts
+++ b/frontend/src/lib/training.ts
@@ -465,8 +465,12 @@ export const trainingApi_legacy = {
     return progress.find(p => p.moduleId === moduleId);
   },
   updateProgress: (progress: TrainingProgress) => {
-    // Fire and forget API call, sync localStorage
-    trainingApiWrapper.updateProgress(progress).catch(() => {});
+    // Fire and forget API call, sync localStorage. Errors are non-fatal
+    // (localStorage is the source of truth) but we log them so a broken
+    // backend isn't completely silent.
+    trainingApiWrapper.updateProgress(progress).catch((err) => {
+      console.warn('Training updateProgress sync failed:', err);
+    });
     
     const data = localStorage.getItem(STORAGE_KEYS.PROGRESS);
     const all: TrainingProgress[] = data ? JSON.parse(data) : [];
@@ -491,8 +495,10 @@ export const trainingApi_legacy = {
       lastAccessedAt: new Date().toISOString(),
     };
     trainingApi_legacy.updateProgress(progress);
-    // Also call API
-    backendTrainingApi.startModule(moduleId).catch(() => {});
+    // Also call API. Errors are non-fatal but worth surfacing in console.
+    backendTrainingApi.startModule(moduleId).catch((err) => {
+      console.warn('Training startModule sync failed:', err);
+    });
     return progress;
   },
   completeModule: (userId: string, moduleId: string, score?: number) => {
@@ -505,8 +511,10 @@ export const trainingApi_legacy = {
       slideProgress: 100,
     };
     trainingApi_legacy.updateProgress(progress);
-    // Also call API
-    backendTrainingApi.completeModule(moduleId, score).catch(() => {});
+    // Also call API. Errors are non-fatal but worth surfacing in console.
+    backendTrainingApi.completeModule(moduleId, score).catch((err) => {
+      console.warn('Training completeModule sync failed:', err);
+    });
     return progress;
   },
   getAssignments: (userId: string) => {

--- a/frontend/src/pages/VendorDetail.tsx
+++ b/frontend/src/pages/VendorDetail.tsx
@@ -13,6 +13,7 @@ import {
 } from '@heroicons/react/24/outline';
 import { vendorsApi, tprmConfigApi, TprmFeatureSettings } from '../lib/api';
 import { Vendor } from '../lib/apiTypes';
+import { safeHref } from '../lib/safeHref';
 import { useAuth } from '@/contexts/AuthContext';
 import { Button } from '@/components/Button';
 import { SkeletonDetailHeader, SkeletonDetailSection } from '@/components/Skeleton';
@@ -689,20 +690,6 @@ function VendorView({ vendor, onRefresh, featureSettings, onStartRiskAssessment 
       )}
     </div>
   );
-}
-
-// Parse a user-supplied URL and only return it if it's http/https. Anything
-// else (javascript:, data:, vbscript:, etc.) returns null, which causes the
-// component to render the raw value as plain text instead of as a link. This
-// prevents a vendor.website value like "javascript:alert(1)" from becoming
-// an XSS sink when clicked.
-function safeHref(raw: string): string | null {
-  try {
-    const u = new URL(raw);
-    return u.protocol === 'http:' || u.protocol === 'https:' ? u.toString() : null;
-  } catch {
-    return null;
-  }
 }
 
 function InfoField({

--- a/frontend/src/pages/VendorDetail.tsx
+++ b/frontend/src/pages/VendorDetail.tsx
@@ -691,6 +691,20 @@ function VendorView({ vendor, onRefresh, featureSettings, onStartRiskAssessment 
   );
 }
 
+// Parse a user-supplied URL and only return it if it's http/https. Anything
+// else (javascript:, data:, vbscript:, etc.) returns null, which causes the
+// component to render the raw value as plain text instead of as a link. This
+// prevents a vendor.website value like "javascript:alert(1)" from becoming
+// an XSS sink when clicked.
+function safeHref(raw: string): string | null {
+  try {
+    const u = new URL(raw);
+    return u.protocol === 'http:' || u.protocol === 'https:' ? u.toString() : null;
+  } catch {
+    return null;
+  }
+}
+
 function InfoField({
   label,
   value,
@@ -704,13 +718,15 @@ function InfoField({
 }) {
   if (!value) return null;
 
+  const href = link ? safeHref(value.toString()) : null;
+
   return (
     <div>
       <dt className="text-sm font-medium text-surface-400 mb-1">{label}</dt>
       <dd className={`text-sm text-surface-100 ${capitalize ? 'capitalize' : ''}`}>
-        {link ? (
+        {href ? (
           <a
-            href={value.toString()}
+            href={href}
             target="_blank"
             rel="noopener noreferrer"
             className="text-brand-400 hover:text-brand-300"

--- a/services/controls/src/integrations/connectors/generic.connector.spec.ts
+++ b/services/controls/src/integrations/connectors/generic.connector.spec.ts
@@ -1,0 +1,124 @@
+import { SSRFProtectionError } from '@gigachad-grc/shared';
+
+// Mock safeFetch BEFORE importing GenericConnector so the import sees the mock.
+const mockSafeFetch = jest.fn();
+jest.mock('@gigachad-grc/shared', () => {
+  const original = jest.requireActual('@gigachad-grc/shared');
+  return {
+    ...original,
+    safeFetch: (...args: any[]) => mockSafeFetch(...args),
+  };
+});
+
+import { GenericConnector } from './generic.connector';
+
+function mockResponse(status: number, body: any) {
+  return {
+    status,
+    json: jest.fn().mockResolvedValue(body),
+    text: jest.fn().mockResolvedValue(JSON.stringify(body)),
+  };
+}
+
+describe('GenericConnector', () => {
+  let connector: GenericConnector;
+
+  beforeEach(() => {
+    connector = new GenericConnector();
+    mockSafeFetch.mockReset();
+  });
+
+  describe('testConnection', () => {
+    it('reports SSRF block as a structured failure rather than swallowing it', async () => {
+      mockSafeFetch.mockRejectedValueOnce(
+        new SSRFProtectionError('Blocked private/internal IP: 169.254.169.254')
+      );
+
+      const result = await connector.testConnection(
+        'integration-x',
+        { apiKey: 'k', baseUrl: 'http://169.254.169.254' },
+        '/status'
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/SSRF protection blocked request/);
+      expect(mockSafeFetch).toHaveBeenCalledTimes(1);
+      const calledUrl = mockSafeFetch.mock.calls[0][0];
+      expect(calledUrl).toContain('169.254.169.254');
+    });
+
+    it('passes Bearer auth header through safeFetch on success', async () => {
+      mockSafeFetch.mockResolvedValueOnce(mockResponse(200, { ok: true }));
+
+      const result = await connector.testConnection(
+        'integration-x',
+        { apiKey: 'secret-token', baseUrl: 'https://api.example.com' }
+      );
+
+      expect(result.success).toBe(true);
+      const callArgs = mockSafeFetch.mock.calls[0][1];
+      expect(callArgs.method).toBe('GET');
+      expect(callArgs.headers.Authorization).toBe('Bearer secret-token');
+    });
+
+    it('returns success=false with response body on non-2xx', async () => {
+      mockSafeFetch.mockResolvedValueOnce(mockResponse(401, { error: 'bad token' }));
+
+      const result = await connector.testConnection(
+        'integration-x',
+        { apiKey: 'k', baseUrl: 'https://api.example.com' }
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('401');
+    });
+
+    it('does not call safeFetch when required config is missing', async () => {
+      const result = await connector.testConnection('integration-x', {});
+      expect(result.success).toBe(false);
+      expect(mockSafeFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('sync', () => {
+    it('records SSRF blocks per-endpoint and continues processing remaining endpoints', async () => {
+      mockSafeFetch
+        .mockRejectedValueOnce(new SSRFProtectionError('blocked internal IP'))
+        .mockResolvedValueOnce(mockResponse(200, { items: [1, 2, 3] }));
+
+      const result = await connector.sync(
+        'integration-x',
+        { apiKey: 'k', baseUrl: 'http://10.0.0.1' },
+        [
+          { name: 'first', path: '/a' },
+          { name: 'second', path: '/b' },
+        ]
+      );
+
+      expect(result.errors.some((e) => /SSRF protection blocked/.test(e))).toBe(true);
+      expect(result.errors.some((e) => e.startsWith('first:'))).toBe(true);
+      expect(result.data.second).toEqual({ items: [1, 2, 3] });
+      expect(result.summary.totalItems).toBe(3);
+      expect(mockSafeFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('still surfaces non-SSRF errors per-endpoint without breaking the loop', async () => {
+      mockSafeFetch
+        .mockRejectedValueOnce(new Error('network timeout'))
+        .mockResolvedValueOnce(mockResponse(200, [{ id: 'x' }]));
+
+      const result = await connector.sync(
+        'integration-x',
+        { apiKey: 'k', baseUrl: 'https://api.example.com' },
+        [
+          { name: 'first', path: '/a' },
+          { name: 'second', path: '/b' },
+        ]
+      );
+
+      expect(result.errors).toContain('first: network timeout');
+      expect(result.data.second).toEqual([{ id: 'x' }]);
+      expect(result.summary.totalItems).toBe(1);
+    });
+  });
+});

--- a/services/controls/src/integrations/connectors/generic.connector.ts
+++ b/services/controls/src/integrations/connectors/generic.connector.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { BaseConnector } from './base-connector';
-import axios from 'axios';
+import { safeFetch, SSRFProtectionError } from '@gigachad-grc/shared';
 
 /**
  * Generic connector for integrations that follow standard patterns
@@ -49,12 +49,14 @@ export class GenericConnector {
     const target = this.joinUrl(base, testEndpoint || '');
 
     try {
-      const response = await axios.get(target, {
+      // safeFetch blocks SSRF targets (internal IPs, link-local, metadata
+      // endpoints) — required because the baseUrl is operator-configured.
+      const response = await safeFetch(target, {
+        method: 'GET',
         headers: {
           Authorization: `Bearer ${bearer}`,
           Accept: 'application/json',
         },
-        validateStatus: () => true,
       });
       if (response.status >= 200 && response.status < 300) {
         return {
@@ -63,14 +65,15 @@ export class GenericConnector {
           details: { status: response.status },
         };
       }
-      const snippet = typeof response.data === 'string'
-        ? response.data.slice(0, 200)
-        : JSON.stringify(response.data || {}).slice(0, 200);
+      const body = await response.text().catch(() => '');
       return {
         success: false,
-        message: `${integrationType} API returned ${response.status}: ${snippet}`,
+        message: `${integrationType} API returned ${response.status}: ${body.slice(0, 200)}`,
       };
     } catch (error: any) {
+      if (error instanceof SSRFProtectionError) {
+        return { success: false, message: `SSRF protection blocked request: ${error.message}` };
+      }
       return { success: false, message: error.message || `${integrationType} connection failed` };
     }
   }
@@ -103,27 +106,33 @@ export class GenericConnector {
     for (const endpoint of endpoints) {
       const url = this.joinUrl(base, endpoint.path);
       try {
-        const response = await axios.get(url, {
+        // safeFetch blocks SSRF — see comment in testConnection above.
+        const response = await safeFetch(url, {
+          method: 'GET',
           headers: {
             Authorization: `Bearer ${bearer}`,
             Accept: 'application/json',
           },
-          validateStatus: () => true,
         });
         if (response.status < 200 || response.status >= 300) {
           errors.push(`${endpoint.name}: HTTP ${response.status}`);
           continue;
         }
-        data[endpoint.name] = response.data;
-        if (Array.isArray(response.data)) {
-          totalItems += response.data.length;
-        } else if (response.data && typeof response.data === 'object') {
-          const arrayField = Object.values(response.data).find((v) => Array.isArray(v));
+        const body = await response.json().catch(() => null);
+        data[endpoint.name] = body;
+        if (Array.isArray(body)) {
+          totalItems += body.length;
+        } else if (body && typeof body === 'object') {
+          const arrayField = Object.values(body).find((v) => Array.isArray(v));
           if (Array.isArray(arrayField)) totalItems += arrayField.length;
           else totalItems += 1;
         }
       } catch (error: any) {
-        errors.push(`${endpoint.name}: ${error.message || 'request failed'}`);
+        if (error instanceof SSRFProtectionError) {
+          errors.push(`${endpoint.name}: SSRF protection blocked request: ${error.message}`);
+        } else {
+          errors.push(`${endpoint.name}: ${error.message || 'request failed'}`);
+        }
       }
     }
 

--- a/services/tprm/src/contracts/contracts.controller.ts
+++ b/services/tprm/src/contracts/contracts.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Controller,
   Get,
   Post,
@@ -13,6 +14,19 @@ import {
   Res,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
+
+// Allowlist for contract document uploads. Anything outside this set is
+// rejected at the interceptor layer before the service handler runs.
+const CONTRACT_MIME_ALLOWLIST = [
+  'application/pdf',
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/vnd.ms-excel',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'text/plain',
+  'text/csv',
+];
+const CONTRACT_MAX_BYTES = 25 * 1024 * 1024;
 import { Response } from 'express';
 import { ContractsService } from './contracts.service';
 import { CreateContractDto } from './dto/create-contract.dto';
@@ -82,12 +96,26 @@ export class ContractsController {
   }
 
   @Post(':id/document')
-  @UseInterceptors(FileInterceptor('file'))
+  @UseInterceptors(
+    FileInterceptor('file', {
+      limits: { fileSize: CONTRACT_MAX_BYTES },
+      fileFilter: (_req, file, cb) => {
+        if (CONTRACT_MIME_ALLOWLIST.includes(file.mimetype)) {
+          cb(null, true);
+        } else {
+          cb(new BadRequestException(`Unsupported file type: ${file.mimetype}`), false);
+        }
+      },
+    })
+  )
   uploadDocument(
     @Param('id') id: string,
     @UploadedFile() file: Express.Multer.File,
     @CurrentUser() user: UserContext
   ) {
+    if (!file) {
+      throw new BadRequestException('No file uploaded');
+    }
     // SECURITY: Pass organizationId to ensure tenant isolation
     return this.contractsService.uploadDocument(id, file, user.userId, user.organizationId);
   }

--- a/services/tprm/src/contracts/contracts.controller.ts
+++ b/services/tprm/src/contracts/contracts.controller.ts
@@ -14,10 +14,17 @@ import {
   Res,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
+import { Response } from 'express';
+import { ContractsService } from './contracts.service';
+import { CreateContractDto } from './dto/create-contract.dto';
+import { UpdateContractDto } from './dto/update-contract.dto';
+import { CurrentUser, UserContext } from '@gigachad-grc/shared';
+import { DevAuthGuard } from '../auth/dev-auth.guard';
 
 // Allowlist for contract document uploads. Anything outside this set is
 // rejected at the interceptor layer before the service handler runs.
-const CONTRACT_MIME_ALLOWLIST = [
+// Exported so it can be exercised directly in tests.
+export const CONTRACT_MIME_ALLOWLIST = [
   'application/pdf',
   'application/msword',
   'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
@@ -26,13 +33,19 @@ const CONTRACT_MIME_ALLOWLIST = [
   'text/plain',
   'text/csv',
 ];
-const CONTRACT_MAX_BYTES = 25 * 1024 * 1024;
-import { Response } from 'express';
-import { ContractsService } from './contracts.service';
-import { CreateContractDto } from './dto/create-contract.dto';
-import { UpdateContractDto } from './dto/update-contract.dto';
-import { CurrentUser, UserContext } from '@gigachad-grc/shared';
-import { DevAuthGuard } from '../auth/dev-auth.guard';
+export const CONTRACT_MAX_BYTES = 25 * 1024 * 1024;
+
+export function contractFileFilter(
+  _req: unknown,
+  file: { mimetype: string },
+  cb: (err: Error | null, acceptFile: boolean) => void,
+): void {
+  if (CONTRACT_MIME_ALLOWLIST.includes(file.mimetype)) {
+    cb(null, true);
+  } else {
+    cb(new BadRequestException(`Unsupported file type: ${file.mimetype}`), false);
+  }
+}
 
 /**
  * SECURITY: Sanitize filename for Content-Disposition header
@@ -99,13 +112,7 @@ export class ContractsController {
   @UseInterceptors(
     FileInterceptor('file', {
       limits: { fileSize: CONTRACT_MAX_BYTES },
-      fileFilter: (_req, file, cb) => {
-        if (CONTRACT_MIME_ALLOWLIST.includes(file.mimetype)) {
-          cb(null, true);
-        } else {
-          cb(new BadRequestException(`Unsupported file type: ${file.mimetype}`), false);
-        }
-      },
+      fileFilter: contractFileFilter,
     })
   )
   uploadDocument(


### PR DESCRIPTION
## Summary

Application-layer hardening for findings the deep audit surfaced. Third of three PRs from the same audit (see #299 for tenant-scoping, #300 for supply-chain).

### Frontend

| File | Finding | Fix |
|---|---|---|
| \`frontend/src/pages/VendorDetail.tsx\` | \`vendor.website\` was rendered as \`<a href={raw}>\` with no scheme validation. A vendor whose \`website\` field was set to \`javascript:alert(1)\` would render as a clickable XSS sink. | Added \`safeHref()\` that parses the URL and only returns it if the protocol is \`http:\`/\`https:\`. Anything else (\`javascript:\`, \`data:\`, \`vbscript:\`, malformed) renders as plain text instead of as a link. |
| \`frontend/Dockerfile\` | \`VITE_ENABLE_DEV_AUTH=true\` was a single build arg with no separate opt-in. A misconfigured CI variable could silently bake the Keycloak-bypassing dev-login UI into a production image. | Build now refuses to proceed if \`VITE_ENABLE_DEV_AUTH=true\` is set without an explicit \`--build-arg ALLOW_DEV_AUTH=true\`. Double opt-in. |
| \`frontend/src/contexts/AuthContext.tsx\` | \`devLogin()\` was gated only by \`import.meta.env.DEV \|\| VITE_ENABLE_DEV_AUTH==='true'\` — if VITE_ENABLE_DEV_AUTH leaked into a prod bundle, the bypass was live. | Added a defense-in-depth guard that refuses to mutate state when \`import.meta.env.PROD\` is true and the dev-auth flag is not set. Backstops the Dockerfile guard. |
| \`frontend/src/lib/training.ts\` | Three \`.catch(() => {})\` handlers silently swallowed background-sync errors. CSRF, auth, or network failures were invisible. | Replaced with \`.catch((err) => console.warn(...))\`. Still non-fatal (localStorage is the source of truth) but no longer invisible. |

### Backend

| File | Finding | Fix |
|---|---|---|
| \`services/controls/src/integrations/connectors/generic.connector.ts\` | \`axios.get(target, …)\` was called against an operator-configured \`baseUrl\` with no SSRF guard. \`safeFetch\` from \`@gigachad-grc/shared\` is the canonical pattern used in \`collectors.service.ts\` for the same threat model. | Replaced both \`axios.get\` call sites with \`safeFetch\`. Surface \`SSRFProtectionError\` as a structured failure rather than swallowing it as a generic "connection failed". |
| \`services/tprm/src/contracts/contracts.controller.ts\` | The contract document upload endpoint accepted any MIME type and had no per-file size cap. | Added a \`FileInterceptor.fileFilter\` that accepts only pdf / doc / docx / xls / xlsx / txt / csv. Added \`limits.fileSize = 25 MB\`. Unknown types throw \`BadRequestException\` at the interceptor layer before the service handler runs. |

## Verification

- [x] \`npx tsc --noEmit\` in \`frontend/\` — clean.
- [x] \`npx tsc --noEmit\` in \`services/controls/\` and \`services/tprm/\` — clean for the two edited files. (There are pre-existing Prisma-codegen errors elsewhere in those services in a local checkout that does not have \`npx prisma generate\` run; the CI build is unaffected because the Dockerfiles run codegen explicitly.)
- [ ] \`docker build -f frontend/Dockerfile . --build-arg VITE_ENABLE_DEV_AUTH=true\` — expected to fail with the explanatory message.
- [ ] \`docker build -f frontend/Dockerfile . --build-arg VITE_ENABLE_DEV_AUTH=true --build-arg ALLOW_DEV_AUTH=true\` — succeeds.
- [ ] In VendorDetail UI, set \`vendor.website = "javascript:alert(1)"\` via the form. Confirm the rendered detail page shows it as plain text, not a clickable link.
- [ ] Try POSTing a \`.exe\` payload to \`/contracts/:id/document\` — expect 400 with the unsupported-MIME message.
- [ ] Configure a generic-pattern integration with a baseUrl of \`http://169.254.169.254\` — expect the test connection to fail with the SSRF-protection message.

## Out of scope (audit findings deferred)

- SCIM token storage migration (\`services/controls/src/scim/scim.controller.ts\`) — env-var to per-org DB row needs a schema + endpoint redesign.
- \`organizationId\` in the public trust-center URL (\`frontend/src/pages/TrustCenterSettings.tsx:252\`) — backend already gates on \`trustCenter.isPublic\`. Flagged for re-review of the public endpoint, not changed here.
- IDE warns the base \`node:20-alpine\` digest is stale with 11 high CVEs. Pre-existing; refreshing the digest is its own change with its own test impact.