### PR TITLE
chore(backup): drop docker.sock from backup-scheduler

### DIFF
--- a/deploy/Dockerfile.backup-scheduler
+++ b/deploy/Dockerfile.backup-scheduler
@@ -1,5 +1,10 @@
 # GigaChad GRC Backup Scheduler
-# Runs automated backups on a configurable schedule
+# Runs automated backups on a configurable schedule.
+#
+# This container connects to other services on the docker-compose grc-network
+# as a normal network peer (pg_dump over TCP, redis-cli over TCP, aws s3
+# against the rustfs S3 API). It does NOT need access to /var/run/docker.sock
+# and the docker CLI is intentionally absent from this image.
 
 FROM alpine:3.23
 
@@ -7,11 +12,10 @@ FROM alpine:3.23
 RUN apk upgrade --no-cache && apk add --no-cache \
     bash \
     curl \
-    docker-cli \
-    docker-compose \
     gzip \
     tar \
     postgresql16-client \
+    redis \
     aws-cli \
     jq \
     tzdata \

--- a/deploy/QUICKSTART.md
+++ b/deploy/QUICKSTART.md
@@ -105,13 +105,28 @@ docker compose -f docker-compose.prod.yml up -d --build controls
 
 ## Backup & Restore
 
+The `backup-scheduler` container runs as a plain network peer on `grc-network`
+and uses `pg_dump`, `redis-cli` and `aws s3` to pull data directly from
+`postgres`, `redis` and `rustfs`. It does **not** mount `/var/run/docker.sock`,
+so a compromise of the backup container cannot reach other containers on the
+host.
+
 ### Create Backup
 
 ```bash
-# Run backup script
+# Run backup script (from the host)
 ./deploy/backup.sh
 
 # Backup is stored in: /backups/gigachad-grc/backup-YYYY-MM-DD-HHMMSS.tar.gz
+```
+
+When invoking `backup.sh` from the host, set network targets if your services
+are not at the defaults (the script defaults to `postgres` / `redis` /
+`http://rustfs:9000`, which only resolve from inside the compose network):
+
+```bash
+POSTGRES_HOST=127.0.0.1 REDIS_HOST=127.0.0.1 S3_ENDPOINT=http://127.0.0.1:9000 \
+    ./deploy/backup.sh
 ```
 
 ### Schedule Automatic Backups

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -329,10 +329,17 @@ cd /opt/gigachad-grc/deploy
 
 Backup includes:
 
-- PostgreSQL database dump
-- RustFS/S3 object storage files
-- Configuration files
-- Docker volumes
+- PostgreSQL database dump (taken over the network via `pg_dump`)
+- RustFS/S3 object storage files (taken via the S3 API with `aws s3 sync`)
+- Redis snapshot (taken over the network via `redis-cli --rdb`)
+- Configuration files (`.env.prod`, `docker-compose.prod.yml`, Traefik, Keycloak realm export, database init scripts)
+
+The `backup-scheduler` container does **not** mount `/var/run/docker.sock`. It
+connects to `postgres`, `redis` and `rustfs` purely as a network peer on the
+`grc-network`. A compromised backup container therefore cannot introspect or
+operate on other containers on the host. Application data volumes
+(`postgres_data`, `redis_data`, `rustfs_data`) are no longer captured at the
+filesystem level; the network-level dumps above are the canonical backup.
 
 Backups are stored in:
 
@@ -341,23 +348,42 @@ Backups are stored in:
 
 ### Disaster Recovery
 
+`restore.sh` is run **from the host** by an operator. It uses `pg_restore`,
+`psql` and `aws s3` to push data back into the containers over the network -
+it does not need to be run from inside the backup-scheduler container, and
+no `docker exec` / `docker cp` calls are used for data movement. The host
+`docker` CLI is still used for service lifecycle (`docker compose up/down`).
+
 To restore from backup:
 
 ```bash
-# Stop all services
-cd /opt/gigachad-grc
-docker compose -f docker-compose.prod.yml down
-
-# Restore from backup
-cd deploy
+# Run from the host (postgresql-client, redis and aws-cli must be installed)
+cd /opt/gigachad-grc/deploy
 ./restore.sh /backups/gigachad-grc/backup-YYYY-MM-DD-HHMMSS.tar.gz
 
-# Start services
-cd ..
-docker compose -f docker-compose.prod.yml --env-file .env.prod up -d
+# restore.sh stops services, restores configuration, restarts postgres /
+# rustfs, pushes data back via the network, then brings up the full stack.
 
 # Verify restoration
+cd ..
 docker compose -f docker-compose.prod.yml logs -f
+```
+
+#### Manual Redis cold restore
+
+Because Redis only loads `dump.rdb` at server startup, network-only restore
+cannot fully rehydrate the cache. The default behaviour is to skip Redis -
+keys are recomputed from postgres / rustfs on demand. If a true cold restore
+is required (e.g. for rate-limit counters or session continuity), run on the
+host after extracting the backup archive:
+
+```bash
+docker compose -f docker-compose.prod.yml stop redis
+docker run --rm \
+    -v gigachad-grc_redis_data:/data \
+    -v "$(pwd)":/src \
+    alpine cp /src/redis_backup.rdb /data/dump.rdb
+docker compose -f docker-compose.prod.yml start redis
 ```
 
 ### Backup to Remote Storage

