### PR TITLE
docs: consolidate updates for the May 2026 hardening train (#305-#310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,166 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Security
 
+#### Platform Hardening Follow-Ups — May 2026
+
+Six-PR follow-up train (#305–#310) addressing pattern-sweep extensions,
+carry-over items from earlier audits, multi-tenant + RBAC test coverage,
+backend test infrastructure, accessibility/visual regression coverage,
+and removal of the backup-scheduler's docker socket dependency.
+
+##### Connector SSRF Coverage (#305)
+
+- Migrated 7 remaining integration connectors from raw `axios` to
+  `safeFetch` (`cloud-connectors`, `itam-connectors`, `hr-connectors`,
+  `productivity-connectors`, `devops-connectors`, `finance-connectors`,
+  `additional-connectors`). Operator-supplied `baseUrl`/`tokenUrl` are
+  now validated against the private-IP / metadata-endpoint blocklist
+  before any outbound call.
+- `SSRFProtectionError` is caught per-endpoint and surfaced as a
+  structured failure rather than an unhandled exception.
+
+##### File Upload Hardening (#305)
+
+- Added MIME allowlist + size cap to 5 additional upload endpoints
+  matching the contracts.controller pattern from PR #301:
+  evidence (50 MB; pdf/png/jpeg/csv/xlsx/docx/txt/json),
+  BCDR plans (25 MB; pdf/docx/txt),
+  training materials (25 MB; mp4/pdf/jpg/png + SCORM),
+  framework imports (25 MB; csv/xlsx),
+  policies (25 MB; pdf/docx/md/txt).
+- Each endpoint exports `*_MIME_ALLOWLIST` and `*_MAX_BYTES` constants
+  alongside a named `fileFilter`, so the policy is reviewable in source.
+
+##### Tenant Isolation Hardening (#308)
+
+- Questionnaires and Knowledge Base controllers no longer accept
+  `organizationId` from the request body. Both controllers now
+  spread `user.organizationId` over the DTO before passing to the
+  service. Previously any authenticated user could POST a record
+  under any tenant.
+- Frameworks, Policies, and Integrations controllers had no
+  `RolesGuard` wired — viewer/auditor roles could POST/PUT/DELETE
+  freely. Fixed by adding `@UseGuards(DevAuthGuard, RolesGuard)` at
+  class level + `@Roles(...)` on every mutation route.
+- Frameworks and Policies services now register
+  `GlobalExceptionFilter` in `main.ts`, so `ForbiddenException` from
+  `RolesGuard` returns 403 instead of a generic 500.
+
+##### Backup Scheduler Privilege Reduction (#310)
+
+- Removed `/var/run/docker.sock` mount from the `backup-scheduler`
+  service in `docker-compose.prod.yml`. A compromised backup container
+  can no longer introspect or control other containers.
+- Switched data-plane movement to direct network commands: `pg_dump`
+  over TCP to postgres, `redis-cli --rdb` over TCP to redis,
+  `mc mirror` (existing) over the S3 API to rustfs.
+- Added `cap_drop: ALL` to the backup-scheduler service.
+- Redis **cold restore** is now a documented manual procedure
+  (`deploy/README.md`) because redis only loads `dump.rdb` at server
+  startup; this is acceptable here because redis is cache-only.
+
+##### Base Image Digest Refresh (#307)
+
+- Re-pinned `node:20-alpine` and `nginx:alpine` digests across all 7
+  Dockerfiles. Trivy HIGH/CRITICAL count on the refreshed images
+  dropped accordingly.
+
+##### Trust Center URL Cleanup (#307)
+
+- Removed `organizationId` from public trust-center share URLs in
+  `TrustCenterSettings`. The backend already resolves the org from
+  the authenticated context — the query parameter was cosmetic
+  information disclosure, not exploitable.
+
+### Added
+
+#### Multi-Tenant + RBAC E2E Coverage (#308)
+
+- New Playwright specs that gate PR merges:
+  - `frontend/e2e/tenant-isolation.spec.ts` (44 tests, 10 resource
+    types). For each resource: cross-tenant GET/PUT/DELETE returns
+    404 (no existence disclosure), cross-tenant POST is rejected or
+    silently scoped to the caller's org.
+  - `frontend/e2e/rbac.spec.ts` (50 tests). Role × action matrix
+    for admin / compliance_manager / auditor / viewer against
+    controls, evidence, frameworks, policies, integrations.
+- Test infrastructure additions:
+  - `services/shared/src/seed/seed-constants.ts` exports stable
+    UUIDs for Org A, Org B, and the 5 seeded users.
+  - `services/controls/src/seed/seed.service.ts` seeds Org B with
+    1 admin + 5 controls + 3 risks + 2 vendors so cross-tenant
+    tests have something to target. Idempotent.
+  - `DevAuthGuard` honors an `x-dev-user-id` header in dev/test
+    environments only, looking the value up in an in-memory fixture
+    table to authenticate as any of the 5 seeded users without a
+    real Keycloak round-trip.
+  - `frontend/e2e/auth.setup.ts` produces 6 storage states
+    (`user.json` legacy + adminA/complianceA/auditorA/viewerA/adminB);
+    `playwright.config.ts` defines 5 role/tenant-specific projects.
+- New required CI job `e2e-tenant-rbac` brings up the dev stack,
+  seeds, and runs both specs. Blocks PR merge on failure.
+
+#### Accessibility + Visual Regression E2E (#309, report-only)
+
+- `frontend/e2e/a11y.spec.ts` runs `@axe-core/playwright` against
+  every primary route and reports WCAG violations.
+- `frontend/e2e/visual.spec.ts` snapshots 8 high-signal pages
+  (dashboard, controls list, control detail, frameworks list,
+  policies list, vendors list, audits list, settings, trust-center).
+  Baselines committed under `frontend/e2e/__snapshots__/`.
+- New CI job `e2e-quality-checks` runs both specs.
+  **Report-only:** `continue-on-error: true` and omitted from the
+  `status` rollup. Will flip to blocking once baselines stabilize.
+
+#### Backend Jest Coverage (#306)
+
+- Wired Jest in `audit`, `policies`, `tprm`, and `trust` services
+  (the latter three previously had no `npm test` script). `controls`
+  and `frameworks` already had test setup.
+- Two pre-existing dormant specs in `audit`
+  (`audits.service.spec.ts`, `findings.service.spec.ts`) are now
+  actually executed by CI.
+- Starter Prisma-mocked specs added to `policies`, `tprm`, `trust`
+  covering one happy-path and one tenant-isolation case per service.
+
+### Changed
+
+#### Empty Catch Handler (#305)
+
+- `frontend/src/pages/Integrations.tsx` — replaced
+  `.catch(() => null)` on `getTypes()` with a `console.warn` that
+  preserves the error before returning null. Last empty `.catch`
+  handler in the frontend.
+
+#### Organization ID Helper (#305)
+
+- Consolidated 3 `localStorage.getItem('organizationId')` fallbacks
+  in `frontend/src/lib/{api.ts,setupFetchAuth.ts,api/client.ts}` to
+  a single `getCurrentOrgId()` helper in `secureStorage.ts`. The
+  fallback now returns `null` when both stores are empty so the
+  calling layer fails loud rather than sending a request without an
+  org header.
+
+### Documentation
+
+- **CHANGELOG.md** — this entry.
+- **frontend/e2e/README.md** — documented the multi-user auth
+  fixture system (6 storage states, 5 role/tenant projects), the
+  `x-dev-user-id` header override, the a11y / visual specs, and how
+  to refresh visual baselines.
+- **docs/SECURITY_MODEL.md** — added connector SSRF coverage to the
+  SSRF section, file-upload allowlist pattern to the File Upload
+  Security section, tenant-isolation e2e gate to the Tenant
+  Isolation section, and a new Backup Scheduler subsection under
+  Infrastructure Hardening.
+- **docs/PERMISSIONS_MATRIX.md** — added a note that the role matrix
+  is now enforced by `frontend/e2e/rbac.spec.ts`.
+- **docs/DEVELOPMENT.md** and **CONTRIBUTING.md** — backend testing
+  sections updated; `npm test` now works in all 6 services.
+- **deploy/README.md** and **deploy/QUICKSTART.md** — updated for
+  the no-docker.sock backup procedure and the Redis cold-restore
+  manual workflow.
+
 #### Security Audit Fixes - February 2026
 
 Comprehensive security hardening based on internal security review and external penetration testing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -321,20 +321,33 @@ const controls = await this.prisma.control.findMany({
 
 ### Running Tests
 
+All six backend services (`controls`, `frameworks`, `audit`,
+`policies`, `tprm`, `trust`) have Jest wired with the same scripts.
+The CI `backend` matrix runs `npm test --if-present` in every service.
+
 ```bash
 # Unit tests for a service
-cd services/controls
-npm run test
+cd services/<service>
+npm run test            # one-shot
+npm run test:watch      # watch mode
+npm run test:ci         # CI flags (--ci --runInBand)
+npm run test:cov        # with coverage
 
-# Watch mode
-npm run test:watch
+# Run every service from the repo root
+for svc in controls frameworks audit policies tprm trust; do
+  (cd services/$svc && npm test) || break
+done
 
-# Coverage report
-npm run test:cov
-
-# E2E tests
-npm run test:e2e
+# E2E tests (Playwright, frontend only)
+cd frontend && npm run test:e2e
 ```
+
+Two Playwright suites are required CI gates:
+[`tenant-isolation.spec.ts`](frontend/e2e/tenant-isolation.spec.ts)
+and [`rbac.spec.ts`](frontend/e2e/rbac.spec.ts). If you touch a
+controller, service method, or guard, add or update a case in both.
+See [frontend/e2e/README.md](frontend/e2e/README.md) for the
+multi-user fixture layout and `x-dev-user-id` header override.
 
 ### Writing Tests
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -537,18 +537,26 @@ npm test -- --coverage
 
 ### Backend Testing
 
+All six services (`controls`, `frameworks`, `audit`, `policies`,
+`tprm`, `trust`) now have Jest wired with the same scripts. Run from
+the workspace root or per-service:
+
 ```bash
-cd services/controls
+# Per service
+cd services/<service>
+npm test                # one-shot
+npm run test:watch      # watch mode
+npm run test:ci         # CI flags (--ci --runInBand)
+npm run test:cov        # with coverage (controls only by default)
 
-# Unit tests
-npm test
-
-# E2E tests
-npm run test:e2e
-
-# Coverage
-npm run test:cov
+# All services from the repo root
+for svc in controls frameworks audit policies tprm trust; do
+  (cd services/$svc && npm test) || break
+done
 ```
+
+The CI `backend` matrix runs `npm test --if-present` in every service —
+adding a new service or a new spec is picked up automatically.
 
 ### Test Patterns
 

--- a/docs/PERMISSIONS_MATRIX.md
+++ b/docs/PERMISSIONS_MATRIX.md
@@ -7,6 +7,16 @@ and is intended as a human-readable reference for administrators.
 > **Note:** This matrix shows default permissions. Actual effective permissions
 > may differ if you customize permission groups or add user-specific overrides.
 
+> **Enforced by CI (v1.3.0+).** The role × action matrix below is
+> machine-verified on every PR by
+> [`frontend/e2e/rbac.spec.ts`](../frontend/e2e/rbac.spec.ts), which
+> drives the backend's `RolesGuard` / `PermissionGuard` decorators as
+> each of the four seeded fixture users. Breaking the matrix —
+> for example, removing a `@Roles(...)` decorator or shipping a new
+> mutation route without one — fails the `e2e-tenant-rbac` CI job
+> and blocks merge. Cross-tenant isolation is verified in parallel by
+> [`tenant-isolation.spec.ts`](../frontend/e2e/tenant-isolation.spec.ts).
+
 ---
 
 ### Resources and Actions

--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -197,6 +197,32 @@ Security improvements to the deployment infrastructure:
 - **Referrer-Policy**: strict-origin-when-cross-origin
 - **Permissions-Policy**: Comprehensive policy restricting browser APIs
 
+#### Backup Scheduler Privilege Reduction (v1.3.0+)
+
+The `backup-scheduler` service no longer mounts `/var/run/docker.sock`.
+A compromised backup container previously had read-only access to the
+host docker socket, which is enough to enumerate every other container,
+read their inspect metadata (env vars, secret bind mounts, network
+topology), and — depending on the runtime — escape to the host.
+
+Data-plane movement is now over the network only:
+
+- **Postgres**: `pg_dump` against the postgres service hostname.
+- **Redis**: `redis-cli --rdb` over TCP.
+- **RustFS / S3**: `mc mirror` over the S3 API (unchanged).
+
+The container also runs with `cap_drop: ALL`. The only remaining
+docker.sock mount in `docker-compose.prod.yml` is on Traefik, where it
+is required for Docker-provider service discovery.
+
+Trade-off: **Redis cold restore** is not possible over the network
+because redis only loads `dump.rdb` at server startup. `restore.sh`
+no-ops with a clear warning for that path; the manual host-side
+procedure is documented in [`deploy/README.md`](../deploy/README.md).
+This is acceptable because Redis is cache-only in this product — keys
+repopulate from postgres / rustfs on demand. Postgres and S3 restore
+are unaffected.
+
 #### TLS Configuration
 
 - Traefik configured for TLS 1.2+ only
@@ -541,6 +567,36 @@ request.headers['x-user-id'] = decodedToken.sub;
 - No API endpoint accepts `organizationId` as a parameter
 - Organization context is derived exclusively from authenticated token
 - Database constraints enforce foreign key relationships
+- Controllers that previously accepted `organizationId` in the request
+  body (Questionnaires, Knowledge Base) now spread `user.organizationId`
+  over the DTO before persistence, so a body-supplied value is silently
+  overridden by the authenticated context.
+
+### E2E Enforcement (v1.3.0+)
+
+Multi-tenant isolation is enforced by a required CI gate, not just by
+code review. [`frontend/e2e/tenant-isolation.spec.ts`](../frontend/e2e/tenant-isolation.spec.ts)
+seeds two organizations (Org A + Org B with stable UUIDs in
+[`services/shared/src/seed/seed-constants.ts`](../services/shared/src/seed/seed-constants.ts))
+and, for each of 10 resource types (controls, risks, vendors, contracts,
+evidence, audits, frameworks, policies, questionnaires, knowledge-base
+entries), asserts:
+
+- `GET /api/<resource>` as adminA returns Org A IDs only.
+- `GET /api/<resource>/<orgB-id>` as adminA returns **404** (we
+  intentionally do not return 403, to avoid leaking existence).
+- `PUT`/`DELETE` on Org B records returns 404.
+- `POST` with a body-supplied `organizationId: <orgB>` is rejected
+  or silently scoped to the caller's org.
+
+Breaking any of these — for example, omitting `where: { organizationId }`
+in a service method — fails the `e2e-tenant-rbac` job and blocks merge.
+
+Role-based access control is similarly enforced by
+[`frontend/e2e/rbac.spec.ts`](../frontend/e2e/rbac.spec.ts), which
+exercises the role × action matrix from
+[docs/PERMISSIONS_MATRIX.md](PERMISSIONS_MATRIX.md) against the
+backend's `RolesGuard` / `PermissionGuard` decorators.
 
 ---
 
@@ -671,6 +727,27 @@ The `FileValidatorService` provides comprehensive validation:
 - **Size limits enforced**: Per-category limits (e.g., 50MB for evidence)
 - **Double extension detection**: Flags suspicious patterns like `.pdf.exe`
 
+### Upload Endpoint Allowlist Pattern (v1.3.0+)
+
+Every controller using `FileInterceptor` must declare an explicit MIME
+allowlist and size cap at the route definition. The pattern mirrors
+[`services/tprm/src/contracts/contracts.controller.ts`](../services/tprm/src/contracts/contracts.controller.ts)
+and is applied across all upload endpoints:
+
+| Controller | MIME allowlist | Size cap |
+|------------|----------------|----------|
+| `tprm/contracts` | pdf, docx | 25 MB |
+| `controls/evidence` | pdf, png, jpeg, csv, xlsx, docx, txt, json | 50 MB |
+| `controls/bcdr-plans` | pdf, docx, txt | 25 MB |
+| `controls/training` | mp4, pdf, jpg, png, SCORM zip | 25 MB |
+| `frameworks` (control imports) | csv, xlsx | 25 MB |
+| `policies` | pdf, docx, md, txt | 25 MB |
+
+Each controller exports `*_MIME_ALLOWLIST` and `*_MAX_BYTES` constants
+alongside a named `fileFilter` function, so the policy is reviewable
+in source and unit-testable. Disallowed MIMEs return 400 from the
+`FileInterceptor` layer before the file ever reaches the service.
+
 ---
 
 ## SSRF Protection (v1.2.0+)
@@ -682,6 +759,14 @@ Server-Side Request Forgery (SSRF) protection is applied to all outbound HTTP re
 - **Webhooks**: User-configured webhook URLs
 - **Custom Integrations**: User-provided API endpoints
 - **Collectors**: Evidence collection endpoints
+- **Connector Library** (May 2026): all 8 connector families in
+  `services/controls/src/integrations/connectors/` route operator-supplied
+  `baseUrl` / `tokenUrl` values through `safeFetch`. Affected families:
+  generic, cloud, ITAM, HR, productivity, devops, finance, and additional
+  (Mimecast, etc.). `SSRFProtectionError` is caught per-endpoint and
+  surfaced as a structured connector failure rather than an unhandled
+  exception, so a single malicious config can't crash a sync run for
+  unrelated connectors.
 
 ### Validation Rules
 

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -44,15 +44,119 @@ git-ignored.
 
 1. Calls the `controls` service `/api/seed/load-demo` endpoint to make
    sure the database has at least the seed fixtures (idempotent — skips
-   if data is already present).
-2. Pre-seeds `localStorage` with the seeded "John Doe" admin user
-   (`grc-dev-auth`, `gigachad-grc-onboarding-completed`). `AuthContext`
+   if data is already present). The seed also populates Org B and its
+   admin user; see [services/shared/src/seed/seed-constants.ts](../../services/shared/src/seed/seed-constants.ts).
+2. Pre-seeds `localStorage` for each fixture user and persists the
+   resulting browser state to one file per identity. `AuthContext`
    reads `grc-dev-auth` on startup and restores the session.
-3. Persists the resulting browser state to `playwright/.auth/user.json`,
-   which every test loads via `storageState`.
 
 Result: each test starts already authenticated, with the onboarding
 tour dismissed, and with data in the DB. No Keycloak round-trip.
+
+### Multi-user fixtures
+
+`auth.setup.ts` produces **six** storage-state files; tests select one
+via the Playwright `storageState` option (configured per project in
+`playwright.config.ts`):
+
+| File                              | User                  | Role                 | Org   |
+|----------------------------------|-----------------------|----------------------|-------|
+| `playwright/.auth/user.json`     | John Doe (legacy)     | admin                | A     |
+| `playwright/.auth/adminA.json`   | Admin A               | admin                | A     |
+| `playwright/.auth/complianceA.json` | Compliance Manager A | compliance_manager  | A     |
+| `playwright/.auth/auditorA.json` | Auditor A             | auditor              | A     |
+| `playwright/.auth/viewerA.json`  | Viewer A              | viewer               | A     |
+| `playwright/.auth/adminB.json`   | Admin B               | admin                | B (Acme) |
+
+`user.json` is preserved so the existing single-user suite (~253 specs)
+continues to run unchanged.
+
+`tenant-isolation.spec.ts` runs once per role/tenant project against the
+matching `storageState`. `rbac.spec.ts` is project-agnostic — it builds
+its own `request` contexts per role using the `x-dev-user-id` header
+override (see below) and skips the per-project re-run via a
+`test.skip(project !== 'chromium')` gate.
+
+### Switching identity per request (`x-dev-user-id`)
+
+`DevAuthGuard` honors an `x-dev-user-id` header **only in dev/test
+environments**. The value is looked up in a hardcoded fixture table
+([services/shared/src/auth/dev-auth.guard.ts](../../services/shared/src/auth/dev-auth.guard.ts))
+mapping seeded UUIDs to their role + organization. This lets a single
+spec exercise multiple identities without juggling storage states.
+Admins receive the full dev permission set; non-admin roles receive an
+empty permissions list so `PermissionGuard` enforces the role matrix.
+
+Sample usage:
+
+```ts
+const adminBContext = await request.newContext({
+  extraHTTPHeaders: { 'x-dev-user-id': SEED_USER_B_ADMIN_ID },
+});
+const res = await adminBContext.get(`/api/controls/${orgAControlId}`);
+expect(res.status()).toBe(404); // no existence disclosure
+```
+
+The frontend never sets this header; it originates only from test
+fixtures, and the guard refuses to run in production.
+
+## Multi-tenant and RBAC specs
+
+Two specs are required CI gates (see `e2e-tenant-rbac` job in
+`.github/workflows/pr-validation.yml`):
+
+- [`tenant-isolation.spec.ts`](tenant-isolation.spec.ts) — 44 tests
+  across 10 resource types. As `adminA`, attempts `GET`/`PUT`/`DELETE`
+  against Org B records → expects **404** (we intentionally do not
+  return 403 because that leaks existence). Cross-tenant `POST` with a
+  body-supplied `organizationId` is rejected or silently scoped to the
+  caller's org.
+- [`rbac.spec.ts`](rbac.spec.ts) — 50 tests covering the role × action
+  matrix against `controls`, `evidence`, `frameworks`, `policies`,
+  `integrations`. Mirrors the matrix in `frontend/src/contexts/AuthContext.tsx`
+  and [docs/PERMISSIONS_MATRIX.md](../../docs/PERMISSIONS_MATRIX.md).
+
+If you add a new resource type or a new mutation route, extend both
+specs to cover it.
+
+## Accessibility and visual regression (report-only)
+
+Two additional specs run in the `e2e-quality-checks` CI job. The job
+is marked `continue-on-error: true` and is **not** in the `status`
+rollup, so its failures don't block merge while baselines stabilize.
+
+- [`a11y.spec.ts`](a11y.spec.ts) uses
+  [`@axe-core/playwright`](https://playwright.dev/docs/accessibility-testing)
+  via the shared helper in [`_a11y.ts`](_a11y.ts). It walks each
+  primary route and reports WCAG A/AA violations. Tag tests with
+  `@a11y` if you want to select only this suite locally.
+- [`visual.spec.ts`](visual.spec.ts) snapshots ~8 high-signal pages
+  using `expect(page).toHaveScreenshot()`. Baselines live in
+  [`__snapshots__/visual.spec.ts/`](__snapshots__/) and are committed
+  to the repo. Tag tests with `@visual`.
+
+### Refreshing visual baselines
+
+When a deliberate UI change lands, regenerate the baselines:
+
+```bash
+cd frontend
+npx playwright test e2e/visual.spec.ts --update-snapshots
+git add e2e/__snapshots__/
+```
+
+Commit the new PNGs alongside the UI change so the visual diff stays
+green on the next CI run. Avoid running `--update-snapshots` blindly
+on flake — investigate the diff in the CI artifact first.
+
+### Selecting one suite locally
+
+```bash
+npx playwright test --grep @a11y      # accessibility only
+npx playwright test --grep @visual    # visual regression only
+npx playwright test e2e/tenant-isolation.spec.ts
+npx playwright test e2e/rbac.spec.ts
+```
 
 ## How to add a new spec
 


### PR DESCRIPTION
## Summary

The six follow-up PRs (#305–#310) each forced a small code change; this PR catches the docs up in one place rather than amending each PR-in-flight.

**Depends on #308 and #310.** The CHANGELOG, e2e README, and several SECURITY_MODEL passages describe behavior that's still on those branches. Merge this after both land.

## Files changed

| File | What |
|------|------|
| `CHANGELOG.md` | New "Platform Hardening Follow-Ups — May 2026" subsection at the top of `[Unreleased]`, covering #305–#310 |
| `frontend/e2e/README.md` | Multi-user fixture layout (6 storage states, 5 role/tenant projects), `x-dev-user-id` header override, the two required `e2e-tenant-rbac` specs, the two report-only `e2e-quality-checks` specs, and the visual-baseline refresh workflow |
| `docs/SECURITY_MODEL.md` | Connector SSRF coverage; per-endpoint MIME allowlist + size cap pattern; tenant-isolation body-org spread fix + e2e enforcement; new "Backup Scheduler Privilege Reduction" subsection under Infrastructure Hardening |
| `docs/PERMISSIONS_MATRIX.md` | One-paragraph note: matrix is now machine-verified by `rbac.spec.ts` |
| `docs/DEVELOPMENT.md` | Backend testing section now reflects all 6 services having `npm test` |
| `CONTRIBUTING.md` | Same backend testing update; pointer to the two required e2e gates |

## Notes

- All entries were written by re-reading the actual commits on each branch (305–310), not from memory.
- No code changes — pure docs.
- The contracts.controller MIME-allowlist precedent referenced in SECURITY_MODEL was the original PR #301 implementation, which PR #305 extended to 5 more endpoints.

## Test plan

- [ ] All Markdown renders (no broken table syntax)
- [ ] Relative links in `SECURITY_MODEL.md` resolve (`../frontend/...`, `../services/...`, `PERMISSIONS_MATRIX.md`)
- [ ] Relative links in `frontend/e2e/README.md` resolve (`../../services/...`, `../../docs/...`)
- [ ] `CHANGELOG.md` entries align with the actual commits on #305–#310