### PR TITLE
fix + test(e2e): /employees route + /assets shadow + post-merge cleanups

### DIFF
--- a/frontend/e2e/assets.spec.ts
+++ b/frontend/e2e/assets.spec.ts
@@ -7,16 +7,7 @@ import { test, expect } from '@playwright/test';
 
 test.describe('Assets', () => {
   test.beforeEach(async ({ page }) => {
-    // Direct nav to /assets hits an nginx 301→`/assets/` redirect (the
-    // built `dist/assets/` directory conflicts with the SPA route). Bootstrap
-    // the SPA on /dashboard, then push the target URL into history so React
-    // Router handles it client-side.
-    await page.goto('/dashboard');
-    await page.waitForLoadState('networkidle');
-    await page.evaluate(() => {
-      window.history.pushState({}, '', '/assets');
-      window.dispatchEvent(new PopStateEvent('popstate'));
-    });
+    await page.goto('/assets');
     await page.waitForLoadState('networkidle');
   });
 

--- a/frontend/e2e/employee-compliance.spec.ts
+++ b/frontend/e2e/employee-compliance.spec.ts
@@ -80,21 +80,15 @@ test.describe('Employee Compliance Dashboard', () => {
     }
   });
 
-  // The dashboard's "View All Employees" link points to /employees, but that
-  // route does not exist (the employee list lives at /people). Clicking the
-  // link triggers a catch-all redirect to /dashboard. Skip until the product
-  // link target is corrected.
-  test.skip('can navigate to employee list', async ({ page }) => {
-    // Look for "View All Employees" link
-    const viewAllLink = page.locator('a, button').filter({ hasText: /View.*Employee|All Employee/i });
+  test('can navigate to employee list', async ({ page }) => {
+    // Scope to main; the sidebar has its own People/Employee links that
+    // would otherwise match first.
+    const viewAllLink = page
+      .locator('main')
+      .getByRole('link', { name: /View.*Employee|All Employee/i });
 
-    if (await viewAllLink.count() > 0) {
-      await viewAllLink.first().click();
-      await page.waitForLoadState('networkidle');
-
-      // Should navigate to employees page
-      await expect(page).toHaveURL(/employee|people/i);
-    }
+    await viewAllLink.first().click();
+    await expect(page).toHaveURL(/\/people(\?|$)/);
   });
 
   test('can access compliance settings', async ({ page }) => {

--- a/frontend/src/pages/EmployeeComplianceDashboard.tsx
+++ b/frontend/src/pages/EmployeeComplianceDashboard.tsx
@@ -292,7 +292,7 @@ export default function EmployeeComplianceDashboard() {
             <ArrowPathIcon className={`h-5 w-5 ${syncMutation.isPending ? 'animate-spin' : ''}`} />
             {syncMutation.isPending ? 'Syncing...' : 'Sync All'}
           </button>
-          <Link to="/employees" className="btn btn-primary">View All Employees</Link>
+          <Link to="/people" className="btn btn-primary">View All Employees</Link>
         </div>
       </div>
 
@@ -488,7 +488,7 @@ export default function EmployeeComplianceDashboard() {
                       {missingData.noBackgroundCheck?.length || 0} employees missing background checks, {' '}
                       {missingData.noTrainingData?.length || 0} missing training data
                     </p>
-                    <Link to="/employees?filter=missing-data" className="text-xs text-amber-700 dark:text-yellow-300 hover:text-amber-800 dark:hover:text-yellow-200 mt-1 inline-block">
+                    <Link to="/people?filter=missing-data" className="text-xs text-amber-700 dark:text-yellow-300 hover:text-amber-800 dark:hover:text-yellow-200 mt-1 inline-block">
                       View details →
                     </Link>
                   </div>
@@ -531,7 +531,7 @@ export default function EmployeeComplianceDashboard() {
                         </div>
                       ))}
                       {metrics.upcomingDeadlines.overdueTrainings.length > 5 && (
-                        <Link to="/employees?filter=overdue-training" className="text-xs text-brand-400 hover:text-brand-300 block text-center mt-2">
+                        <Link to="/people?filter=overdue-training" className="text-xs text-brand-400 hover:text-brand-300 block text-center mt-2">
                           View all {metrics.upcomingDeadlines.overdueTrainings.length} →
                         </Link>
                       )}
@@ -562,7 +562,7 @@ export default function EmployeeComplianceDashboard() {
                         </div>
                       ))}
                       {metrics.upcomingDeadlines.expiringBackgroundChecks.length > 5 && (
-                        <Link to="/employees?filter=expiring-background" className="text-xs text-brand-400 hover:text-brand-300 block text-center mt-2">
+                        <Link to="/people?filter=expiring-background" className="text-xs text-brand-400 hover:text-brand-300 block text-center mt-2">
                           View all {metrics.upcomingDeadlines.expiringBackgroundChecks.length} →
                         </Link>
                       )}
@@ -593,7 +593,7 @@ export default function EmployeeComplianceDashboard() {
                         </div>
                       ))}
                       {metrics.upcomingDeadlines.pendingAttestations.length > 5 && (
-                        <Link to="/employees?filter=pending-attestation" className="text-xs text-brand-400 hover:text-brand-300 block text-center mt-2">
+                        <Link to="/people?filter=pending-attestation" className="text-xs text-brand-400 hover:text-brand-300 block text-center mt-2">
                           View all {metrics.upcomingDeadlines.pendingAttestations.length} →
                         </Link>
                       )}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -35,6 +35,13 @@ export default defineConfig(({ mode }) => {
       },
     },
     build: {
+      // Output bundled JS/CSS under dist/static/ instead of the Vite
+      // default dist/assets/. The default name collides with the SPA's
+      // /assets route: nginx's `try_files` resolves the literal
+      // dist/assets/ directory before falling through to /index.html,
+      // so direct navigation or refresh on /assets/* returns 404 instead
+      // of the SPA. Renaming the asset directory unshadows the route.
+      assetsDir: 'static',
       rollupOptions: {
         output: {
           manualChunks: (id) => {


### PR DESCRIPTION
## Summary

Two product bugs found while writing browser-level e2e coverage in PR #303, plus the test-side cleanups they enable now that #303 has merged.

After this lands, the frontend e2e suite is **253 / 253 fully green** against the dev docker stack — first time since the harness landed.

## Bug 1: EmployeeComplianceDashboard linked to nonexistent /employees route

`frontend/src/pages/EmployeeComplianceDashboard.tsx` had 5 `<Link to="/employees">`s — the main "View All Employees" CTA plus four `?filter=...` deep-links from the metric tiles. `/employees` is not registered in `App.tsx`; the real list is at `/people`. Clicking any of them silently routed to `/dashboard` via the catch-all; none of the filter deep-links worked at all.

**Fix:** all 5 `to="/employees"` → `to="/people"`, preserving the `?filter=...` query strings.

## Bug 2: Vite assets/ build dir shadowed the /assets SPA route

`frontend/nginx.conf:428`'s SPA fallback is `try_files $uri $uri/ /index.html`. Vite's default `build.assetsDir: 'assets'` produces `dist/assets/`, which `$uri/` resolves before falling through. Direct nav or refresh on `/assets` → 301 → Traefik 404, never the SPA.

**Fix:** `build.assetsDir: 'static'` in `frontend/vite.config.ts`. Bundles now land at `dist/static/`. nginx's static-asset cache rule (line 432) matches by file extension, no nginx change needed.

## Test cleanups enabled by the fixes (commit 2)

PR #303 left two workarounds in place because the product was broken. Both are unwound here:

- **`e2e/assets.spec.ts`** — dropped the `history.pushState` bootstrap; `beforeEach` is back to a plain `page.goto('/assets')`.
- **`e2e/employee-compliance.spec.ts`** — un-skipped `can navigate to employee list`. With the link fixed, the test clicks the live link and asserts the resulting URL.

## Verification

| Check | Result |
|---|---|
| `curl /assets` | 200 with SPA index.html (was 301 → 404) |
| `curl /static/index-<hash>.js` | 200 |
| Compiled bundle `to="/employees"` count | 0 (was 5) |
| Compiled bundle `to="/people"` count | 5 (new) |
| Targeted Playwright smoke ("View All Employees" → `/people`) | passes |
| **Frontend full e2e suite** | **253 passed, 0 failed, 0 skipped** (~1.3 min) |

## Files touched

| File | Change |
|---|---|
| `frontend/src/pages/EmployeeComplianceDashboard.tsx` | 5 link targets fixed |
| `frontend/vite.config.ts` | `assetsDir: 'static'` + explanatory comment |
| `frontend/e2e/assets.spec.ts` | revert pushState workaround |
| `frontend/e2e/employee-compliance.spec.ts` | un-skip + update employee-list test |

No backend, no Docker config, no nginx, no Helm.