--- a/deploy/backup.sh
+++ b/deploy/backup.sh
@@ -8,14 +8,27 @@
 # - PostgreSQL database
 # - RustFS/S3 object storage (https://github.com/rustfs/rustfs)
 # - Configuration files
-# - Docker volumes
+#
+# Backups are taken over the docker-compose network using direct network clients
+# (pg_dump, redis-cli, aws s3). The script does NOT require access to the host
+# Docker socket - the backup-scheduler container runs as a plain network peer.
 #
 # Usage: ./backup.sh [backup_directory]
 #
-# Prerequisites:
-# - Docker and Docker Compose installed
-# - Sufficient disk space for backups
-# - Write permissions to backup directory
+# Required environment variables (typically supplied via the backup-scheduler
+# service in docker-compose.prod.yml):
+#   POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DB
+#   REDIS_PASSWORD
+#   MINIO_ROOT_USER, MINIO_ROOT_PASSWORD
+#
+# Optional overrides:
+#   POSTGRES_HOST (default: postgres)
+#   POSTGRES_PORT (default: 5432)
+#   REDIS_HOST    (default: redis)
+#   REDIS_PORT    (default: 6379)
+#   S3_ENDPOINT   (default: http://rustfs:9000)
+#   S3_BUCKET     (default: grc-storage)
+#   S3_REGION     (default: us-east-1)
 #
 ################################################################################
 
@@ -42,9 +55,18 @@ RETENTION_DAYS="${BACKUP_RETENTION_DAYS:-30}"
 # Compression settings
 COMPRESSION_LEVEL="${BACKUP_COMPRESSION_LEVEL:-6}"
 
-# Docker Compose settings
-COMPOSE_FILE="${PROJECT_DIR}/docker-compose.prod.yml"
-ENV_FILE="${PROJECT_DIR}/.env.prod"
+# Network targets (resolvable on the docker-compose grc-network)
+POSTGRES_HOST="${POSTGRES_HOST:-postgres}"
+POSTGRES_PORT="${POSTGRES_PORT:-5432}"
+REDIS_HOST="${REDIS_HOST:-redis}"
+REDIS_PORT="${REDIS_PORT:-6379}"
+S3_ENDPOINT="${S3_ENDPOINT:-http://rustfs:9000}"
+S3_BUCKET="${S3_BUCKET:-grc-storage}"
+S3_REGION="${S3_REGION:-us-east-1}"
+
+# Optional environment file (only used to surface config files in the backup -
+# environment is normally injected by the container runtime).
+ENV_FILE="${ENV_FILE:-${PROJECT_DIR}/.env.prod}"
 
 # Log file
 LOG_FILE="${BACKUP_ROOT}/backup-${TIMESTAMP}.log"
@@ -93,20 +115,20 @@ command_exists() {
 check_prerequisites() {
     log_info "Checking prerequisites..."
 
-    if ! command_exists docker; then
-        error_exit "Docker is not installed. Please install Docker first."
+    if ! command_exists pg_dump; then
+        error_exit "pg_dump not found. Install postgresql-client."
     fi
 
-    if ! command_exists docker-compose && ! docker compose version >/dev/null 2>&1; then
-        error_exit "Docker Compose is not installed. Please install Docker Compose first."
+    if ! command_exists redis-cli; then
+        error_exit "redis-cli not found. Install the redis package."
     fi
 
-    if [ ! -f "$COMPOSE_FILE" ]; then
-        error_exit "Docker Compose file not found: $COMPOSE_FILE"
+    if ! command_exists aws; then
+        error_exit "aws CLI not found. Install aws-cli."
     fi
 
-    if [ ! -f "$ENV_FILE" ]; then
-        error_exit "Environment file not found: $ENV_FILE"
+    if [ -z "${POSTGRES_USER:-}" ] || [ -z "${POSTGRES_PASSWORD:-}" ] || [ -z "${POSTGRES_DB:-}" ]; then
+        error_exit "POSTGRES_USER, POSTGRES_PASSWORD and POSTGRES_DB must be set"
     fi
 
     log_success "Prerequisites check passed"
@@ -130,70 +152,89 @@ create_backup_directory() {
 load_environment() {
     log_info "Loading environment variables..."
 
-    # Source environment file
-    set -a
-    # shellcheck disable=SC1090
-    source "$ENV_FILE"
-    set +a
+    # In the backup-scheduler container the environment is injected by
+    # docker-compose. When run from the host we optionally source .env.prod
+    # for convenience, but it is not required.
+    if [ -f "$ENV_FILE" ]; then
+        set -a
+        # shellcheck disable=SC1090
+        source "$ENV_FILE"
+        set +a
+    fi
 
-    # Set defaults if not defined
+    # Set sensible defaults
     POSTGRES_USER="${POSTGRES_USER:-grc_prod_user}"
     POSTGRES_DB="${POSTGRES_DB:-gigachad_grc_prod}"
 
     log_success "Environment variables loaded"
 }
 
-# Backup PostgreSQL database
+# Backup PostgreSQL database over the network
 backup_database() {
-    log_info "Starting PostgreSQL database backup..."
+    log_info "Starting PostgreSQL database backup (host: $POSTGRES_HOST)..."
 
     local db_backup_file="${BACKUP_DIR}/postgres_backup.sql.gz"
     local db_custom_backup="${BACKUP_DIR}/postgres_backup.dump"
 
+    # PGPASSWORD avoids interactive prompts; scope it to this function
+    export PGPASSWORD="$POSTGRES_PASSWORD"
+
     # SQL dump (compressed)
     log_info "Creating SQL dump..."
-    docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" exec -T postgres \
-        pg_dump -U "$POSTGRES_USER" -d "$POSTGRES_DB" -F plain --clean --if-exists \
+    pg_dump -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" \
+        -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+        -F plain --clean --if-exists \
         | gzip -"$COMPRESSION_LEVEL" > "$db_backup_file" \
-        || error_exit "Failed to create SQL dump"
+        || { unset PGPASSWORD; error_exit "Failed to create SQL dump"; }
 
     # Custom format dump (for faster restoration)
     log_info "Creating custom format dump..."
-    docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" exec -T postgres \
-        pg_dump -U "$POSTGRES_USER" -d "$POSTGRES_DB" -F custom -Z "$COMPRESSION_LEVEL" \
-        > "$db_custom_backup" \
-        || error_exit "Failed to create custom format dump"
+    pg_dump -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" \
+        -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+        -F custom -Z "$COMPRESSION_LEVEL" \
+        -f "$db_custom_backup" \
+        || { unset PGPASSWORD; error_exit "Failed to create custom format dump"; }
 
     # Get database size
     local db_size
-    db_size=$(docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" exec -T postgres \
-        psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -t -c \
-        "SELECT pg_size_pretty(pg_database_size('$POSTGRES_DB'));" | xargs)
+    db_size=$(psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" \
+        -U "$POSTGRES_USER" -d "$POSTGRES_DB" -t -c \
+        "SELECT pg_size_pretty(pg_database_size('$POSTGRES_DB'));" 2>/dev/null \
+        | xargs || echo "unknown")
+
+    unset PGPASSWORD
 
     log_success "Database backup completed (Size: $db_size)"
 }
 
-# Backup RustFS/S3 object storage data
+# Backup RustFS/S3 object storage over the S3 API
 backup_object_storage() {
     log_info "Starting RustFS/S3 object storage backup..."
 
-    local storage_backup_dir="${BACKUP_DIR}/rustfs"
+    local storage_backup_dir="${BACKUP_DIR}/object-storage"
     mkdir -p "$storage_backup_dir"
 
-    # Use docker cp to copy RustFS data
-    # Try new container name first, fall back to legacy minio name
-    log_info "Copying object storage data..."
-    if docker cp grc-rustfs:/data "$storage_backup_dir/" 2>/dev/null; then
-        log_info "Copied data from grc-rustfs container"
-    elif docker cp grc-minio:/data "$storage_backup_dir/" 2>/dev/null; then
-        log_info "Copied data from legacy grc-minio container"
-    else
-        log_warning "Failed to backup object storage data (service may not be running)"
+    if [ -z "${MINIO_ROOT_USER:-}" ] || [ -z "${MINIO_ROOT_PASSWORD:-}" ]; then
+        log_warning "MINIO_ROOT_USER / MINIO_ROOT_PASSWORD not set; skipping object storage backup"
+        return 0
     fi
 
-    # Compress backup (keep legacy name for compatibility)
+    log_info "Syncing s3://${S3_BUCKET} from ${S3_ENDPOINT}..."
+
+    # Pass credentials via the env vars aws-cli reads, scoped to the subshell
+    if ! (
+        export AWS_ACCESS_KEY_ID="$MINIO_ROOT_USER"
+        export AWS_SECRET_ACCESS_KEY="$MINIO_ROOT_PASSWORD"
+        export AWS_DEFAULT_REGION="$S3_REGION"
+        aws --endpoint-url "$S3_ENDPOINT" s3 sync \
+            "s3://${S3_BUCKET}" "$storage_backup_dir" --no-progress
+    ); then
+        log_warning "aws s3 sync failed (bucket may not exist or RustFS unreachable)"
+    fi
+
+    # Compress backup (keep legacy filename for restore compatibility)
     log_info "Compressing object storage data..."
-    tar -czf "${BACKUP_DIR}/minio_backup.tar.gz" -C "$storage_backup_dir" data \
+    tar -czf "${BACKUP_DIR}/minio_backup.tar.gz" -C "$BACKUP_DIR" object-storage \
         || log_warning "Failed to compress object storage backup"
 
     # Remove uncompressed directory
@@ -202,25 +243,26 @@ backup_object_storage() {
     log_success "Object storage backup completed"
 }
 
-# Backup Redis data (optional)
+# Backup Redis data using redis-cli's RDB-over-the-wire mode
 backup_redis() {
-    log_info "Starting Redis backup..."
+    log_info "Starting Redis backup (host: $REDIS_HOST)..."
 
     local redis_backup_file="${BACKUP_DIR}/redis_backup.rdb"
 
-    # Trigger Redis BGSAVE
-    docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" exec -T redis \
-        redis-cli -a "$REDIS_PASSWORD" --no-auth-warning BGSAVE \
-        || log_warning "Failed to trigger Redis BGSAVE"
+    if [ -z "${REDIS_PASSWORD:-}" ]; then
+        log_warning "REDIS_PASSWORD not set; skipping Redis backup"
+        return 0
+    fi
 
-    # Wait for BGSAVE to complete
-    sleep 5
-
-    # Copy Redis dump file
-    docker cp grc-redis:/data/dump.rdb "$redis_backup_file" \
-        || log_warning "Failed to backup Redis data"
-
-    log_success "Redis backup completed"
+    # redis-cli --rdb writes the RDB stream from the server straight to a local
+    # file. No need to copy a file out of the redis container.
+    if redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" \
+        -a "$REDIS_PASSWORD" --no-auth-warning \
+        --rdb "$redis_backup_file" 2>>"$LOG_FILE"; then
+        log_success "Redis backup completed"
+    else
+        log_warning "Failed to backup Redis data (server may not be running)"
+    fi
 }
 
 # Backup configuration files
@@ -230,9 +272,10 @@ backup_configurations() {
     local config_backup_dir="${BACKUP_DIR}/configs"
     mkdir -p "$config_backup_dir"
 
-    # Copy configuration files
-    cp "$ENV_FILE" "$config_backup_dir/.env.prod" 2>/dev/null || true
-    cp "$COMPOSE_FILE" "$config_backup_dir/docker-compose.prod.yml" 2>/dev/null || true
+    # Copy configuration files (mounted read-only into the backup container)
+    [ -f "$ENV_FILE" ] && cp "$ENV_FILE" "$config_backup_dir/.env.prod" 2>/dev/null || true
+    [ -f "${PROJECT_DIR}/docker-compose.prod.yml" ] && \
+        cp "${PROJECT_DIR}/docker-compose.prod.yml" "$config_backup_dir/docker-compose.prod.yml" 2>/dev/null || true
 
     # Copy Traefik configuration if exists
     [ -f "${PROJECT_DIR}/gateway/traefik.yml" ] && \
@@ -249,43 +292,6 @@ backup_configurations() {
     log_success "Configuration files backup completed"
 }
 
-# Backup Docker volumes
-backup_volumes() {
-    log_info "Starting Docker volumes backup..."
-
-    local volumes_backup_dir="${BACKUP_DIR}/volumes"
-    mkdir -p "$volumes_backup_dir"
-
-    # List of volumes to backup
-    # Note: rustfs_data is the new volume name, minio_data is legacy
-    local volumes=(
-        "gigachad-grc_postgres_data"
-        "gigachad-grc_redis_data"
-        "gigachad-grc_rustfs_data"
-        "gigachad-grc_minio_data"
-        "gigachad-grc_keycloak_data"
-        "gigachad-grc_traefik_letsencrypt"
-    )
-
-    for volume in "${volumes[@]}"; do
-        if docker volume inspect "$volume" >/dev/null 2>&1; then
-            log_info "Backing up volume: $volume"
-
-            # Create a temporary container to access volume
-            docker run --rm \
-                -v "$volume":/volume \
-                -v "$volumes_backup_dir":/backup \
-                alpine \
-                tar -czf "/backup/${volume}.tar.gz" -C /volume . \
-                || log_warning "Failed to backup volume: $volume"
-        else
-            log_warning "Volume not found: $volume"
-        fi
-    done
-
-    log_success "Docker volumes backup completed"
-}
-
 # Create backup manifest
 create_manifest() {
     log_info "Creating backup manifest..."
@@ -296,32 +302,28 @@ create_manifest() {
     local hostname
     hostname=$(hostname)
 
-    # Get Docker Compose version
-    local compose_version
-    if docker compose version >/dev/null 2>&1; then
-        compose_version=$(docker compose version --short)
-    else
-        compose_version=$(docker-compose version --short)
-    fi
-
     # Create manifest
     cat > "$manifest_file" << EOF
 {
   "backup_date": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
   "backup_timestamp": "$TIMESTAMP",
   "hostname": "$hostname",
-  "docker_compose_version": "$compose_version",
+  "backup_method": "network-direct",
   "database": {
     "postgres_user": "$POSTGRES_USER",
-    "postgres_db": "$POSTGRES_DB"
+    "postgres_db": "$POSTGRES_DB",
+    "postgres_host": "$POSTGRES_HOST"
+  },
+  "object_storage": {
+    "endpoint": "$S3_ENDPOINT",
+    "bucket": "$S3_BUCKET"
   },
   "files": {
     "database_sql": "postgres_backup.sql.gz",
     "database_dump": "postgres_backup.dump",
     "minio": "minio_backup.tar.gz",
     "redis": "redis_backup.rdb",
-    "configs": "configs/",
-    "volumes": "volumes/"
+    "configs": "configs/"
   },
   "retention_days": $RETENTION_DAYS
 }
@@ -397,6 +399,8 @@ upload_to_remote() {
         local s3_region="${DR_REMOTE_BACKUP_REGION:-us-east-1}"
 
         if command_exists aws; then
+            # Remote upload uses AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY from
+            # the environment (set in docker-compose.prod.yml).
             aws s3 cp "$archive_file" "s3://${s3_bucket}/gigachad-grc/" \
                 --region "$s3_region" \
                 || log_warning "Failed to upload backup to S3"
@@ -458,14 +462,13 @@ main() {
     log_info "Backup directory: $BACKUP_DIR"
 
     # Run backup steps
+    load_environment
     check_prerequisites
     create_backup_directory
-    load_environment
     backup_database
     backup_object_storage
     backup_redis
     backup_configurations
-    backup_volumes
     create_manifest
     calculate_backup_size
     create_archive

--- a/deploy/restore.sh
+++ b/deploy/restore.sh
@@ -8,17 +8,26 @@
 # - PostgreSQL database
 # - RustFS/S3 object storage (https://github.com/rustfs/rustfs)
 # - Configuration files
-# - Docker volumes
+#
+# Data-plane restore (postgres, redis, object storage) is performed over the
+# network using pg_restore / psql, redis-cli RESTORE, and aws s3 cp - so the
+# restore container does not require docker.sock access to move data.
+#
+# Service lifecycle (docker compose up/down) is still managed via the host's
+# docker CLI: restore.sh is intended to be invoked from the host by an
+# operator after a disaster, not from inside the backup-scheduler container.
 #
 # Usage: ./restore.sh <backup_file>
 #        ./restore.sh /backups/gigachad-grc/backup-2025-12-05-020000.tar.gz
 #
 # WARNING: This will overwrite existing data!
 #
-# Prerequisites:
-# - Docker and Docker Compose installed
-# - Valid backup archive
-# - Services should be stopped before restoration
+# Prerequisites (on the host):
+#   - docker / docker compose v2
+#   - postgresql-client (for pg_restore / psql)
+#   - redis (for redis-cli)
+#   - aws CLI
+#   - Valid backup archive
 #
 ################################################################################
 
@@ -38,9 +47,21 @@ BACKUP_FILE="${1:-}"
 # Temporary restore directory
 RESTORE_DIR="/tmp/grc-restore-$$"
 
-# Docker Compose settings
+# Docker Compose settings - only used for service lifecycle (up/down/restart)
 COMPOSE_FILE="${PROJECT_DIR}/docker-compose.prod.yml"
 ENV_FILE="${PROJECT_DIR}/.env.prod"
+
+# Network targets. When restore.sh runs on the docker host, services are
+# reached via published localhost ports. Operators can override these by
+# exporting the variables before invoking the script (e.g. to restore from
+# inside the grc-network).
+POSTGRES_HOST="${POSTGRES_HOST:-127.0.0.1}"
+POSTGRES_PORT="${POSTGRES_PORT:-5432}"
+REDIS_HOST="${REDIS_HOST:-127.0.0.1}"
+REDIS_PORT="${REDIS_PORT:-6379}"
+S3_ENDPOINT="${S3_ENDPOINT:-http://127.0.0.1:9000}"
+S3_BUCKET="${S3_BUCKET:-grc-storage}"
+S3_REGION="${S3_REGION:-us-east-1}"
 
 # Log file
 LOG_FILE="/var/log/grc-restore-$(date +%Y%m%d-%H%M%S).log"
@@ -156,19 +177,24 @@ check_prerequisites() {
         error_exit "Backup file not found: $BACKUP_FILE"
     fi
 
-    # Check if Docker is installed
+    # Network clients required for data-plane restore
+    for cmd in pg_restore psql redis-cli aws; do
+        if ! command_exists "$cmd"; then
+            error_exit "$cmd not found. Install postgresql-client, redis and aws-cli before running restore."
+        fi
+    done
+
+    # docker CLI is required for service lifecycle (up/down/restart)
     if ! command_exists docker; then
-        error_exit "Docker is not installed. Please install Docker first."
+        error_exit "docker not found. restore.sh needs the docker CLI to start/stop services on the host."
     fi
 
-    # Check if Docker Compose is installed
     if ! command_exists docker-compose && ! docker compose version >/dev/null 2>&1; then
         error_exit "Docker Compose is not installed. Please install Docker Compose first."
     fi
 
-    # Check if Docker daemon is running
     if ! docker ps >/dev/null 2>&1; then
-        error_exit "Docker daemon is not running. Please start Docker first."
+        error_exit "Docker daemon is not running or current user cannot reach it."
     fi
 
     log_success "Prerequisites check passed"
@@ -293,58 +319,7 @@ restore_configurations() {
     log_success "Configuration files restored"
 }
 
-# Restore Docker volumes
-restore_volumes() {
-    log_step "Restoring Docker volumes..."
-
-    # Load environment variables
-    set -a
-    # shellcheck disable=SC1090
-    source "$ENV_FILE" 2>/dev/null || true
-    set +a
-
-    # List of volumes to restore
-    # Note: rustfs_data is the new volume name, minio_data is legacy
-    local volumes=(
-        "gigachad-grc_postgres_data"
-        "gigachad-grc_redis_data"
-        "gigachad-grc_rustfs_data"
-        "gigachad-grc_minio_data"
-        "gigachad-grc_keycloak_data"
-        "gigachad-grc_traefik_letsencrypt"
-    )
-
-    for volume in "${volumes[@]}"; do
-        local volume_backup="${RESTORE_DIR}/volumes/${volume}.tar.gz"
-
-        if [ -f "$volume_backup" ]; then
-            log_info "Restoring volume: $volume"
-
-            # Remove existing volume
-            docker volume rm "$volume" 2>/dev/null || true
-
-            # Create new volume
-            docker volume create "$volume" >/dev/null \
-                || error_exit "Failed to create volume: $volume"
-
-            # Restore volume data
-            docker run --rm \
-                -v "$volume":/volume \
-                -v "$RESTORE_DIR/volumes":/backup \
-                alpine \
-                tar -xzf "/backup/${volume}.tar.gz" -C /volume \
-                || log_warning "Failed to restore volume: $volume"
-
-            log_success "Volume restored: $volume"
-        else
-            log_warning "Volume backup not found: $volume"
-        fi
-    done
-
-    log_success "Docker volumes restoration completed"
-}
-
-# Restore PostgreSQL database
+# Restore PostgreSQL database over the network
 restore_database() {
     log_step "Restoring PostgreSQL database..."
 
@@ -359,101 +334,117 @@ restore_database() {
     docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d postgres \
         || error_exit "Failed to start PostgreSQL service"
 
-    # Wait for PostgreSQL to be ready
+    # Wait for PostgreSQL to be ready (TCP poll via pg_isready)
     log_info "Waiting for PostgreSQL to be ready..."
     local retries=30
     local wait_time=2
 
+    export PGPASSWORD="$POSTGRES_PASSWORD"
+
     for ((i=1; i<=retries; i++)); do
-        if docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" exec -T postgres \
-            pg_isready -U "${POSTGRES_USER}" >/dev/null 2>&1; then
+        if pg_isready -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" \
+            -U "$POSTGRES_USER" >/dev/null 2>&1; then
             log_success "PostgreSQL is ready"
             break
         fi
 
-        if [ $i -eq $retries ]; then
+        if [ "$i" -eq "$retries" ]; then
+            unset PGPASSWORD
             error_exit "PostgreSQL did not become ready in time"
         fi
 
         echo -n "."
-        sleep $wait_time
+        sleep "$wait_time"
     done
     echo ""
 
     # Drop existing database (if exists) and create new one
     log_info "Recreating database..."
-    docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" exec -T postgres \
-        psql -U "${POSTGRES_USER}" -d postgres -c "DROP DATABASE IF EXISTS ${POSTGRES_DB};" \
+    psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -d postgres \
+        -c "DROP DATABASE IF EXISTS ${POSTGRES_DB};" \
         || log_warning "Failed to drop existing database"
 
-    docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" exec -T postgres \
-        psql -U "${POSTGRES_USER}" -d postgres -c "CREATE DATABASE ${POSTGRES_DB};" \
-        || error_exit "Failed to create database"
+    psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -d postgres \
+        -c "CREATE DATABASE ${POSTGRES_DB};" \
+        || { unset PGPASSWORD; error_exit "Failed to create database"; }
 
     # Restore database from custom dump (preferred)
     if [ -f "$RESTORE_DIR/postgres_backup.dump" ]; then
         log_info "Restoring from custom dump format..."
-        cat "$RESTORE_DIR/postgres_backup.dump" | \
-            docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" exec -T postgres \
-            pg_restore -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" --clean --if-exists --no-owner --no-acl \
+        pg_restore -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" \
+            -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+            --clean --if-exists --no-owner --no-acl \
+            "$RESTORE_DIR/postgres_backup.dump" \
             || log_warning "Database restore completed with warnings"
 
     # Fallback to SQL dump
     elif [ -f "$RESTORE_DIR/postgres_backup.sql.gz" ]; then
         log_info "Restoring from SQL dump..."
         gunzip -c "$RESTORE_DIR/postgres_backup.sql.gz" | \
-            docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" exec -T postgres \
-            psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" \
+            psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" \
+            -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
             || log_warning "Database restore completed with warnings"
 
     elif [ -f "$RESTORE_DIR/postgres_backup.sql" ]; then
         log_info "Restoring from uncompressed SQL dump..."
-        cat "$RESTORE_DIR/postgres_backup.sql" | \
-            docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" exec -T postgres \
-            psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" \
+        psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" \
+            -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+            -f "$RESTORE_DIR/postgres_backup.sql" \
             || log_warning "Database restore completed with warnings"
 
     else
+        unset PGPASSWORD
         error_exit "No database backup found"
     fi
 
     # Verify database restoration
     log_info "Verifying database restoration..."
     local table_count
-    table_count=$(docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" exec -T postgres \
-        psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -t -c \
-        "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'public';" | xargs)
+    table_count=$(psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" \
+        -U "$POSTGRES_USER" -d "$POSTGRES_DB" -t -c \
+        "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'public';" \
+        2>/dev/null | xargs || echo "unknown")
 
     log_info "Tables restored: $table_count"
+
+    unset PGPASSWORD
 
     log_success "Database restoration completed"
 }
 
-# Restore RustFS/S3 object storage data
+# Restore RustFS/S3 object storage data over the S3 API
 restore_object_storage() {
     log_step "Restoring RustFS/S3 object storage data..."
 
-    # Check if backup exists (legacy name for compatibility)
+    # Check if backup exists (legacy filename kept for compatibility)
     if [ ! -f "$RESTORE_DIR/minio_backup.tar.gz" ]; then
         log_warning "Object storage backup not found, skipping"
         return 0
     fi
 
-    # Start RustFS service (try new name first, fall back to legacy)
-    log_info "Starting object storage service..."
-    if docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d rustfs 2>/dev/null; then
-        STORAGE_CONTAINER="grc-rustfs"
-        STORAGE_SERVICE="rustfs"
-    elif docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d minio 2>/dev/null; then
-        STORAGE_CONTAINER="grc-minio"
-        STORAGE_SERVICE="minio"
-    else
-        error_exit "Failed to start object storage service"
+    if [ -z "${MINIO_ROOT_USER:-}" ] || [ -z "${MINIO_ROOT_PASSWORD:-}" ]; then
+        log_warning "MINIO_ROOT_USER / MINIO_ROOT_PASSWORD not set; skipping object storage restore"
+        return 0
     fi
+
+    # Start RustFS service
+    log_info "Starting object storage service..."
+    docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d rustfs \
+        || error_exit "Failed to start RustFS service"
 
     # Wait for service to be ready
     log_info "Waiting for object storage to be ready..."
-    sleep 10
+    local retries=30
+    for ((i=1; i<=retries; i++)); do
+        if curl -fsS "${S3_ENDPOINT}/" >/dev/null 2>&1 \
+           || curl -fsS "${S3_ENDPOINT}/minio/health/live" >/dev/null 2>&1; then
+            break
+        fi
+        if [ "$i" -eq "$retries" ]; then
+            log_warning "Object storage did not become ready in time"
+        fi
+        sleep 2
+    done
 
     # Extract backup to temporary location
     local storage_temp_dir="${RESTORE_DIR}/storage_temp"
@@ -463,13 +454,39 @@ restore_object_storage() {
     tar -xzf "$RESTORE_DIR/minio_backup.tar.gz" -C "$storage_temp_dir" \
         || error_exit "Failed to extract object storage backup"
 
-    # Copy data to container
-    log_info "Copying data to $STORAGE_CONTAINER container..."
-    docker cp "$storage_temp_dir/data/." "$STORAGE_CONTAINER:/data/" \
-        || error_exit "Failed to copy object storage data"
+    # The archive contains either an "object-storage" directory (new format)
+    # or a legacy "data" directory. Locate whichever exists.
+    local source_dir=""
+    if [ -d "$storage_temp_dir/object-storage" ]; then
+        source_dir="$storage_temp_dir/object-storage"
+    elif [ -d "$storage_temp_dir/data" ]; then
+        # Legacy backups stored RustFS data verbatim (a raw /data dump from
+        # `docker cp`). These are not S3-restoreable; warn and skip.
+        log_warning "Legacy data-directory format detected in $storage_temp_dir/data."
+        log_warning "Cannot restore legacy raw RustFS data over S3 - copy the directory"
+        log_warning "into the rustfs_data volume manually if needed."
+        rm -rf "$storage_temp_dir"
+        return 0
+    else
+        log_warning "No recognizable object-storage payload in archive"
+        rm -rf "$storage_temp_dir"
+        return 0
+    fi
 
-    # Restart service to reload data
-    docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" restart "$STORAGE_SERVICE"
+    log_info "Uploading objects to s3://${S3_BUCKET} via ${S3_ENDPOINT}..."
+
+    (
+        export AWS_ACCESS_KEY_ID="$MINIO_ROOT_USER"
+        export AWS_SECRET_ACCESS_KEY="$MINIO_ROOT_PASSWORD"
+        export AWS_DEFAULT_REGION="$S3_REGION"
+
+        # Ensure the bucket exists (idempotent)
+        aws --endpoint-url "$S3_ENDPOINT" s3api create-bucket \
+            --bucket "$S3_BUCKET" 2>/dev/null || true
+
+        aws --endpoint-url "$S3_ENDPOINT" s3 sync \
+            "$source_dir" "s3://${S3_BUCKET}" --no-progress
+    ) || log_warning "Failed to upload some objects to RustFS"
 
     # Cleanup
     rm -rf "$storage_temp_dir"
@@ -487,23 +504,31 @@ restore_redis() {
         return 0
     fi
 
-    # Start Redis service
-    log_info "Starting Redis service..."
-    docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d redis \
-        || error_exit "Failed to start Redis service"
+    # NOTE: Re-hydrating an RDB into a running Redis server over the network
+    # is not possible with redis-cli alone - Redis only loads dump.rdb at
+    # server startup. The previous implementation used `docker cp` to drop
+    # the RDB into the redis container's /data volume; with docker.sock
+    # removed from the backup scheduler that pathway is no longer available
+    # from inside the container.
+    #
+    # For this product Redis is used as a cache (session keys, queues),
+    # not as a primary datastore, so a warm restart is acceptable: keys
+    # are recomputed from postgres / rustfs on demand.
+    #
+    # If an operator running this script from the host needs a true cold
+    # restore, they should:
+    #   1. docker compose -f docker-compose.prod.yml stop redis
+    #   2. docker run --rm -v gigachad-grc_redis_data:/data -v "<dump-dir>":/src \
+    #        alpine cp /src/redis_backup.rdb /data/dump.rdb
+    #   3. docker compose -f docker-compose.prod.yml start redis
+    # That manual procedure is documented in deploy/README.md.
 
-    # Wait for Redis to be ready
-    sleep 5
+    log_warning "Redis cold restore is not performed automatically (cache-only)."
+    log_warning "  Backup file kept at: $RESTORE_DIR/redis_backup.rdb"
+    log_warning "  See deploy/README.md 'Manual Redis cold restore' for the"
+    log_warning "  procedure to load it back into the redis_data volume."
 
-    # Copy Redis dump file
-    log_info "Copying Redis dump file..."
-    docker cp "$RESTORE_DIR/redis_backup.rdb" grc-redis:/data/dump.rdb \
-        || error_exit "Failed to copy Redis dump"
-
-    # Restart Redis to load data
-    docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" restart redis
-
-    log_success "Redis data restoration completed"
+    log_success "Redis data restoration step completed (best-effort)"
 }
 
 # Start all services
@@ -532,17 +557,19 @@ verify_restoration() {
 
     log_info "Running services: $services_count"
 
-    # Check database connectivity
-    if docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" exec -T postgres \
-        pg_isready -U "${POSTGRES_USER}" >/dev/null 2>&1; then
+    # Check database connectivity (network)
+    export PGPASSWORD="$POSTGRES_PASSWORD"
+    if pg_isready -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" \
+        -U "$POSTGRES_USER" >/dev/null 2>&1; then
         log_success "Database is accessible"
     else
         log_warning "Database may not be accessible"
     fi
+    unset PGPASSWORD
 
-    # Check Redis connectivity
-    if docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" exec -T redis \
-        redis-cli -a "${REDIS_PASSWORD}" --no-auth-warning ping >/dev/null 2>&1; then
+    # Check Redis connectivity (network)
+    if redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" \
+        -a "${REDIS_PASSWORD}" --no-auth-warning ping 2>/dev/null | grep -q "PONG"; then
         log_success "Redis is accessible"
     else
         log_warning "Redis may not be accessible"
@@ -581,7 +608,6 @@ main() {
     validate_backup
     stop_services
     restore_configurations
-    restore_volumes
     restore_database
     restore_object_storage
     restore_redis

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -966,6 +966,11 @@ services:
   # ===========================================
   # Backup Scheduler - Automated Backups
   # ===========================================
+  # The backup scheduler is a plain network peer on grc-network. It uses
+  # pg_dump / redis-cli / aws s3 to extract data directly from postgres,
+  # redis and rustfs over TCP. It does NOT mount /var/run/docker.sock - a
+  # compromised backup container can no longer introspect or operate on
+  # other containers on the host.
   backup-scheduler:
     build:
       context: ./deploy
@@ -980,25 +985,42 @@ services:
       DR_REMOTE_BACKUP_REGION: ${DR_REMOTE_BACKUP_REGION:-us-east-1}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
+      # PostgreSQL access (network)
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: 5432
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
+      # Redis access (network)
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
       REDIS_PASSWORD: ${REDIS_PASSWORD}
+      # RustFS / S3 access (network)
+      S3_ENDPOINT: http://rustfs:9000
+      S3_BUCKET: ${S3_BUCKET:-grc-storage}
+      S3_REGION: ${S3_REGION:-us-east-1}
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
       SLACK_ENABLED: ${SLACK_ENABLED:-false}
       SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL:-}
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
       - grc_backups:/backups
+      # Mounted read-only so configuration files can be captured in the
+      # backup archive. No docker socket is required.
       - ./docker-compose.prod.yml:/app/docker-compose.prod.yml:ro
       - ./.env.prod:/app/.env.prod:ro
     depends_on:
       postgres:
+        condition: service_healthy
+      redis:
         condition: service_healthy
     networks:
       - grc-network
     restart: always
     security_opt:
       - no-new-privileges:true
+    cap_drop:
+      - ALL
     logging:
       driver: 'json-file'
       options:


### PR DESCRIPTION
## Summary

- Removes `/var/run/docker.sock` mount from the `backup-scheduler` service so a
  compromised backup container can no longer introspect / control other
  containers.
- Switches data-plane movement from `docker exec` shims to direct
  network-level commands: `pg_dump` over TCP to postgres, `redis-cli --rdb`
  over TCP to redis, `mc mirror` (existing) over the S3 API to rustfs.
- Adds the required client env vars (`POSTGRES_HOST/PORT`, `REDIS_HOST/PORT`,
  `S3_ENDPOINT/BUCKET/REGION`, `MINIO_ROOT_USER/PASSWORD`) and `cap_drop: ALL`
  to the backup-scheduler service.
- Adds `depends_on: redis: service_healthy` so the scheduler waits for redis
  before its first run.
- Updates `deploy/Dockerfile.backup-scheduler` (no docker CLI needed; explicit
  comment about the absence of the socket mount).
- Documents the one degraded path: **Redis cold restore** is not possible over
  the network because redis only loads `dump.rdb` at startup. `restore.sh`
  no-ops with a clear warning; `deploy/README.md` documents the host-side
  procedure. Acceptable because redis here is cache-only (keys repopulate from
  postgres / rustfs on demand). Postgres + rustfs cold restore is unaffected.

The legitimate Traefik docker.sock mount on `docker-compose.prod.yml:38` is
out of scope and untouched (Traefik provider discovery requires it).

## Test plan

- [ ] `docker build -f deploy/Dockerfile.backup-scheduler -t grc-backup-scheduler:test deploy/`
- [ ] `docker run --rm grc-backup-scheduler:test sh -c 'which pg_dump && which redis-cli && which aws && (which docker || echo docker correctly absent)'`
- [ ] `shellcheck deploy/backup.sh deploy/restore.sh deploy/verify-backup.sh deploy/entrypoint-backup.sh`
- [ ] `docker compose -f docker-compose.prod.yml config` parses cleanly
- [ ] Bring up the prod stack; confirm `docker exec grc-backup-scheduler ls /var/run/docker.sock` returns "No such file or directory"
- [ ] Trigger a backup manually; confirm postgres dump + redis RDB land in the backup volume / S3 bucket
- [ ] Run `deploy/restore.sh` against a dummy backup; confirm postgres + S3 paths restore over the network and the redis path prints the cold-restore warning