### PR TITLE
feat(design-system): dark mode support via class-based Tailwind variants

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,14 +81,17 @@ services:
           memory: 256M
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER:-grc} -d ${POSTGRES_DB:-gigachad_grc}']
+      # First boot runs every script under database/init/ (creates keycloak + infisical DBs,
+      # 26+ SQL files for soft-delete, BCDR, enums, indexes, etc.). On a slow / contended CI
+      # runner this can easily push past 30s. We've seen `docker compose up -d` exit non-zero
+      # with "dependency failed to start: grc-postgres is unhealthy" on PRs #320 and #321
+      # despite the previous 30s budget. Bumped headroom + retry total so the dependency wait
+      # has 60s of init grace + 80s of polling = ~140s total before compose gives up.
+      start_period: 60s
       interval: 10s
       timeout: 5s
-      retries: 5
-      # First boot runs every script under database/init/ (creates keycloak + infisical DBs,
-      # 26+ SQL files for soft-delete, BCDR, enums, indexes, etc.). On a slow CI runner this
-      # easily exceeds the default zero start_period and trips compose's dependency-wait
-      # before pg_isready can ever return 0. 30s leaves headroom for cold runners.
-      start_period: 30s
+      retries: 8
+      start_interval: 5s
 
   # ===========================================
   # Cache & Message Queue - Redis (Docker Hardened Image)

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -41,12 +41,16 @@ const designSystemRules = [
     message:
       'Do not hand-roll centered modal overlays with `grid place-items-center`. Use <Dialog open={...} onClose={...}> from @/components/ui.',
   },
-  // 4. Faint text colors on the light cream background
+  // 4. Faint text colors on the light cream background.
+  //    The negative-lookbehind for `:` skips dark-mode forms — in dark mode
+  //    the 300/400 shades are the BRIGHT text colors, intentionally used
+  //    (e.g., `dark:text-brand-300`). Hover/focus modifiers also bypass
+  //    because they target ephemeral states.
   {
     selector:
-      'JSXAttribute[name.name="className"] Literal[value=/\\btext-(green|yellow|red|blue|orange|purple|teal|cyan|indigo|emerald|sky|violet|amber|fuchsia|lime|rose|surface)-(300|400)\\b/]',
+      'JSXAttribute[name.name="className"] Literal[value=/(?<!:)\\btext-(green|yellow|red|blue|orange|purple|teal|cyan|indigo|emerald|sky|violet|amber|fuchsia|lime|rose|surface)-(300|400)\\b/]',
     message:
-      'Text-300/400 shades are unreadable on the cream background. Use 600-800 for text or `text-surface-500` for muted.',
+      'Text-300/400 shades are unreadable on the cream background. Use 600-800 for text or `text-surface-500` for muted. (Dark-mode forms `dark:text-*-300/400` are allowed.)',
   },
   // 5. `rounded-full` on what looks like a text pill (has px-* and bg-*-* together)
   {

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -62,12 +62,15 @@ const designSystemRules = [
     message:
       'Hand-rolled colored pill. Use <Badge variant="..."> or <CategoryChip value="..."> from @/components/ui.',
   },
-  // 7. Card chrome on dark surface
+  // 7. Card chrome via bg-surface-100/200 base bg. Use bg-white instead.
+  //    The negative-lookbehind for `:` and `-` skips modifier prefixes
+  //    (`hover:bg-surface-200`, `border-surface-200`) so the rule fires
+  //    only on the base background token.
   {
     selector:
-      'JSXAttribute[name.name="className"] Literal[value=/\\bbg-surface-(100|200)\\b.*\\brounded(-md|-lg|-xl)\\b.*\\bborder\\b/]',
+      'JSXAttribute[name.name="className"] Literal[value=/(?<![:\\-])\\bbg-surface-(100|200)\\b.*\\brounded(-md|-lg|-xl)\\b.*\\bborder\\b/]',
     message:
-      'Card chrome on dark surface. Use <Card> or `bg-white border border-surface-200 rounded-lg`.',
+      'Card chrome via `bg-surface-100/200` is a design-system anti-pattern. Use <Card> or `bg-white border border-surface-200 rounded-lg`.',
   },
   // 8. Raw <input> for text-style inputs — use <Input> from @/components/ui
   {

--- a/frontend/src/components/ActionItemsWidget.tsx
+++ b/frontend/src/components/ActionItemsWidget.tsx
@@ -115,12 +115,12 @@ export function ActionItemsWidget({
 
   if (isLoading) {
     return (
-      <div className="bg-surface-800 border border-surface-700 rounded-xl p-6">
+      <div className="bg-white border border-surface-200 rounded-xl p-6">
         <div className="animate-pulse space-y-4">
-          <div className="h-6 bg-surface-700 rounded w-1/3" />
+          <div className="h-6 bg-surface-200 rounded w-1/3" />
           <div className="space-y-3">
             {[1, 2, 3].map((i) => (
-              <div key={i} className="h-16 bg-surface-700 rounded" />
+              <div key={i} className="h-16 bg-surface-200 rounded" />
             ))}
           </div>
         </div>
@@ -129,11 +129,11 @@ export function ActionItemsWidget({
   }
 
   return (
-    <div className="bg-surface-800 border border-surface-700 rounded-xl">
+    <div className="bg-white border border-surface-200 rounded-xl">
       {/* Header */}
-      <div className="flex items-center justify-between p-4 border-b border-surface-700">
+      <div className="flex items-center justify-between p-4 border-b border-surface-200">
         <div>
-          <h3 className="text-lg font-semibold text-surface-100">Action Items</h3>
+          <h3 className="text-lg font-semibold text-surface-900">Action Items</h3>
           {pendingCount > 0 && (
             <p className="text-sm text-surface-600">
               {pendingCount} pending task{pendingCount !== 1 ? 's' : ''}
@@ -152,7 +152,7 @@ export function ActionItemsWidget({
       </div>
 
       {/* Tasks list */}
-      <div className="divide-y divide-surface-700">
+      <div className="divide-y divide-surface-200">
         {displayedTasks.length === 0 ? (
           <div className="p-8 text-center">
             <CheckCircleIcon className="h-12 w-12 text-green-500 mx-auto mb-3" />
@@ -166,7 +166,7 @@ export function ActionItemsWidget({
             const isDueSoon = task.dueDate && getDaysUntilDue(task.dueDate) <= 3 && !isOverdue;
 
             return (
-              <div key={task.id} className="p-4 hover:bg-surface-700/50 transition-colors">
+              <div key={task.id} className="p-4 hover:bg-surface-200/50 transition-colors">
                 <div className="flex items-start gap-3">
                   {/* Checkbox / Status */}
                   <button
@@ -195,7 +195,7 @@ export function ActionItemsWidget({
                           ${
                             task.status === 'completed'
                               ? 'text-surface-600 line-through'
-                              : 'text-surface-100 hover:text-blue-600'
+                              : 'text-surface-900 hover:text-blue-600'
                           }
                         `}
                       >
@@ -245,7 +245,7 @@ export function ActionItemsWidget({
 
       {/* Show more link if there are more tasks */}
       {tasks && tasks.length > limit && (
-        <div className="p-4 border-t border-surface-700">
+        <div className="p-4 border-t border-surface-200">
           <button
             onClick={() => navigate('/tasks')}
             className="text-sm text-blue-600 hover:text-blue-700 w-full text-center"

--- a/frontend/src/components/ActivityFeed.tsx
+++ b/frontend/src/components/ActivityFeed.tsx
@@ -143,19 +143,19 @@ export function ActivityFeed({
 
   if (isLoading) {
     return (
-      <div className={clsx('bg-surface-800 rounded-xl border border-surface-700', className)}>
+      <div className={clsx('bg-white rounded-xl border border-surface-200', className)}>
         {showHeader && (
-          <div className="px-4 py-3 border-b border-surface-700">
-            <div className="h-5 bg-surface-700 rounded w-32 animate-pulse" />
+          <div className="px-4 py-3 border-b border-surface-200">
+            <div className="h-5 bg-surface-200 rounded w-32 animate-pulse" />
           </div>
         )}
         <div className="p-4 space-y-4">
           {Array.from({ length: 5 }).map((_, i) => (
             <div key={i} className="flex items-start gap-3 animate-pulse">
-              <div className="w-8 h-8 rounded-lg bg-surface-700" />
+              <div className="w-8 h-8 rounded-lg bg-surface-200" />
               <div className="flex-1 space-y-2">
-                <div className="h-4 bg-surface-700 rounded w-3/4" />
-                <div className="h-3 bg-surface-700 rounded w-1/2" />
+                <div className="h-4 bg-surface-200 rounded w-3/4" />
+                <div className="h-3 bg-surface-200 rounded w-1/2" />
               </div>
             </div>
           ))}
@@ -165,16 +165,16 @@ export function ActivityFeed({
   }
 
   return (
-    <div className={clsx('bg-surface-800 rounded-xl border border-surface-700', className)}>
+    <div className={clsx('bg-white rounded-xl border border-surface-200', className)}>
       {showHeader && (
-        <div className="px-4 py-3 border-b border-surface-700 flex items-center justify-between">
+        <div className="px-4 py-3 border-b border-surface-200 flex items-center justify-between">
           <h3 className="font-medium text-white">Recent Activity</h3>
           <div className="flex items-center gap-2">
             {!entityType && (
               <SelectNative
                 value={filter}
                 onChange={(e) => setFilter(e.target.value)}
-                className="text-xs bg-surface-700 border-surface-600 rounded-md text-surface-700 py-1 px-2"
+                className="text-xs bg-surface-200 border-surface-300 rounded-md text-surface-700 py-1 px-2"
               >
                 <option value="all">All Types</option>
                 <option value="control">Controls</option>
@@ -187,7 +187,7 @@ export function ActivityFeed({
             <button
               onClick={() => refetch()}
               className={clsx(
-                'p-1.5 rounded-md hover:bg-surface-700 text-surface-600 hover:text-white transition-colors',
+                'p-1.5 rounded-md hover:bg-surface-200 text-surface-600 hover:text-white transition-colors',
                 isRefetching && 'animate-spin'
               )}
             >
@@ -205,7 +205,7 @@ export function ActivityFeed({
           </p>
         </div>
       ) : (
-        <div className={clsx('divide-y divide-surface-700', compact ? '' : 'p-2')}>
+        <div className={clsx('divide-y divide-surface-200', compact ? '' : 'p-2')}>
           {activities.map((activity) => {
             const ActionIcon = getActionIcon(activity.action);
             const EntityIcon = getEntityIcon(activity.entityType);
@@ -216,7 +216,7 @@ export function ActivityFeed({
               <div
                 key={activity.id}
                 className={clsx(
-                  'flex items-start gap-3 hover:bg-surface-700/50 transition-colors',
+                  'flex items-start gap-3 hover:bg-surface-200/50 transition-colors',
                   compact ? 'py-2 px-3' : 'p-3 rounded-lg'
                 )}
               >
@@ -267,7 +267,7 @@ export function ActivityFeed({
         </div>
       )}
       {activities.length > 0 && showHeader && (
-        <div className="px-4 py-3 border-t border-surface-700">
+        <div className="px-4 py-3 border-t border-surface-200">
           <Link to="/audit-log" className="text-sm text-brand-400 hover:text-brand-300 font-medium">
             View all activity →
           </Link>
@@ -279,7 +279,7 @@ export function ActivityFeed({
 
 // Compact version for sidebars
 export function CompactActivityFeed({ limit = 5 }: { limit?: number }) {
-  return <ActivityFeed limit={limit} compact showHeader className="bg-surface-800/50" />;
+  return <ActivityFeed limit={limit} compact showHeader className="bg-white/50" />;
 }
 
 export default ActivityFeed;

--- a/frontend/src/components/AdvancedFilters.tsx
+++ b/frontend/src/components/AdvancedFilters.tsx
@@ -234,22 +234,22 @@ export function AdvancedFilters({ fields, onApply, storageKey, className }: Adva
       {isOpen && (
         <>
           <div className="fixed inset-0 z-40" onClick={() => setIsOpen(false)} />
-          <div className="absolute right-0 mt-2 w-[480px] bg-surface-800 border border-surface-700 rounded-xl shadow-xl z-50 overflow-hidden">
+          <div className="absolute right-0 mt-2 w-[480px] bg-white border border-surface-200 rounded-xl shadow-xl z-50 overflow-hidden">
             {/* Header */}
-            <div className="p-4 border-b border-surface-700 flex items-center justify-between">
+            <div className="p-4 border-b border-surface-200 flex items-center justify-between">
               <h3 className="font-medium text-white">Advanced Filters</h3>
               <div className="flex items-center gap-2">
                 {conditions.length > 0 && (
                   <button
                     onClick={clearAll}
-                    className="text-sm text-surface-600 hover:text-surface-200"
+                    className="text-sm text-surface-600 hover:text-surface-800"
                   >
                     Clear all
                   </button>
                 )}
                 <button
                   onClick={() => setIsOpen(false)}
-                  className="p-1 hover:bg-surface-700 rounded"
+                  className="p-1 hover:bg-surface-200 rounded"
                 >
                   <XMarkIcon className="w-5 h-5 text-surface-600" />
                 </button>
@@ -258,7 +258,7 @@ export function AdvancedFilters({ fields, onApply, storageKey, className }: Adva
 
             {/* Presets */}
             {presets.length > 0 && (
-              <div className="p-3 border-b border-surface-700 bg-surface-800/50">
+              <div className="p-3 border-b border-surface-200 bg-white/50">
                 <p className="text-xs text-surface-500 mb-2">Saved Filters</p>
                 <div className="flex flex-wrap gap-2">
                   {presets.map((preset) => (
@@ -268,7 +268,7 @@ export function AdvancedFilters({ fields, onApply, storageKey, className }: Adva
                         'group flex items-center gap-1 px-2 py-1 rounded-lg text-sm cursor-pointer',
                         activePresetId === preset.id
                           ? 'bg-brand-500/20 text-brand-400'
-                          : 'bg-surface-700 text-surface-700 hover:bg-surface-600'
+                          : 'bg-surface-200 text-surface-700 hover:bg-surface-600'
                       )}
                       onClick={() => loadPreset(preset)}
                     >
@@ -313,7 +313,7 @@ export function AdvancedFilters({ fields, onApply, storageKey, className }: Adva
 
               <button
                 onClick={addCondition}
-                className="flex items-center gap-2 px-3 py-2 text-sm text-brand-400 hover:text-brand-300 hover:bg-surface-700 rounded-lg w-full"
+                className="flex items-center gap-2 px-3 py-2 text-sm text-brand-400 hover:text-brand-300 hover:bg-surface-200 rounded-lg w-full"
               >
                 <PlusIcon className="w-4 h-4" />
                 Add Filter
@@ -321,7 +321,7 @@ export function AdvancedFilters({ fields, onApply, storageKey, className }: Adva
             </div>
 
             {/* Footer */}
-            <div className="p-4 border-t border-surface-700 flex items-center justify-between">
+            <div className="p-4 border-t border-surface-200 flex items-center justify-between">
               {showSavePreset ? (
                 <div className="flex items-center gap-2 flex-1">
                   <Input
@@ -329,7 +329,7 @@ export function AdvancedFilters({ fields, onApply, storageKey, className }: Adva
                     value={presetName}
                     onChange={(e) => setPresetName(e.target.value)}
                     placeholder="Filter name..."
-                    className="flex-1 px-3 py-1.5 bg-surface-700 border border-surface-600 rounded-lg text-sm text-white placeholder-surface-500"
+                    className="flex-1 px-3 py-1.5 bg-surface-200 border border-surface-300 rounded-lg text-sm text-white placeholder-surface-500"
                     autoFocus
                     onKeyDown={(e) => e.key === 'Enter' && savePreset()}
                   />
@@ -411,7 +411,7 @@ function FilterConditionRow({
         <SelectNative
           value={condition.field}
           onChange={(e) => handleFieldChange(e.target.value)}
-          className="flex-1 px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-sm text-white"
+          className="flex-1 px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-sm text-white"
         >
           {fields.map((f) => (
             <option key={f.key} value={f.key}>
@@ -424,7 +424,7 @@ function FilterConditionRow({
         <SelectNative
           value={condition.operator}
           onChange={(e) => onUpdate({ operator: e.target.value as FilterOperator, value: '' })}
-          className="w-36 px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-sm text-white"
+          className="w-36 px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-sm text-white"
         >
           {operators.map((op) => (
             <option key={op.value} value={op.value}>
@@ -446,7 +446,7 @@ function FilterConditionRow({
         {/* Remove Button */}
         <button
           onClick={onRemove}
-          className="p-2 hover:bg-surface-700 rounded-lg text-surface-600 hover:text-red-600"
+          className="p-2 hover:bg-surface-200 rounded-lg text-surface-600 hover:text-red-600"
         >
           <TrashIcon className="w-4 h-4" />
         </button>
@@ -475,7 +475,7 @@ function ValueInput({ field, operator, value, onChange }: ValueInputProps) {
       <SelectNative
         value={String(value || '')}
         onChange={(e) => onChange(e.target.value === 'true')}
-        className="flex-1 px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-sm text-white"
+        className="flex-1 px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-sm text-white"
       >
         <option value="">Select...</option>
         <option value="true">Yes</option>
@@ -491,7 +491,7 @@ function ValueInput({ field, operator, value, onChange }: ValueInputProps) {
       const selectedValues = Array.isArray(value) ? value : [];
       return (
         <div className="flex-1">
-          <div className="flex flex-wrap gap-1 p-2 bg-surface-700 border border-surface-600 rounded-lg min-h-[38px]">
+          <div className="flex flex-wrap gap-1 p-2 bg-surface-200 border border-surface-300 rounded-lg min-h-[38px]">
             {selectedValues.map((v) => {
               const opt = field.options?.find((o) => o.value === v);
               return (
@@ -536,7 +536,7 @@ function ValueInput({ field, operator, value, onChange }: ValueInputProps) {
         <SelectNative
           value={String(value || '')}
           onChange={(e) => onChange(e.target.value)}
-          className="flex-1 px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-sm text-white"
+          className="flex-1 px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-sm text-white"
         >
           <option value="">Select...</option>
           {field.options.map((o) => (
@@ -556,7 +556,7 @@ function ValueInput({ field, operator, value, onChange }: ValueInputProps) {
         type="date"
         value={String(value || '')}
         onChange={(e) => onChange(e.target.value)}
-        className="flex-1 px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-sm text-white"
+        className="flex-1 px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-sm text-white"
       />
     );
   }
@@ -569,7 +569,7 @@ function ValueInput({ field, operator, value, onChange }: ValueInputProps) {
         value={String(value || '')}
         onChange={(e) => onChange(e.target.value ? Number(e.target.value) : null)}
         placeholder="Enter value..."
-        className="flex-1 px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-sm text-white placeholder-surface-500"
+        className="flex-1 px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-sm text-white placeholder-surface-500"
       />
     );
   }
@@ -581,7 +581,7 @@ function ValueInput({ field, operator, value, onChange }: ValueInputProps) {
       value={String(value || '')}
       onChange={(e) => onChange(e.target.value)}
       placeholder="Enter value..."
-      className="flex-1 px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-sm text-white placeholder-surface-500"
+      className="flex-1 px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-sm text-white placeholder-surface-500"
     />
   );
 }

--- a/frontend/src/components/BulkActions.tsx
+++ b/frontend/src/components/BulkActions.tsx
@@ -101,7 +101,7 @@ export function SelectCheckbox({
         onChange={onChange}
         disabled={disabled}
         className={clsx(
-          'h-4 w-4 rounded bg-surface-700 border-surface-600',
+          'h-4 w-4 rounded bg-surface-200 border-surface-300',
           'text-brand-600 focus:ring-brand-500 focus:ring-offset-0',
           'disabled:opacity-50 disabled:cursor-not-allowed',
           'cursor-pointer'
@@ -164,16 +164,16 @@ export function BulkActionsBar({
 
   return (
     <>
-      <div className="sticky top-0 z-40 bg-surface-800 border border-surface-700 rounded-lg p-3 flex items-center justify-between shadow-lg animate-slide-down">
+      <div className="sticky top-0 z-40 bg-white border border-surface-200 rounded-lg p-3 flex items-center justify-between shadow-lg animate-slide-down">
         <div className="flex items-center gap-4">
           <button
             onClick={onClear}
-            className="p-1.5 hover:bg-surface-700 rounded-lg text-surface-600 transition-colors"
+            className="p-1.5 hover:bg-surface-200 rounded-lg text-surface-600 transition-colors"
             aria-label="Clear selection"
           >
             <XMarkIcon className="w-5 h-5" />
           </button>
-          <span className="text-surface-200 font-medium">
+          <span className="text-surface-800 font-medium">
             {selectedCount} of {totalCount} selected
           </span>
         </div>
@@ -259,7 +259,7 @@ export function StatusUpdateDropdown({
       {isOpen && (
         <>
           <div className="fixed inset-0 z-40" onClick={() => setIsOpen(false)} />
-          <div className="absolute right-0 mt-2 w-48 bg-surface-800 border border-surface-700 rounded-lg shadow-xl z-50 overflow-hidden">
+          <div className="absolute right-0 mt-2 w-48 bg-white border border-surface-200 rounded-lg shadow-xl z-50 overflow-hidden">
             {options.map((option) => (
               <button
                 key={option.value}
@@ -267,7 +267,7 @@ export function StatusUpdateDropdown({
                   onSelect(option.value);
                   setIsOpen(false);
                 }}
-                className="w-full px-4 py-2.5 text-left text-sm text-surface-200 hover:bg-surface-700 flex items-center gap-2 transition-colors"
+                className="w-full px-4 py-2.5 text-left text-sm text-surface-800 hover:bg-surface-200 flex items-center gap-2 transition-colors"
               >
                 {option.color && <span className={clsx('w-2 h-2 rounded-full', option.color)} />}
                 {option.label}

--- a/frontend/src/components/BulkUploadModal.tsx
+++ b/frontend/src/components/BulkUploadModal.tsx
@@ -163,16 +163,16 @@ export default function BulkUploadModal({ isOpen, onClose }: BulkUploadModalProp
         <div className="fixed inset-0 bg-black/70 backdrop-blur-sm" onClick={handleClose} />
 
         {/* Modal */}
-        <div className="relative w-full max-w-2xl bg-surface-900 rounded-xl shadow-2xl border border-surface-700">
+        <div className="relative w-full max-w-2xl bg-white rounded-xl shadow-2xl border border-surface-200">
           {/* Header */}
-          <div className="flex items-center justify-between p-6 border-b border-surface-700">
+          <div className="flex items-center justify-between p-6 border-b border-surface-200">
             <div>
-              <h2 className="text-xl font-semibold text-surface-100">Bulk Upload Controls</h2>
+              <h2 className="text-xl font-semibold text-surface-900">Bulk Upload Controls</h2>
               <p className="text-sm text-surface-600 mt-1">Import controls from CSV or JSON file</p>
             </div>
             <button
               onClick={handleClose}
-              className="p-2 text-surface-600 hover:text-surface-200 hover:bg-surface-800 rounded-lg transition-colors"
+              className="p-2 text-surface-600 hover:text-surface-800 hover:bg-white rounded-lg transition-colors"
             >
               <XMarkIcon className="w-5 h-5" />
             </button>
@@ -190,7 +190,7 @@ export default function BulkUploadModal({ isOpen, onClose }: BulkUploadModalProp
                     <ExclamationTriangleIcon className="w-8 h-8 text-yellow-600" />
                   )}
                   <div>
-                    <h3 className="text-lg font-medium text-surface-100">Upload Complete</h3>
+                    <h3 className="text-lg font-medium text-surface-900">Upload Complete</h3>
                     <p className="text-surface-600">
                       Processed {result.total || result.created + result.updated + result.skipped}{' '}
                       controls
@@ -199,19 +199,19 @@ export default function BulkUploadModal({ isOpen, onClose }: BulkUploadModalProp
                 </div>
 
                 <div className="grid grid-cols-4 gap-4">
-                  <div className="bg-surface-800 rounded-lg p-4 text-center">
+                  <div className="bg-white rounded-lg p-4 text-center">
                     <div className="text-2xl font-bold text-green-600">{result.created}</div>
                     <div className="text-sm text-surface-600">Created</div>
                   </div>
-                  <div className="bg-surface-800 rounded-lg p-4 text-center">
+                  <div className="bg-white rounded-lg p-4 text-center">
                     <div className="text-2xl font-bold text-blue-600">{result.updated}</div>
                     <div className="text-sm text-surface-600">Updated</div>
                   </div>
-                  <div className="bg-surface-800 rounded-lg p-4 text-center">
+                  <div className="bg-white rounded-lg p-4 text-center">
                     <div className="text-2xl font-bold text-surface-600">{result.skipped}</div>
                     <div className="text-sm text-surface-600">Skipped</div>
                   </div>
-                  <div className="bg-surface-800 rounded-lg p-4 text-center">
+                  <div className="bg-white rounded-lg p-4 text-center">
                     <div className="text-2xl font-bold text-red-600">
                       {result.errors?.length || 0}
                     </div>
@@ -249,7 +249,7 @@ export default function BulkUploadModal({ isOpen, onClose }: BulkUploadModalProp
                       'flex-1 py-2 px-4 rounded-lg border transition-colors',
                       uploadMode === 'csv'
                         ? 'bg-brand-600 border-brand-500 text-white'
-                        : 'bg-surface-800 border-surface-700 text-surface-700 hover:border-surface-600'
+                        : 'bg-white border-surface-200 text-surface-700 hover:border-surface-300'
                     )}
                   >
                     CSV Format
@@ -260,7 +260,7 @@ export default function BulkUploadModal({ isOpen, onClose }: BulkUploadModalProp
                       'flex-1 py-2 px-4 rounded-lg border transition-colors',
                       uploadMode === 'json'
                         ? 'bg-brand-600 border-brand-500 text-white'
-                        : 'bg-surface-800 border-surface-700 text-surface-700 hover:border-surface-600'
+                        : 'bg-white border-surface-200 text-surface-700 hover:border-surface-300'
                     )}
                   >
                     JSON Format
@@ -275,7 +275,7 @@ export default function BulkUploadModal({ isOpen, onClose }: BulkUploadModalProp
                       ? 'border-brand-500 bg-brand-500/10'
                       : fileContent
                         ? 'border-green-500 bg-green-500/10'
-                        : 'border-surface-700 hover:border-surface-600'
+                        : 'border-surface-200 hover:border-surface-300'
                   )}
                   onDragEnter={handleDrag}
                   onDragLeave={handleDrag}
@@ -293,7 +293,7 @@ export default function BulkUploadModal({ isOpen, onClose }: BulkUploadModalProp
                   {fileContent ? (
                     <div className="space-y-2">
                       <DocumentTextIcon className="w-12 h-12 mx-auto text-green-600" />
-                      <p className="text-surface-100 font-medium">{fileName}</p>
+                      <p className="text-surface-900 font-medium">{fileName}</p>
                       <p className="text-surface-600 text-sm">
                         {fileContent.split('\n').length} lines loaded
                       </p>
@@ -334,7 +334,7 @@ export default function BulkUploadModal({ isOpen, onClose }: BulkUploadModalProp
                         setSkipExisting(e.target.checked);
                         if (e.target.checked) setUpdateExisting(false);
                       }}
-                      className="w-4 h-4 rounded border-surface-600 bg-surface-800 text-brand-500 focus:ring-brand-500"
+                      className="w-4 h-4 rounded border-surface-300 bg-white text-brand-500 focus:ring-brand-500"
                     />
                     <span className="text-surface-700">Skip existing controls</span>
                   </label>
@@ -346,17 +346,17 @@ export default function BulkUploadModal({ isOpen, onClose }: BulkUploadModalProp
                         setUpdateExisting(e.target.checked);
                         if (e.target.checked) setSkipExisting(false);
                       }}
-                      className="w-4 h-4 rounded border-surface-600 bg-surface-800 text-brand-500 focus:ring-brand-500"
+                      className="w-4 h-4 rounded border-surface-300 bg-white text-brand-500 focus:ring-brand-500"
                     />
                     <span className="text-surface-700">Update existing controls</span>
                   </label>
                 </div>
 
                 {/* Template download */}
-                <div className="bg-surface-800 rounded-lg p-4">
+                <div className="bg-white rounded-lg p-4">
                   <div className="flex items-center justify-between">
                     <div>
-                      <h4 className="font-medium text-surface-200">Need a template?</h4>
+                      <h4 className="font-medium text-surface-800">Need a template?</h4>
                       <p className="text-sm text-surface-600">
                         Download our CSV template with example data
                       </p>
@@ -388,7 +388,7 @@ export default function BulkUploadModal({ isOpen, onClose }: BulkUploadModalProp
 
           {/* Footer */}
           {!result && (
-            <div className="flex items-center justify-end gap-3 p-6 border-t border-surface-700">
+            <div className="flex items-center justify-end gap-3 p-6 border-t border-surface-200">
               <Button onClick={handleClose} variant="secondary">
                 Cancel
               </Button>

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -385,7 +385,7 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
             leaveFrom="opacity-100 scale-100"
             leaveTo="opacity-0 scale-95"
           >
-            <Dialog.Panel className="mx-auto max-w-2xl transform overflow-hidden rounded-xl bg-surface-800 border border-surface-700 shadow-2xl transition-all">
+            <Dialog.Panel className="mx-auto max-w-2xl transform overflow-hidden rounded-xl bg-white border border-surface-200 shadow-2xl transition-all">
               <Combobox onChange={handleSelect}>
                 {/* Search Input */}
                 <div className="relative">
@@ -401,7 +401,7 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
                     value={query}
                   />
                   <div className="absolute right-4 top-3 text-xs text-surface-500 hidden sm:flex items-center gap-1">
-                    <kbd className="px-1.5 py-0.5 bg-surface-700 rounded text-surface-600">Esc</kbd>
+                    <kbd className="px-1.5 py-0.5 bg-surface-200 rounded text-surface-600">Esc</kbd>
                     <span>to close</span>
                   </div>
                 </div>
@@ -410,11 +410,11 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
                 {filteredCommands.length > 0 && (
                   <Combobox.Options
                     static
-                    className="max-h-96 scroll-py-2 overflow-y-auto border-t border-surface-700"
+                    className="max-h-96 scroll-py-2 overflow-y-auto border-t border-surface-200"
                   >
                     {Object.entries(groupedCommands).map(([category, commands]) => (
                       <div key={category}>
-                        <div className="px-4 py-2 text-xs font-semibold text-surface-500 uppercase tracking-wider bg-surface-900/50">
+                        <div className="px-4 py-2 text-xs font-semibold text-surface-500 uppercase tracking-wider bg-white/50">
                           {categoryLabels[category] || category}
                         </div>
                         {commands.map((command) => (
@@ -424,7 +424,7 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
                             className={({ active }) =>
                               clsx(
                                 'flex items-center gap-3 px-4 py-3 cursor-pointer',
-                                active ? 'bg-surface-700' : ''
+                                active ? 'bg-surface-200' : ''
                               )
                             }
                           >
@@ -440,7 +440,7 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
                                   <p
                                     className={clsx(
                                       'text-sm font-medium truncate',
-                                      active ? 'text-white' : 'text-surface-200'
+                                      active ? 'text-white' : 'text-surface-800'
                                     )}
                                   >
                                     {command.name}
@@ -452,7 +452,7 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
                                   )}
                                 </div>
                                 {command.shortcut && (
-                                  <kbd className="px-2 py-1 text-xs bg-surface-700 rounded text-surface-600">
+                                  <kbd className="px-2 py-1 text-xs bg-surface-200 rounded text-surface-600">
                                     {command.shortcut}
                                   </kbd>
                                 )}
@@ -467,7 +467,7 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
 
                 {/* Empty state */}
                 {query && filteredCommands.length === 0 && (
-                  <div className="px-6 py-14 text-center border-t border-surface-700">
+                  <div className="px-6 py-14 text-center border-t border-surface-200">
                     <MagnifyingGlassIcon className="mx-auto h-8 w-8 text-surface-500" />
                     <p className="mt-4 text-sm text-surface-600">No results found for "{query}"</p>
                     <p className="mt-2 text-xs text-surface-500">
@@ -477,15 +477,15 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
                 )}
 
                 {/* Footer */}
-                <div className="flex items-center justify-between border-t border-surface-700 px-4 py-2 text-xs text-surface-500">
+                <div className="flex items-center justify-between border-t border-surface-200 px-4 py-2 text-xs text-surface-500">
                   <div className="flex items-center gap-4">
                     <span className="flex items-center gap-1">
-                      <kbd className="px-1.5 py-0.5 bg-surface-700 rounded">↑</kbd>
-                      <kbd className="px-1.5 py-0.5 bg-surface-700 rounded">↓</kbd>
+                      <kbd className="px-1.5 py-0.5 bg-surface-200 rounded">↑</kbd>
+                      <kbd className="px-1.5 py-0.5 bg-surface-200 rounded">↓</kbd>
                       navigate
                     </span>
                     <span className="flex items-center gap-1">
-                      <kbd className="px-1.5 py-0.5 bg-surface-700 rounded">↵</kbd>
+                      <kbd className="px-1.5 py-0.5 bg-surface-200 rounded">↵</kbd>
                       select
                     </span>
                   </div>

--- a/frontend/src/components/CommentsPanel.tsx
+++ b/frontend/src/components/CommentsPanel.tsx
@@ -93,7 +93,7 @@ export default function CommentsPanel({ entityType, entityId }: CommentsPanelPro
     <div className="space-y-4">
       <div className="flex items-center gap-2">
         <ChatBubbleLeftRightIcon className="w-5 h-5 text-surface-600" />
-        <h3 className="text-sm font-semibold text-surface-100">Comments ({comments.length})</h3>
+        <h3 className="text-sm font-semibold text-surface-900">Comments ({comments.length})</h3>
       </div>
       {/* New Comment Form */}
       <form onSubmit={handleSubmit} className="flex gap-2">
@@ -125,15 +125,12 @@ export default function CommentsPanel({ entityType, entityId }: CommentsPanelPro
           {comments.map((comment: any) => (
             <div
               key={comment.id}
-              className={clsx(
-                'p-3 rounded-lg',
-                comment.isResolved ? 'bg-surface-800/50' : 'bg-surface-800'
-              )}
+              className={clsx('p-3 rounded-lg', comment.isResolved ? 'bg-white/50' : 'bg-white')}
             >
               <div className="flex items-start justify-between gap-2">
                 <div className="flex-1">
                   <div className="flex items-center gap-2 mb-1">
-                    <span className="text-sm font-medium text-surface-200">
+                    <span className="text-sm font-medium text-surface-800">
                       {comment.author?.displayName || 'Unknown'}
                     </span>
                     <span className="text-xs text-surface-500">
@@ -156,7 +153,7 @@ export default function CommentsPanel({ entityType, entityId }: CommentsPanelPro
                       })
                     }
                     className={clsx(
-                      'p-1 rounded hover:bg-surface-700 transition-colors',
+                      'p-1 rounded hover:bg-surface-200 transition-colors',
                       comment.isResolved ? 'text-green-600' : 'text-surface-500'
                     )}
                     title={comment.isResolved ? 'Unresolve' : 'Mark as resolved'}
@@ -166,7 +163,7 @@ export default function CommentsPanel({ entityType, entityId }: CommentsPanelPro
                   {comment.authorId === user?.id && (
                     <button
                       onClick={() => deleteMutation.mutate(comment.id)}
-                      className="p-1 rounded text-surface-500 hover:text-red-600 hover:bg-surface-700 transition-colors"
+                      className="p-1 rounded text-surface-500 hover:text-red-600 hover:bg-surface-200 transition-colors"
                       title="Delete"
                     >
                       <TrashIcon className="w-4 h-4" />
@@ -177,7 +174,7 @@ export default function CommentsPanel({ entityType, entityId }: CommentsPanelPro
 
               {/* Replies */}
               {comment.replies?.length > 0 && (
-                <div className="mt-3 ml-4 pl-3 border-l-2 border-surface-700 space-y-2">
+                <div className="mt-3 ml-4 pl-3 border-l-2 border-surface-200 space-y-2">
                   {comment.replies.map((reply: any) => (
                     <div key={reply.id} className="text-sm">
                       <div className="flex items-center gap-2 mb-1">

--- a/frontend/src/components/ComplianceCalendar.tsx
+++ b/frontend/src/components/ComplianceCalendar.tsx
@@ -409,14 +409,14 @@ export function ComplianceCalendar({ className, showFilters = true }: Compliance
     <div className={clsx('space-y-6', className)}>
       {/* View Mode Toggle and Actions */}
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2 bg-surface-800 rounded-lg p-1">
+        <div className="flex items-center gap-2 bg-white rounded-lg p-1">
           <button
             onClick={() => setViewMode('month')}
             className={clsx(
               'px-3 py-1.5 rounded text-sm flex items-center gap-1',
               viewMode === 'month'
                 ? 'bg-brand-500 text-white'
-                : 'text-surface-600 hover:text-surface-200'
+                : 'text-surface-600 hover:text-surface-800'
             )}
           >
             <CalendarIcon className="w-4 h-4" />
@@ -428,7 +428,7 @@ export function ComplianceCalendar({ className, showFilters = true }: Compliance
               'px-3 py-1.5 rounded text-sm flex items-center gap-1',
               viewMode === 'week'
                 ? 'bg-brand-500 text-white'
-                : 'text-surface-600 hover:text-surface-200'
+                : 'text-surface-600 hover:text-surface-800'
             )}
           >
             <CalendarIcon className="w-4 h-4" />
@@ -440,7 +440,7 @@ export function ComplianceCalendar({ className, showFilters = true }: Compliance
               'px-3 py-1.5 rounded text-sm flex items-center gap-1',
               viewMode === 'list'
                 ? 'bg-brand-500 text-white'
-                : 'text-surface-600 hover:text-surface-200'
+                : 'text-surface-600 hover:text-surface-800'
             )}
           >
             <Bars3Icon className="w-4 h-4" />
@@ -450,7 +450,7 @@ export function ComplianceCalendar({ className, showFilters = true }: Compliance
         <div className="flex items-center gap-2">
           <button
             onClick={handleExportIcal}
-            className="px-3 py-1.5 text-sm text-surface-600 hover:text-surface-200 flex items-center gap-1"
+            className="px-3 py-1.5 text-sm text-surface-600 hover:text-surface-800 flex items-center gap-1"
           >
             <ArrowDownTrayIcon className="w-4 h-4" />
             Export iCal
@@ -469,7 +469,7 @@ export function ComplianceCalendar({ className, showFilters = true }: Compliance
       </div>
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Calendar Grid */}
-        <div className="lg:col-span-2 bg-surface-800 rounded-xl border border-surface-700 p-6">
+        <div className="lg:col-span-2 bg-white rounded-xl border border-surface-200 p-6">
           {/* Header */}
           <div className="flex items-center justify-between mb-6">
             <div className="flex items-center gap-4">
@@ -478,7 +478,7 @@ export function ComplianceCalendar({ className, showFilters = true }: Compliance
               </h2>
               <button
                 onClick={goToToday}
-                className="px-3 py-1 text-sm bg-surface-700 hover:bg-surface-600 rounded-lg text-surface-700"
+                className="px-3 py-1 text-sm bg-surface-200 hover:bg-surface-600 rounded-lg text-surface-700"
               >
                 Today
               </button>
@@ -486,13 +486,13 @@ export function ComplianceCalendar({ className, showFilters = true }: Compliance
             <div className="flex items-center gap-2">
               <button
                 onClick={prevMonth}
-                className="p-2 hover:bg-surface-700 rounded-lg text-surface-600"
+                className="p-2 hover:bg-surface-200 rounded-lg text-surface-600"
               >
                 <ChevronLeftIcon className="w-5 h-5" />
               </button>
               <button
                 onClick={nextMonth}
-                className="p-2 hover:bg-surface-700 rounded-lg text-surface-600"
+                className="p-2 hover:bg-surface-200 rounded-lg text-surface-600"
               >
                 <ChevronRightIcon className="w-5 h-5" />
               </button>
@@ -530,8 +530,8 @@ export function ComplianceCalendar({ className, showFilters = true }: Compliance
                   onClick={() => setSelectedDate(date)}
                   className={clsx(
                     'aspect-square p-1 rounded-lg transition-all relative',
-                    isSelected ? 'bg-brand-500/20 ring-2 ring-brand-500' : 'hover:bg-surface-700',
-                    isTodayDate && 'bg-surface-700',
+                    isSelected ? 'bg-brand-500/20 ring-2 ring-brand-500' : 'hover:bg-surface-200',
+                    isTodayDate && 'bg-surface-200',
                     isPast && 'opacity-50'
                   )}
                 >
@@ -570,7 +570,7 @@ export function ComplianceCalendar({ className, showFilters = true }: Compliance
 
           {/* Filter toggles */}
           {showFilters && (
-            <div className="mt-6 pt-4 border-t border-surface-700">
+            <div className="mt-6 pt-4 border-t border-surface-200">
               <div className="flex flex-wrap gap-2">
                 {Object.entries(EVENT_CONFIG).map(([type, config]) => {
                   const Icon = config.icon;
@@ -583,7 +583,7 @@ export function ComplianceCalendar({ className, showFilters = true }: Compliance
                         'flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm transition-all',
                         isActive
                           ? `${config.color}/20 ${config.textColor}`
-                          : 'bg-surface-700/50 text-surface-500'
+                          : 'bg-surface-200/50 text-surface-500'
                       )}
                     >
                       <Icon className="w-4 h-4" />
@@ -600,7 +600,7 @@ export function ComplianceCalendar({ className, showFilters = true }: Compliance
         <div className="space-y-6">
           {/* Selected Date Events */}
           {selectedDate && (
-            <div className="bg-surface-800 rounded-xl border border-surface-700 p-4">
+            <div className="bg-white rounded-xl border border-surface-200 p-4">
               <h3 className="font-medium text-white mb-3">{formatDate(selectedDate)}</h3>
               {selectedDateEvents.length === 0 ? (
                 <p className="text-sm text-surface-500">No events scheduled</p>
@@ -613,14 +613,14 @@ export function ComplianceCalendar({ className, showFilters = true }: Compliance
                       <button
                         key={event.id}
                         onClick={() => handleEventClick(event)}
-                        className="w-full text-left p-2 rounded-lg bg-surface-700/50 hover:bg-surface-700 transition-colors"
+                        className="w-full text-left p-2 rounded-lg bg-surface-200/50 hover:bg-surface-200 transition-colors"
                       >
                         <div className="flex items-start gap-2">
                           <div className={clsx('p-1 rounded', `${config.color}/20`)}>
                             <Icon className={clsx('w-4 h-4', config.textColor)} />
                           </div>
                           <div className="flex-1 min-w-0">
-                            <p className="text-sm font-medium text-surface-100 truncate">
+                            <p className="text-sm font-medium text-surface-900 truncate">
                               {event.title}
                             </p>
                             <p className="text-xs text-surface-500">{config.label}</p>
@@ -635,7 +635,7 @@ export function ComplianceCalendar({ className, showFilters = true }: Compliance
           )}
 
           {/* Upcoming Events */}
-          <div className="bg-surface-800 rounded-xl border border-surface-700 p-4">
+          <div className="bg-white rounded-xl border border-surface-200 p-4">
             <h3 className="font-medium text-white mb-3">Upcoming (30 days)</h3>
             {upcomingEvents.length === 0 ? (
               <p className="text-sm text-surface-500">No upcoming events</p>
@@ -651,14 +651,14 @@ export function ComplianceCalendar({ className, showFilters = true }: Compliance
                     <button
                       key={event.id}
                       onClick={() => handleEventClick(event)}
-                      className="w-full text-left p-2 rounded-lg bg-surface-700/50 hover:bg-surface-700 transition-colors"
+                      className="w-full text-left p-2 rounded-lg bg-surface-200/50 hover:bg-surface-200 transition-colors"
                     >
                       <div className="flex items-start gap-2">
                         <div className={clsx('p-1 rounded', `${config.color}/20`)}>
                           <Icon className={clsx('w-4 h-4', config.textColor)} />
                         </div>
                         <div className="flex-1 min-w-0">
-                          <p className="text-sm font-medium text-surface-100 truncate">
+                          <p className="text-sm font-medium text-surface-900 truncate">
                             {event.title}
                           </p>
                           <p className="text-xs text-surface-500">
@@ -684,7 +684,7 @@ export function ComplianceCalendar({ className, showFilters = true }: Compliance
           <h3 className="text-lg font-semibold text-white">Create Event</h3>
           <button
             onClick={() => setShowCreateModal(false)}
-            className="text-surface-600 hover:text-surface-200"
+            className="text-surface-600 hover:text-surface-800"
           >
             <XMarkIcon className="w-5 h-5" />
           </button>
@@ -696,7 +696,7 @@ export function ComplianceCalendar({ className, showFilters = true }: Compliance
               type="text"
               value={newEventTitle}
               onChange={(e) => setNewEventTitle(e.target.value)}
-              className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-white placeholder-surface-500 focus:ring-2 focus:ring-brand-500 focus:border-transparent"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-white placeholder-surface-500 focus:ring-2 focus:ring-brand-500 focus:border-transparent"
               placeholder="Event title"
               required
             />
@@ -706,7 +706,7 @@ export function ComplianceCalendar({ className, showFilters = true }: Compliance
             <Textarea
               value={newEventDescription}
               onChange={(e) => setNewEventDescription(e.target.value)}
-              className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-white placeholder-surface-500 focus:ring-2 focus:ring-brand-500 focus:border-transparent"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-white placeholder-surface-500 focus:ring-2 focus:ring-brand-500 focus:border-transparent"
               placeholder="Optional description"
               rows={2}
             />
@@ -717,7 +717,7 @@ export function ComplianceCalendar({ className, showFilters = true }: Compliance
               type="date"
               value={newEventDate}
               onChange={(e) => setNewEventDate(e.target.value)}
-              className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-white focus:ring-2 focus:ring-brand-500 focus:border-transparent"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-white focus:ring-2 focus:ring-brand-500 focus:border-transparent"
               required
             />
           </div>
@@ -726,7 +726,7 @@ export function ComplianceCalendar({ className, showFilters = true }: Compliance
             <SelectNative
               value={newEventPriority}
               onChange={(e) => setNewEventPriority(e.target.value)}
-              className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-white focus:ring-2 focus:ring-brand-500 focus:border-transparent"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-white focus:ring-2 focus:ring-brand-500 focus:border-transparent"
             >
               <option value="low">Low</option>
               <option value="medium">Medium</option>
@@ -738,7 +738,7 @@ export function ComplianceCalendar({ className, showFilters = true }: Compliance
             <button
               type="button"
               onClick={() => setShowCreateModal(false)}
-              className="px-4 py-2 text-surface-600 hover:text-surface-200"
+              className="px-4 py-2 text-surface-600 hover:text-surface-800"
             >
               Cancel
             </button>

--- a/frontend/src/components/ComplianceScoreCard.tsx
+++ b/frontend/src/components/ComplianceScoreCard.tsx
@@ -42,8 +42,8 @@ export function ComplianceScoreCard({
     <div
       onClick={onClick}
       className={`
-        bg-surface-800 border border-surface-700 rounded-xl p-6
-        ${onClick ? 'cursor-pointer hover:border-surface-600 transition-colors' : ''}
+        bg-white border border-surface-200 rounded-xl p-6
+        ${onClick ? 'cursor-pointer hover:border-surface-300 transition-colors' : ''}
       `}
     >
       <div className="flex items-start justify-between mb-4">
@@ -67,13 +67,13 @@ export function ComplianceScoreCard({
             )}
           </div>
         </div>
-        <div className="p-3 bg-surface-700 rounded-lg">
+        <div className="p-3 bg-surface-200 rounded-lg">
           <ChartBarIcon className={`h-6 w-6 ${scoreColor}`} />
         </div>
       </div>
 
       {/* Progress bar */}
-      <div className="h-2 bg-surface-700 rounded-full overflow-hidden mb-3">
+      <div className="h-2 bg-surface-200 rounded-full overflow-hidden mb-3">
         <div
           className={`h-full ${progressColor} transition-all duration-500 ease-out`}
           style={{ width: `${score}%` }}

--- a/frontend/src/components/DashboardWidgets.tsx
+++ b/frontend/src/components/DashboardWidgets.tsx
@@ -207,7 +207,7 @@ export function DashboardWidgets({ widgets, storageKey, className }: DashboardWi
 
       {/* Widget Visibility Panel (when customizing) */}
       {isCustomizing && (
-        <div className="mb-6 p-4 bg-surface-800 border border-surface-700 rounded-xl">
+        <div className="mb-6 p-4 bg-white border border-surface-200 rounded-xl">
           <h3 className="text-sm font-medium text-surface-700 mb-3">
             Widget Visibility ({layout.filter((w) => w.visible).length} of {layout.length} visible)
           </h3>
@@ -223,7 +223,7 @@ export function DashboardWidgets({ widgets, storageKey, className }: DashboardWi
                     'flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm transition-all',
                     w.visible
                       ? 'bg-brand-500/20 text-brand-400 border border-brand-500/30'
-                      : 'bg-surface-700 text-surface-500 border border-surface-600'
+                      : 'bg-surface-200 text-surface-500 border border-surface-300'
                   )}
                 >
                   {w.visible ? (
@@ -257,8 +257,7 @@ export function DashboardWidgets({ widgets, storageKey, className }: DashboardWi
             className={clsx(
               'transition-all duration-200',
               isCustomizing && 'cursor-move',
-              dragOverWidget === id &&
-                'ring-2 ring-brand-500 ring-offset-2 ring-offset-surface-900',
+              dragOverWidget === id && 'ring-2 ring-brand-500 ring-offset-2 ring-offset-surface-50',
               draggedWidget === id && 'opacity-50'
             )}
           >
@@ -275,7 +274,7 @@ export function DashboardWidgets({ widgets, storageKey, className }: DashboardWi
 
       {/* Empty State */}
       {visibleWidgets.length === 0 && (
-        <div className="text-center py-12 bg-surface-800 border border-surface-700 rounded-xl">
+        <div className="text-center py-12 bg-white border border-surface-200 rounded-xl">
           <EyeSlashIcon className="w-12 h-12 mx-auto text-surface-600 mb-4" />
           <h3 className="text-lg font-medium text-surface-700 mb-2">No widgets visible</h3>
           <p className="text-surface-500 mb-4">Click "Customize" to enable some widgets</p>
@@ -313,13 +312,10 @@ interface WidgetCardProps {
 export function WidgetCard({ title, children, action, className }: WidgetCardProps) {
   return (
     <div
-      className={clsx(
-        'bg-surface-800 rounded-xl border border-surface-700 overflow-hidden',
-        className
-      )}
+      className={clsx('bg-white rounded-xl border border-surface-200 overflow-hidden', className)}
     >
-      <div className="p-4 border-b border-surface-700 flex items-center justify-between">
-        <h3 className="font-medium text-surface-100">{title}</h3>
+      <div className="p-4 border-b border-surface-200 flex items-center justify-between">
+        <h3 className="font-medium text-surface-900">{title}</h3>
         {action}
       </div>
       <div className="p-4">{children}</div>

--- a/frontend/src/components/DemoDataSettings.tsx
+++ b/frontend/src/components/DemoDataSettings.tsx
@@ -324,7 +324,7 @@ export default function DemoDataSettings() {
 
 function DataCard({ label, count }: { label: string; count: number }) {
   return (
-    <div className="p-3 bg-surface-800/50 rounded-lg">
+    <div className="p-3 bg-white/50 rounded-lg">
       <p className="text-lg font-semibold text-foreground">{count}</p>
       <p className="text-xs text-muted-foreground">{label}</p>
     </div>

--- a/frontend/src/components/EntityAuditHistory.tsx
+++ b/frontend/src/components/EntityAuditHistory.tsx
@@ -259,7 +259,7 @@ function ChangesDiff({
         {changedFields.map(({ field, oldValue, newValue }) => (
           <div
             key={field}
-            className="flex flex-col gap-1 p-2 rounded-lg bg-surface-800/50 border border-surface-700"
+            className="flex flex-col gap-1 p-2 rounded-lg bg-white/50 border border-surface-200"
           >
             <span className="text-xs text-surface-600 font-medium">
               {FIELD_LABELS[field] || field}
@@ -306,7 +306,7 @@ function AuditLogItem({ entry }: { entry: AuditLogEntry }) {
   return (
     <div className="relative pl-8 pb-6 last:pb-0">
       {/* Timeline line */}
-      <div className="absolute left-[11px] top-6 bottom-0 w-px bg-surface-700 last:hidden" />
+      <div className="absolute left-[11px] top-6 bottom-0 w-px bg-surface-200 last:hidden" />
       {/* Timeline dot */}
       <div
         className={clsx(
@@ -321,8 +321,8 @@ function AuditLogItem({ entry }: { entry: AuditLogEntry }) {
       {/* Content */}
       <div
         className={clsx(
-          'bg-surface-800 rounded-lg border border-surface-700 overflow-hidden',
-          hasChanges && 'cursor-pointer hover:border-surface-600 transition-colors'
+          'bg-white rounded-lg border border-surface-200 overflow-hidden',
+          hasChanges && 'cursor-pointer hover:border-surface-300 transition-colors'
         )}
         onClick={() => hasChanges && setIsExpanded(!isExpanded)}
       >
@@ -362,7 +362,7 @@ function AuditLogItem({ entry }: { entry: AuditLogEntry }) {
             {/* Expand button */}
             {hasChanges && (
               <button
-                className="p-1 rounded hover:bg-surface-700 text-surface-600 hover:text-surface-200 transition-colors"
+                className="p-1 rounded hover:bg-surface-200 text-surface-600 hover:text-surface-800 transition-colors"
                 onClick={(e) => {
                   e.stopPropagation();
                   setIsExpanded(!isExpanded);
@@ -426,7 +426,7 @@ export function EntityAuditHistory({ entityType, entityId, limit = 50 }: EntityA
         <div className="flex items-center gap-3">
           <h3 className="text-lg font-semibold text-white">Change History</h3>
           {entries.length > 0 && (
-            <span className="text-xs text-surface-500 bg-surface-800 px-2 py-0.5 rounded-full">
+            <span className="text-xs text-surface-500 bg-white px-2 py-0.5 rounded-full">
               {entries.length} {entries.length === 1 ? 'entry' : 'entries'}
             </span>
           )}
@@ -438,7 +438,7 @@ export function EntityAuditHistory({ entityType, entityId, limit = 50 }: EntityA
             <SelectNative
               value={filterAction}
               onChange={(e) => setFilterAction(e.target.value)}
-              className="text-xs bg-surface-800 border border-surface-700 rounded-md text-surface-700 py-1.5 px-2"
+              className="text-xs bg-white border border-surface-200 rounded-md text-surface-700 py-1.5 px-2"
             >
               <option value="all">All Actions</option>
               {uniqueActions.map((action) => (
@@ -453,7 +453,7 @@ export function EntityAuditHistory({ entityType, entityId, limit = 50 }: EntityA
           <button
             onClick={() => refetch()}
             className={clsx(
-              'p-1.5 rounded-md hover:bg-surface-700 text-surface-600 hover:text-white transition-colors',
+              'p-1.5 rounded-md hover:bg-surface-200 text-surface-600 hover:text-white transition-colors',
               isRefetching && 'animate-spin'
             )}
             title="Refresh"
@@ -467,16 +467,16 @@ export function EntityAuditHistory({ entityType, entityId, limit = 50 }: EntityA
         <div className="space-y-4">
           {Array.from({ length: 3 }).map((_, i) => (
             <div key={i} className="relative pl-8 pb-6">
-              <div className="absolute left-0 w-6 h-6 rounded-full bg-surface-700 animate-pulse" />
-              <div className="bg-surface-800 rounded-lg border border-surface-700 p-4 animate-pulse">
-                <div className="h-4 bg-surface-700 rounded w-1/3 mb-2" />
-                <div className="h-3 bg-surface-700 rounded w-2/3" />
+              <div className="absolute left-0 w-6 h-6 rounded-full bg-surface-200 animate-pulse" />
+              <div className="bg-white rounded-lg border border-surface-200 p-4 animate-pulse">
+                <div className="h-4 bg-surface-200 rounded w-1/3 mb-2" />
+                <div className="h-3 bg-surface-200 rounded w-2/3" />
               </div>
             </div>
           ))}
         </div>
       ) : filteredEntries.length === 0 ? (
-        <div className="text-center py-12 bg-surface-800/50 rounded-lg border border-surface-700">
+        <div className="text-center py-12 bg-white/50 rounded-lg border border-surface-200">
           <ClockIcon className="w-10 h-10 mx-auto text-surface-600 mb-3" />
           <p className="text-surface-600">No history recorded yet</p>
           <p className="text-surface-500 text-sm mt-1">Changes will appear here as they are made</p>

--- a/frontend/src/components/ExportDropdown.tsx
+++ b/frontend/src/components/ExportDropdown.tsx
@@ -118,12 +118,12 @@ export function ExportDropdown<T>({
       </Button>
 
       {isOpen && (
-        <div className="absolute right-0 mt-2 w-48 bg-surface-800 border border-surface-700 rounded-lg shadow-xl z-50 overflow-hidden">
+        <div className="absolute right-0 mt-2 w-48 bg-white border border-surface-200 rounded-lg shadow-xl z-50 overflow-hidden">
           {formatOptions.map((option) => (
             <button
               key={option.value}
               onClick={() => handleExport(option.value)}
-              className="w-full px-4 py-2.5 text-left text-sm text-surface-200 hover:bg-surface-700 flex items-center gap-3 transition-colors"
+              className="w-full px-4 py-2.5 text-left text-sm text-surface-800 hover:bg-surface-200 flex items-center gap-3 transition-colors"
             >
               <span className="text-base">{option.icon}</span>
               {option.label}

--- a/frontend/src/components/Form.tsx
+++ b/frontend/src/components/Form.tsx
@@ -137,12 +137,12 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
             ref={ref}
             type="checkbox"
             className={clsx(
-              'h-4 w-4 rounded bg-surface-700 border',
-              'focus:ring-2 focus:ring-offset-0 focus:ring-offset-surface-900',
+              'h-4 w-4 rounded bg-surface-200 border',
+              'focus:ring-2 focus:ring-offset-0 focus:ring-offset-surface-50',
               'disabled:cursor-not-allowed disabled:opacity-50',
               error
                 ? 'border-red-500 text-red-600 focus:ring-red-500/20'
-                : 'border-surface-600 text-brand-600 focus:ring-brand-500/20'
+                : 'border-surface-300 text-brand-600 focus:ring-brand-500/20'
             )}
             {...registration}
             {...props}
@@ -207,12 +207,12 @@ export function RadioGroup({
               value={option.value}
               disabled={option.disabled}
               className={clsx(
-                'h-4 w-4 bg-surface-700 border',
-                'focus:ring-2 focus:ring-offset-0 focus:ring-offset-surface-900',
+                'h-4 w-4 bg-surface-200 border',
+                'focus:ring-2 focus:ring-offset-0 focus:ring-offset-surface-50',
                 'disabled:cursor-not-allowed disabled:opacity-50',
                 error
                   ? 'border-red-500 text-red-600 focus:ring-red-500/20'
-                  : 'border-surface-600 text-brand-600 focus:ring-brand-500/20'
+                  : 'border-surface-300 text-brand-600 focus:ring-brand-500/20'
               )}
               {...registration}
             />
@@ -260,7 +260,7 @@ export function FormActions({ children, className, align = 'right' }: FormAction
   return (
     <div
       className={clsx(
-        'flex items-center gap-3 pt-4 border-t border-surface-700',
+        'flex items-center gap-3 pt-4 border-t border-surface-200',
         alignClasses[align],
         className
       )}
@@ -286,7 +286,7 @@ export function FormSection({ title, description, children, className }: FormSec
     <div className={clsx('space-y-4', className)}>
       {(title || description) && (
         <div>
-          {title && <h3 className="text-lg font-medium text-surface-100">{title}</h3>}
+          {title && <h3 className="text-lg font-medium text-surface-900">{title}</h3>}
           {description && <p className="mt-1 text-sm text-surface-600">{description}</p>}
         </div>
       )}
@@ -300,7 +300,7 @@ export function FormSection({ title, description, children, className }: FormSec
 // ===========================================
 
 export function FormDivider({ className }: { className?: string }) {
-  return <hr className={clsx('border-surface-700 my-6', className)} />;
+  return <hr className={clsx('border-surface-200 my-6', className)} />;
 }
 
 // ===========================================

--- a/frontend/src/components/GlobalSearch.tsx
+++ b/frontend/src/components/GlobalSearch.tsx
@@ -166,7 +166,7 @@ export default function GlobalSearch() {
             setIsOpen(true);
           }}
           onFocus={() => setIsOpen(true)}
-          className="w-full pl-10 pr-10 py-2 bg-surface-800 border border-surface-700 rounded-lg text-sm text-surface-100 placeholder-surface-500 focus:outline-none focus:border-brand-500 focus:ring-1 focus:ring-brand-500"
+          className="w-full pl-10 pr-10 py-2 bg-white border border-surface-200 rounded-lg text-sm text-surface-900 placeholder-surface-500 focus:outline-none focus:border-brand-500 focus:ring-1 focus:ring-brand-500"
         />
         {query && (
           <button
@@ -174,7 +174,7 @@ export default function GlobalSearch() {
               setQuery('');
               setSelectedIndex(0);
             }}
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-surface-600 hover:text-surface-100"
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-surface-600 hover:text-surface-900"
           >
             <XMarkIcon className="w-5 h-5" />
           </button>
@@ -182,10 +182,10 @@ export default function GlobalSearch() {
       </div>
       {/* Results dropdown */}
       {isOpen && query.length >= 2 && (
-        <div className="absolute top-full left-0 right-0 mt-2 bg-surface-900 border border-surface-800 rounded-lg shadow-xl max-h-96 overflow-y-auto z-50">
+        <div className="absolute top-full left-0 right-0 mt-2 bg-white border border-surface-200 rounded-lg shadow-xl max-h-96 overflow-y-auto z-50">
           {isLoading ? (
             <div className="p-4 text-center text-surface-600">
-              <div className="animate-spin w-5 h-5 border-2 border-surface-700 border-t-brand-500 rounded-full mx-auto"></div>
+              <div className="animate-spin w-5 h-5 border-2 border-surface-200 border-t-brand-500 rounded-full mx-auto"></div>
             </div>
           ) : results.length === 0 ? (
             <div className="p-4 text-center text-surface-600">No results found for "{query}"</div>
@@ -202,14 +202,14 @@ export default function GlobalSearch() {
                     className={clsx(
                       'w-full px-4 py-3 flex items-center gap-3 text-left transition-colors',
                       isSelected
-                        ? 'bg-brand-500/20 text-surface-100'
-                        : 'text-surface-700 hover:bg-surface-800'
+                        ? 'bg-brand-500/20 text-surface-900'
+                        : 'text-surface-700 hover:bg-white'
                     )}
                   >
                     <div
                       className={clsx(
                         'p-2 rounded-lg',
-                        isSelected ? 'bg-brand-500/30' : 'bg-surface-800'
+                        isSelected ? 'bg-brand-500/30' : 'bg-white'
                       )}
                     >
                       <Icon className="w-4 h-4" />
@@ -222,7 +222,7 @@ export default function GlobalSearch() {
                             'text-xs px-2 py-0.5 rounded',
                             isSelected
                               ? 'bg-brand-500/30 text-brand-300'
-                              : 'bg-surface-800 text-surface-500'
+                              : 'bg-white text-surface-500'
                           )}
                         >
                           {SEARCH_LABELS[result.type]}

--- a/frontend/src/components/KeyboardShortcuts.tsx
+++ b/frontend/src/components/KeyboardShortcuts.tsx
@@ -92,14 +92,14 @@ export function KeyboardShortcutsModal({ isOpen, onClose }: KeyboardShortcutsPro
               leaveFrom="opacity-100 scale-100"
               leaveTo="opacity-0 scale-95"
             >
-              <Dialog.Panel className="w-full max-w-2xl transform overflow-hidden rounded-xl bg-surface-800 border border-surface-700 shadow-2xl transition-all">
-                <div className="flex items-center justify-between px-6 py-4 border-b border-surface-700">
+              <Dialog.Panel className="w-full max-w-2xl transform overflow-hidden rounded-xl bg-white border border-surface-200 shadow-2xl transition-all">
+                <div className="flex items-center justify-between px-6 py-4 border-b border-surface-200">
                   <Dialog.Title className="text-lg font-semibold text-white">
                     Keyboard Shortcuts
                   </Dialog.Title>
                   <button
                     onClick={onClose}
-                    className="p-2 rounded-lg hover:bg-surface-700 text-surface-600 hover:text-white transition-colors"
+                    className="p-2 rounded-lg hover:bg-surface-200 text-surface-600 hover:text-white transition-colors"
                   >
                     <XMarkIcon className="w-5 h-5" />
                   </button>
@@ -121,7 +121,7 @@ export function KeyboardShortcutsModal({ isOpen, onClose }: KeyboardShortcutsPro
                                   {keyIdx > 0 && (
                                     <span className="text-surface-600 text-xs mx-0.5">+</span>
                                   )}
-                                  <kbd className="px-2 py-1 text-xs font-medium bg-surface-700 text-surface-700 rounded border border-surface-600">
+                                  <kbd className="px-2 py-1 text-xs font-medium bg-surface-200 text-surface-700 rounded border border-surface-300">
                                     {key}
                                   </kbd>
                                 </Fragment>
@@ -134,11 +134,11 @@ export function KeyboardShortcutsModal({ isOpen, onClose }: KeyboardShortcutsPro
                   ))}
                 </div>
 
-                <div className="px-6 py-4 bg-surface-900/50 border-t border-surface-700">
+                <div className="px-6 py-4 bg-white/50 border-t border-surface-200">
                   <p className="text-xs text-surface-500 text-center">
                     Press{' '}
-                    <kbd className="px-1.5 py-0.5 bg-surface-700 rounded text-surface-600">⌘</kbd> +{' '}
-                    <kbd className="px-1.5 py-0.5 bg-surface-700 rounded text-surface-600">/</kbd>{' '}
+                    <kbd className="px-1.5 py-0.5 bg-surface-200 rounded text-surface-600">⌘</kbd> +{' '}
+                    <kbd className="px-1.5 py-0.5 bg-surface-200 rounded text-surface-600">/</kbd>{' '}
                     to toggle this help
                   </p>
                 </div>

--- a/frontend/src/components/LanguageSelector.tsx
+++ b/frontend/src/components/LanguageSelector.tsx
@@ -38,7 +38,7 @@ export default function LanguageSelector({
               'px-3 py-1.5 rounded-md text-sm font-medium transition-colors',
               currentLanguage === language.code
                 ? 'bg-brand-500 text-white'
-                : 'bg-surface-100 text-surface-700 hover:bg-surface-200 dark:bg-surface-700 dark:text-surface-200 dark:hover:bg-surface-600'
+                : 'bg-surface-100 text-surface-700 hover:bg-surface-200 dark:bg-surface-200 dark:text-surface-800 dark:hover:bg-surface-600'
             )}
           >
             {showNativeName ? language.nativeName : language.name}
@@ -50,7 +50,7 @@ export default function LanguageSelector({
 
   return (
     <Menu as="div" className={clsx('relative inline-block text-left', className)}>
-      <Menu.Button className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-surface-700 dark:text-surface-200 bg-surface-100 dark:bg-surface-700 rounded-md hover:bg-surface-200 dark:hover:bg-surface-600 transition-colors">
+      <Menu.Button className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-surface-700 dark:text-surface-800 bg-surface-100 dark:bg-surface-200 rounded-md hover:bg-surface-200 dark:hover:bg-surface-600 transition-colors">
         {showIcon && <GlobeAltIcon className="w-4 h-4" />}
         <span>{displayName}</span>
         <ChevronDownIcon className="w-4 h-4" aria-hidden="true" />
@@ -65,7 +65,7 @@ export default function LanguageSelector({
         leaveFrom="transform opacity-100 scale-100"
         leaveTo="transform opacity-0 scale-95"
       >
-        <Menu.Items className="absolute right-0 z-50 mt-2 w-48 origin-top-right rounded-md bg-white dark:bg-surface-800 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
+        <Menu.Items className="absolute right-0 z-50 mt-2 w-48 origin-top-right rounded-md bg-white dark:bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
           <div className="py-1">
             {availableLanguages.map((language) => (
               <Menu.Item key={language.code}>
@@ -75,7 +75,7 @@ export default function LanguageSelector({
                     className={clsx(
                       'w-full flex items-center justify-between px-4 py-2 text-sm',
                       active
-                        ? 'bg-surface-100 dark:bg-surface-700 text-surface-900 dark:text-surface-100'
+                        ? 'bg-surface-100 dark:bg-surface-200 text-surface-900 dark:text-surface-900'
                         : 'text-surface-700 dark:text-surface-700',
                       currentLanguage === language.code && 'font-medium'
                     )}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -247,7 +247,7 @@ function NavSectionComponent({ section }: { section: NavSection }) {
           'flex items-center justify-between w-full px-3 py-2 rounded-lg text-sm font-medium transition-all duration-300',
           hasActiveItem
             ? 'text-brand-400'
-            : 'text-surface-600 hover:bg-surface-800 hover:text-surface-100'
+            : 'text-surface-600 hover:bg-white hover:text-surface-900'
         )}
       >
         <div className="flex items-center gap-3">
@@ -263,7 +263,7 @@ function NavSectionComponent({ section }: { section: NavSection }) {
       </button>
 
       <div
-        className="ml-4 pl-4 border-l border-surface-800 overflow-hidden"
+        className="ml-4 pl-4 border-l border-surface-200 overflow-hidden"
         style={{
           display: 'grid',
           gridTemplateRows: isOpen ? '1fr' : '0fr',
@@ -290,7 +290,7 @@ function NavSectionComponent({ section }: { section: NavSection }) {
                     'flex items-center gap-3 px-3 py-2 rounded-lg text-sm transition-all duration-200',
                     isActive
                       ? 'bg-brand-600/20 text-brand-400 font-medium'
-                      : 'text-surface-600 hover:bg-surface-800 hover:text-surface-100'
+                      : 'text-surface-600 hover:bg-white hover:text-surface-900'
                   )}
                   style={{
                     transitionDelay: isOpen ? `${index * 30}ms` : '0ms',
@@ -330,7 +330,7 @@ export default function Layout() {
   const isDashboardActive = location.pathname === '/dashboard' || location.pathname === '/';
 
   return (
-    <div className="min-h-screen bg-surface-950">
+    <div className="min-h-screen bg-surface-50">
       {/* Skip to main content link for keyboard users */}
       <a
         href="#main-content"
@@ -352,15 +352,15 @@ export default function Layout() {
         role="navigation"
         aria-label="Main navigation"
         className={clsx(
-          'fixed inset-y-0 left-0 z-50 w-64 bg-surface-900 border-r border-surface-800 transform transition-transform duration-200 ease-in-out lg:translate-x-0',
+          'fixed inset-y-0 left-0 z-50 w-64 bg-white border-r border-surface-200 transform transition-transform duration-200 ease-in-out lg:translate-x-0',
           sidebarOpen ? 'translate-x-0' : '-translate-x-full'
         )}
       >
         <div className="flex flex-col h-full">
           {/* Logo */}
-          <div className="flex items-center gap-3 px-6 py-5 border-b border-surface-800">
+          <div className="flex items-center gap-3 px-6 py-5 border-b border-surface-200">
             <img src={branding.logoUrl} alt="Logo" className="w-8 h-8 object-contain" />
-            <span className="text-lg font-semibold text-surface-100">{branding.platformName}</span>
+            <span className="text-lg font-semibold text-surface-900">{branding.platformName}</span>
           </div>
 
           {/* Navigation */}
@@ -372,7 +372,7 @@ export default function Layout() {
                 'flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors',
                 isDashboardActive
                   ? 'bg-brand-600/20 text-brand-400'
-                  : 'text-surface-600 hover:bg-surface-800 hover:text-surface-100'
+                  : 'text-surface-600 hover:bg-white hover:text-surface-900'
               )}
               onClick={() => setSidebarOpen(false)}
             >
@@ -388,7 +388,7 @@ export default function Layout() {
                   'flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors ml-2',
                   isActive
                     ? 'bg-brand-600/20 text-brand-400'
-                    : 'text-surface-600 hover:bg-surface-800 hover:text-surface-100'
+                    : 'text-surface-600 hover:bg-white hover:text-surface-900'
                 )
               }
               onClick={() => setSidebarOpen(false)}
@@ -398,7 +398,7 @@ export default function Layout() {
             </NavLink>
 
             {/* Divider */}
-            <div className="h-px bg-surface-800 my-2" />
+            <div className="h-px bg-white my-2" />
 
             {/* Collapsible Sections */}
             {navSections
@@ -419,15 +419,15 @@ export default function Layout() {
           </nav>
 
           {/* User section */}
-          <div className="p-4 border-t border-surface-800">
+          <div className="p-4 border-t border-surface-200">
             <div className="flex items-center gap-3 mb-3">
-              <div className="w-8 h-8 rounded-full bg-surface-700 flex items-center justify-center">
+              <div className="w-8 h-8 rounded-full bg-surface-200 flex items-center justify-center">
                 <span className="text-sm font-medium text-surface-700">
                   {user?.name?.charAt(0)?.toUpperCase() || 'U'}
                 </span>
               </div>
               <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium text-surface-100 truncate">{user?.name}</p>
+                <p className="text-sm font-medium text-surface-900 truncate">{user?.name}</p>
                 <p className="text-xs text-surface-500 truncate capitalize">
                   {user?.role?.replace('_', ' ')}
                 </p>
@@ -435,7 +435,7 @@ export default function Layout() {
             </div>
             <button
               onClick={logout}
-              className="flex items-center gap-2 w-full px-3 py-2 text-sm text-surface-600 hover:text-surface-100 hover:bg-surface-800 rounded-lg transition-colors"
+              className="flex items-center gap-2 w-full px-3 py-2 text-sm text-surface-600 hover:text-surface-900 hover:bg-white rounded-lg transition-colors"
             >
               <ArrowRightOnRectangleIcon className="w-5 h-5" />
               Sign out
@@ -450,12 +450,12 @@ export default function Layout() {
         <header
           role="banner"
           aria-label="Site header"
-          className="sticky top-0 z-[60] bg-surface-900/80 backdrop-blur-sm border-b border-surface-800"
+          className="sticky top-0 z-[60] bg-white/80 backdrop-blur-sm border-b border-surface-200"
         >
           <div className="flex items-center justify-between gap-4 px-4 py-3 lg:px-6">
             <div className="flex items-center gap-2">
               <button
-                className="lg:hidden p-2 -ml-2 text-surface-600 hover:text-surface-100"
+                className="lg:hidden p-2 -ml-2 text-surface-600 hover:text-surface-900"
                 onClick={() => setSidebarOpen(true)}
               >
                 <Bars3Icon className="w-6 h-6" />
@@ -469,7 +469,7 @@ export default function Layout() {
               {/* Keyboard Shortcuts Button */}
               <button
                 onClick={() => setShowShortcuts(true)}
-                className="p-2 text-surface-600 hover:text-surface-100 hover:bg-surface-800 rounded-lg transition-colors"
+                className="p-2 text-surface-600 hover:text-surface-900 hover:bg-white rounded-lg transition-colors"
                 title="Keyboard Shortcuts (⌘/)"
               >
                 <CommandLineIcon className="w-5 h-5" />
@@ -478,7 +478,7 @@ export default function Layout() {
               {/* Help Center Link */}
               <NavLink
                 to="/help"
-                className="p-2 text-surface-600 hover:text-surface-100 hover:bg-surface-800 rounded-lg transition-colors"
+                className="p-2 text-surface-600 hover:text-surface-900 hover:bg-white rounded-lg transition-colors"
                 title="Help Center"
               >
                 <QuestionMarkCircleIcon className="w-5 h-5" />
@@ -486,7 +486,7 @@ export default function Layout() {
 
               <NavLink
                 to="/account"
-                className="p-2 text-surface-600 hover:text-surface-100 hover:bg-surface-800 rounded-lg transition-colors"
+                className="p-2 text-surface-600 hover:text-surface-900 hover:bg-white rounded-lg transition-colors"
                 title="Account Settings"
               >
                 <CogIcon className="w-5 h-5" />

--- a/frontend/src/components/Loading.test.tsx
+++ b/frontend/src/components/Loading.test.tsx
@@ -5,7 +5,7 @@ import Loading from './Loading';
 describe('Loading', () => {
   it('renders loading spinner', () => {
     render(<Loading />);
-    
+
     // Look for the spinner element (has animate-spin class)
     const spinner = document.querySelector('[class*="animate-spin"]');
     expect(spinner).toBeInTheDocument();
@@ -13,19 +13,19 @@ describe('Loading', () => {
 
   it('renders default loading text', () => {
     render(<Loading />);
-    
+
     expect(screen.getByText('Loading...')).toBeInTheDocument();
   });
 
   it('renders with min-h-screen class', () => {
     const { container } = render(<Loading />);
-    
+
     expect(container.firstChild).toHaveClass('min-h-screen');
   });
 
   it('renders centered content', () => {
     const { container } = render(<Loading />);
-    
+
     expect(container.firstChild).toHaveClass('flex');
     expect(container.firstChild).toHaveClass('items-center');
     expect(container.firstChild).toHaveClass('justify-center');
@@ -33,7 +33,7 @@ describe('Loading', () => {
 
   it('has proper background', () => {
     const { container } = render(<Loading />);
-    
-    expect(container.firstChild).toHaveClass('bg-surface-950');
+
+    expect(container.firstChild).toHaveClass('bg-surface-50');
   });
 });

--- a/frontend/src/components/Loading.tsx
+++ b/frontend/src/components/Loading.tsx
@@ -6,11 +6,11 @@ interface LoadingProps {
 export default function Loading({ fullScreen = true, message = 'Loading...' }: LoadingProps) {
   return (
     <div
-      className={`${fullScreen ? 'min-h-screen' : 'min-h-[200px]'} flex items-center justify-center bg-surface-950`}
+      className={`${fullScreen ? 'min-h-screen' : 'min-h-[200px]'} flex items-center justify-center bg-surface-50`}
     >
       <div className="flex flex-col items-center gap-4">
         <div className="relative">
-          <div className="w-12 h-12 border-4 border-surface-700 rounded-full animate-spin border-t-brand-500"></div>
+          <div className="w-12 h-12 border-4 border-surface-200 rounded-full animate-spin border-t-brand-500"></div>
         </div>
         <p className="text-surface-600 text-sm">{message}</p>
       </div>

--- a/frontend/src/components/NavigationProgress.tsx
+++ b/frontend/src/components/NavigationProgress.tsx
@@ -15,12 +15,12 @@ export default function NavigationProgress() {
     if (navigation.state === 'loading') {
       setVisible(true);
       setProgress(0);
-      
+
       // Simulate progress (since we don't know actual load progress)
       const timer1 = setTimeout(() => setProgress(30), 100);
       const timer2 = setTimeout(() => setProgress(60), 300);
       const timer3 = setTimeout(() => setProgress(80), 600);
-      
+
       return () => {
         clearTimeout(timer1);
         clearTimeout(timer2);
@@ -39,7 +39,7 @@ export default function NavigationProgress() {
   if (!visible) return null;
 
   return (
-    <div className="fixed top-0 left-0 right-0 z-[60] h-1 bg-surface-800/50">
+    <div className="fixed top-0 left-0 right-0 z-[60] h-1 bg-white/50">
       <div
         className={clsx(
           'h-full bg-brand-500 transition-all duration-300 ease-out',
@@ -50,4 +50,3 @@ export default function NavigationProgress() {
     </div>
   );
 }
-

--- a/frontend/src/components/OfflineIndicator.tsx
+++ b/frontend/src/components/OfflineIndicator.tsx
@@ -67,8 +67,8 @@ export default function OfflineIndicator({
 
       {/* Expanded Details */}
       {isExpanded && (
-        <div className="absolute right-0 top-full mt-2 w-72 bg-surface-900 border border-surface-700 rounded-xl shadow-xl z-50 overflow-hidden">
-          <div className="flex items-center justify-between p-3 border-b border-surface-800">
+        <div className="absolute right-0 top-full mt-2 w-72 bg-white border border-surface-200 rounded-xl shadow-xl z-50 overflow-hidden">
+          <div className="flex items-center justify-between p-3 border-b border-surface-200">
             <div className="flex items-center gap-2">
               {isOnline ? (
                 <div className="w-2 h-2 bg-emerald-500 rounded-full animate-pulse" />
@@ -105,7 +105,7 @@ export default function OfflineIndicator({
                   <span className="text-xs text-surface-600">Pending Changes</span>
                   <span className="text-xs font-medium text-yellow-600">{pendingCount}</span>
                 </div>
-                <div className="w-full bg-surface-800 rounded-full h-1">
+                <div className="w-full bg-white rounded-full h-1">
                   <div
                     className="bg-yellow-500 rounded-full h-1 transition-all"
                     style={{ width: `${Math.min(pendingCount * 10, 100)}%` }}
@@ -117,11 +117,11 @@ export default function OfflineIndicator({
             {/* Storage Stats */}
             {storageStats && (
               <div className="grid grid-cols-2 gap-2 text-xs">
-                <div className="p-2 bg-surface-800 rounded-lg">
+                <div className="p-2 bg-white rounded-lg">
                   <span className="text-surface-600">Cached Items</span>
                   <div className="font-medium text-white">{storageStats.cachedItems}</div>
                 </div>
-                <div className="p-2 bg-surface-800 rounded-lg">
+                <div className="p-2 bg-white rounded-lg">
                   <span className="text-surface-600">Storage Used</span>
                   <div className="font-medium text-white">{storageStats.estimatedSize}</div>
                 </div>
@@ -136,7 +136,7 @@ export default function OfflineIndicator({
                 className={clsx(
                   'w-full flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-all',
                   isSyncing
-                    ? 'bg-surface-700 text-surface-600 cursor-wait'
+                    ? 'bg-surface-200 text-surface-600 cursor-wait'
                     : 'bg-brand-500 hover:bg-brand-600 text-white'
                 )}
               >

--- a/frontend/src/components/OnboardingBanner.tsx
+++ b/frontend/src/components/OnboardingBanner.tsx
@@ -103,7 +103,7 @@ export default function OnboardingBanner({ onDismiss }: OnboardingBannerProps) {
           <div className="flex justify-end lg:hidden">
             <button
               onClick={handleDismiss}
-              className="p-1 hover:bg-surface-700 rounded-lg text-muted-foreground hover:text-foreground"
+              className="p-1 hover:bg-surface-200 rounded-lg text-muted-foreground hover:text-foreground"
             >
               <XMarkIcon className="h-5 w-5" />
             </button>
@@ -127,7 +127,7 @@ export default function OnboardingBanner({ onDismiss }: OnboardingBannerProps) {
             {/* Desktop dismiss button */}
             <button
               onClick={handleDismiss}
-              className="hidden lg:flex p-2 hover:bg-surface-700 rounded-lg text-muted-foreground hover:text-foreground flex-shrink-0"
+              className="hidden lg:flex p-2 hover:bg-surface-200 rounded-lg text-muted-foreground hover:text-foreground flex-shrink-0"
               title="Dismiss"
             >
               <XMarkIcon className="h-5 w-5" />
@@ -158,7 +158,7 @@ function FeatureCard({
   description: string;
 }) {
   return (
-    <div className="flex items-center gap-2 p-2 bg-surface-800/50 rounded-lg">
+    <div className="flex items-center gap-2 p-2 bg-white/50 rounded-lg">
       <Icon className="h-5 w-5 text-brand-400 flex-shrink-0" />
       <div className="min-w-0">
         <p className="text-xs font-medium text-foreground truncate">{label}</p>

--- a/frontend/src/components/OnboardingTour.tsx
+++ b/frontend/src/components/OnboardingTour.tsx
@@ -212,9 +212,9 @@ export function OnboardingTour({ isOpen, onClose, onComplete }: OnboardingTourPr
               leaveFrom="opacity-100 scale-100"
               leaveTo="opacity-0 scale-95"
             >
-              <Dialog.Panel className="w-full max-w-lg transform overflow-hidden rounded-2xl bg-gradient-to-br from-surface-800 to-surface-900 border border-surface-700 shadow-2xl transition-all">
+              <Dialog.Panel className="w-full max-w-lg transform overflow-hidden rounded-2xl bg-gradient-to-br from-surface-800 to-surface-900 border border-surface-200 shadow-2xl transition-all">
                 {/* Progress Bar */}
-                <div className="h-1 bg-surface-700">
+                <div className="h-1 bg-surface-200">
                   <div
                     className="h-full bg-gradient-to-r from-brand-500 to-brand-400 transition-all duration-300"
                     style={{ width: `${progress}%` }}
@@ -248,7 +248,7 @@ export function OnboardingTour({ isOpen, onClose, onComplete }: OnboardingTourPr
 
                   {/* Tips */}
                   {step.tips && step.tips.length > 0 && (
-                    <div className="bg-surface-800/50 rounded-xl p-4 mb-6 text-left">
+                    <div className="bg-white/50 rounded-xl p-4 mb-6 text-left">
                       <p className="text-xs font-semibold text-surface-600 uppercase tracking-wider mb-3">
                         Pro Tips
                       </p>
@@ -291,7 +291,7 @@ export function OnboardingTour({ isOpen, onClose, onComplete }: OnboardingTourPr
                 </div>
 
                 {/* Footer */}
-                <div className="flex items-center justify-between px-8 py-4 border-t border-surface-700 bg-surface-800/50">
+                <div className="flex items-center justify-between px-8 py-4 border-t border-surface-200 bg-white/50">
                   <button
                     onClick={handlePrev}
                     disabled={isFirst}
@@ -299,7 +299,7 @@ export function OnboardingTour({ isOpen, onClose, onComplete }: OnboardingTourPr
                       'px-4 py-2 text-sm font-medium rounded-lg transition-colors',
                       isFirst
                         ? 'text-surface-600 cursor-not-allowed'
-                        : 'text-surface-700 hover:text-white hover:bg-surface-700'
+                        : 'text-surface-700 hover:text-white hover:bg-surface-200'
                     )}
                   >
                     Previous
@@ -390,7 +390,7 @@ export function WelcomeBanner({
           </button>
           <button
             onClick={onDismiss}
-            className="p-1.5 rounded-lg hover:bg-surface-700 text-surface-600 hover:text-white transition-colors"
+            className="p-1.5 rounded-lg hover:bg-surface-200 text-surface-600 hover:text-white transition-colors"
           >
             <XMarkIcon className="w-4 h-4" />
           </button>

--- a/frontend/src/components/OnboardingWizard.tsx
+++ b/frontend/src/components/OnboardingWizard.tsx
@@ -145,10 +145,10 @@ export function OnboardingWizard({ onDismiss }: OnboardingWizardProps) {
   }
 
   return (
-    <div className="bg-surface-800 border border-surface-700 rounded-xl p-6 mb-6">
+    <div className="bg-white border border-surface-200 rounded-xl p-6 mb-6">
       <div className="flex items-start justify-between mb-6">
         <div>
-          <h2 className="text-xl font-semibold text-surface-100">Welcome to GigaChad GRC! 🚀</h2>
+          <h2 className="text-xl font-semibold text-surface-900">Welcome to GigaChad GRC! 🚀</h2>
           <p className="text-surface-600 mt-1">
             Complete these steps to set up your compliance program
           </p>
@@ -170,7 +170,7 @@ export function OnboardingWizard({ onDismiss }: OnboardingWizardProps) {
             {completedSteps}/{steps.length} complete
           </span>
         </div>
-        <div className="h-2 bg-surface-700 rounded-full overflow-hidden">
+        <div className="h-2 bg-surface-200 rounded-full overflow-hidden">
           <div
             className="h-full bg-blue-500 transition-all duration-500"
             style={{ width: `${progress}%` }}
@@ -194,14 +194,14 @@ export function OnboardingWizard({ onDismiss }: OnboardingWizardProps) {
                     ? 'bg-green-900/20 border-green-800'
                     : isNext
                       ? 'bg-blue-900/20 border-blue-700'
-                      : 'bg-surface-900 border-surface-700'
+                      : 'bg-white border-surface-200'
                 }
               `}
             >
               <div
                 className={`
                 p-2 rounded-lg
-                ${step.isComplete ? 'bg-green-800' : isNext ? 'bg-blue-800' : 'bg-surface-700'}
+                ${step.isComplete ? 'bg-green-800' : isNext ? 'bg-blue-800' : 'bg-surface-200'}
               `}
               >
                 {step.isComplete ? (
@@ -213,7 +213,7 @@ export function OnboardingWizard({ onDismiss }: OnboardingWizardProps) {
 
               <div className="flex-1">
                 <h4
-                  className={`font-medium ${step.isComplete ? 'text-green-600' : 'text-surface-100'}`}
+                  className={`font-medium ${step.isComplete ? 'text-green-600' : 'text-surface-900'}`}
                 >
                   {step.title}
                 </h4>
@@ -229,7 +229,7 @@ export function OnboardingWizard({ onDismiss }: OnboardingWizardProps) {
                     ${
                       isNext
                         ? 'bg-blue-600 text-white hover:bg-blue-700'
-                        : 'bg-surface-700 text-surface-700 hover:bg-surface-600'
+                        : 'bg-surface-200 text-surface-700 hover:bg-surface-600'
                     }
                   `}
                 >
@@ -247,7 +247,7 @@ export function OnboardingWizard({ onDismiss }: OnboardingWizardProps) {
       </div>
 
       {/* Help text */}
-      <div className="mt-6 pt-4 border-t border-surface-700">
+      <div className="mt-6 pt-4 border-t border-surface-200">
         <p className="text-surface-600 text-sm">
           Need help getting started?{' '}
           <button onClick={() => navigate('/help')} className="text-blue-600 hover:text-blue-700">

--- a/frontend/src/components/ProductionReadiness.tsx
+++ b/frontend/src/components/ProductionReadiness.tsx
@@ -60,7 +60,7 @@ export function ProductionReadiness() {
 
   if (loading) {
     return (
-      <div className="bg-surface-800 rounded-xl p-6">
+      <div className="bg-white rounded-xl p-6">
         <div className="flex items-center justify-center py-8">
           <ArrowPathIcon className="h-6 w-6 animate-spin text-primary" />
           <span className="ml-2 text-foreground/60">Analyzing system...</span>
@@ -71,7 +71,7 @@ export function ProductionReadiness() {
 
   if (error || !data) {
     return (
-      <div className="bg-surface-800 rounded-xl p-6">
+      <div className="bg-white rounded-xl p-6">
         <div className="text-center py-8">
           <ExclamationTriangleIcon className="h-12 w-12 mx-auto text-yellow-500 mb-3" />
           <p className="text-foreground/60">{error || 'Unable to load data'}</p>
@@ -93,7 +93,7 @@ export function ProductionReadiness() {
     data.score >= 80 ? 'bg-green-500/20' : data.score >= 60 ? 'bg-yellow-500/20' : 'bg-red-500/20';
 
   return (
-    <div className="bg-surface-800 rounded-xl overflow-hidden">
+    <div className="bg-white rounded-xl overflow-hidden">
       {/* Header with score */}
       <div className="p-6 border-b border-white/10">
         <div className="flex items-center justify-between">

--- a/frontend/src/components/QuickActions.tsx
+++ b/frontend/src/components/QuickActions.tsx
@@ -72,7 +72,7 @@ export function QuickActions({ className }: QuickActionsProps) {
   ];
 
   return (
-    <div className={clsx('bg-surface-800 rounded-xl border border-surface-700 p-4', className)}>
+    <div className={clsx('bg-white rounded-xl border border-surface-200 p-4', className)}>
       <h3 className="font-medium text-white mb-4 flex items-center gap-2">
         <PlusIcon className="w-5 h-5 text-brand-400" />
         Quick Actions
@@ -85,7 +85,7 @@ export function QuickActions({ className }: QuickActionsProps) {
             className={clsx(
               'flex flex-col items-center p-3 rounded-lg transition-all',
               action.color,
-              'border border-transparent hover:border-surface-600'
+              'border border-transparent hover:border-surface-300'
             )}
           >
             <action.icon className="w-6 h-6 mb-2" />
@@ -138,12 +138,12 @@ export function QuickActionsBar() {
   ];
 
   return (
-    <div className="flex items-center gap-2 bg-surface-800/50 rounded-lg p-1">
+    <div className="flex items-center gap-2 bg-white/50 rounded-lg p-1">
       {actions.map((action) => (
         <button
           key={action.id}
           onClick={action.action}
-          className="flex items-center gap-2 px-3 py-1.5 rounded-md text-surface-600 hover:text-white hover:bg-surface-700 transition-colors"
+          className="flex items-center gap-2 px-3 py-1.5 rounded-md text-surface-600 hover:text-white hover:bg-surface-200 transition-colors"
           title={action.label}
         >
           <action.icon className="w-4 h-4" />

--- a/frontend/src/components/ReportDownloadButton.tsx
+++ b/frontend/src/components/ReportDownloadButton.tsx
@@ -139,7 +139,7 @@ export function ReportDownloadButton({
   // Menu variant with all report types
   return (
     <Menu as="div" className={`relative inline-block text-left ${className}`}>
-      <Menu.Button className="inline-flex items-center gap-2 px-4 py-2 rounded-lg font-medium bg-surface-700 text-surface-100 hover:bg-surface-600 transition-colors">
+      <Menu.Button className="inline-flex items-center gap-2 px-4 py-2 rounded-lg font-medium bg-surface-200 text-surface-900 hover:bg-surface-600 transition-colors">
         <DocumentChartBarIcon className="h-5 w-5" />
         Generate Report
       </Menu.Button>
@@ -153,7 +153,7 @@ export function ReportDownloadButton({
         leaveFrom="transform opacity-100 scale-100"
         leaveTo="transform opacity-0 scale-95"
       >
-        <Menu.Items className="absolute right-0 mt-2 w-72 origin-top-right rounded-lg bg-surface-800 border border-surface-700 shadow-lg focus:outline-none z-50">
+        <Menu.Items className="absolute right-0 mt-2 w-72 origin-top-right rounded-lg bg-white border border-surface-200 shadow-lg focus:outline-none z-50">
           <div className="p-2">
             <p className="px-3 py-2 text-xs font-medium text-surface-600 uppercase tracking-wider">
               Download Reports
@@ -171,7 +171,7 @@ export function ReportDownloadButton({
                       disabled={isDisabled || isDownloading}
                       className={`
                         w-full text-left px-3 py-2 rounded-md flex items-start gap-3
-                        ${active && !isDisabled ? 'bg-surface-700' : ''}
+                        ${active && !isDisabled ? 'bg-surface-200' : ''}
                         ${isDisabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}
                       `}
                     >
@@ -198,7 +198,7 @@ export function ReportDownloadButton({
                         )}
                       </div>
                       <div>
-                        <p className="text-sm font-medium text-surface-100">{report.name}</p>
+                        <p className="text-sm font-medium text-surface-900">{report.name}</p>
                         <p className="text-xs text-surface-600">
                           {report.description}
                           {report.requiresFramework && !frameworkId && (

--- a/frontend/src/components/ScheduledReports.tsx
+++ b/frontend/src/components/ScheduledReports.tsx
@@ -168,7 +168,7 @@ export function ScheduledReports({ className }: ScheduledReportsProps) {
           <div className="animate-spin h-8 w-8 border-2 border-indigo-500 border-t-transparent rounded-full"></div>
         </div>
       ) : reports.length === 0 ? (
-        <div className="text-center py-12 bg-surface-800 border border-surface-700 rounded-xl">
+        <div className="text-center py-12 bg-white border border-surface-200 rounded-xl">
           <ClockIcon className="w-12 h-12 mx-auto text-surface-600 mb-4" />
           <h3 className="text-lg font-medium text-surface-700 mb-2">No scheduled reports</h3>
           <p className="text-surface-500 mb-4">
@@ -231,8 +231,8 @@ function ReportCard({ report, onEdit, onDelete, onToggle, onRunNow }: ReportCard
   return (
     <div
       className={clsx(
-        'bg-surface-800 border rounded-xl p-4',
-        report.enabled ? 'border-surface-700' : 'border-surface-700/50 opacity-60'
+        'bg-white border rounded-xl p-4',
+        report.enabled ? 'border-surface-200' : 'border-surface-200/50 opacity-60'
       )}
     >
       <div className="flex items-start justify-between">
@@ -240,7 +240,7 @@ function ReportCard({ report, onEdit, onDelete, onToggle, onRunNow }: ReportCard
           <div
             className={clsx(
               'p-2 rounded-lg',
-              report.enabled ? 'bg-brand-500/20' : 'bg-surface-700'
+              report.enabled ? 'bg-brand-500/20' : 'bg-surface-200'
             )}
           >
             <DocumentChartBarIcon
@@ -248,7 +248,7 @@ function ReportCard({ report, onEdit, onDelete, onToggle, onRunNow }: ReportCard
             />
           </div>
           <div>
-            <h3 className="font-medium text-surface-100">{report.name}</h3>
+            <h3 className="font-medium text-surface-900">{report.name}</h3>
             <p className="text-sm text-surface-600 mt-1">
               {reportType?.label || report.reportType} • {report.format.toUpperCase()}
             </p>
@@ -285,7 +285,7 @@ function ReportCard({ report, onEdit, onDelete, onToggle, onRunNow }: ReportCard
               'p-2 rounded-lg transition-colors',
               report.enabled
                 ? 'bg-green-500/20 text-green-600 hover:bg-green-500/30'
-                : 'bg-surface-700 text-surface-500 hover:bg-surface-600'
+                : 'bg-surface-200 text-surface-500 hover:bg-surface-600'
             )}
             title={report.enabled ? 'Disable' : 'Enable'}
           >
@@ -295,12 +295,12 @@ function ReportCard({ report, onEdit, onDelete, onToggle, onRunNow }: ReportCard
               <PauseIcon className="w-5 h-5" />
             )}
           </button>
-          <button onClick={onEdit} className="p-2 hover:bg-surface-700 rounded-lg text-surface-600">
+          <button onClick={onEdit} className="p-2 hover:bg-surface-200 rounded-lg text-surface-600">
             <PencilIcon className="w-5 h-5" />
           </button>
           <button
             onClick={onDelete}
-            className="p-2 hover:bg-surface-700 rounded-lg text-surface-600 hover:text-red-600"
+            className="p-2 hover:bg-surface-200 rounded-lg text-surface-600 hover:text-red-600"
           >
             <TrashIcon className="w-5 h-5" />
           </button>
@@ -421,7 +421,7 @@ function ReportScheduleModal({ isOpen, onClose, report, onSave }: ReportSchedule
             value={formData.name}
             onChange={(e) => setFormData({ ...formData, name: e.target.value })}
             placeholder="Weekly Risk Summary"
-            className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white placeholder-surface-500"
+            className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white placeholder-surface-500"
           />
         </div>
 
@@ -431,7 +431,7 @@ function ReportScheduleModal({ isOpen, onClose, report, onSave }: ReportSchedule
           <SelectNative
             value={formData.reportType}
             onChange={(e) => setFormData({ ...formData, reportType: e.target.value })}
-            className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+            className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
           >
             {REPORT_TYPES.map((type) => (
               <option key={type.value} value={type.value}>
@@ -454,7 +454,7 @@ function ReportScheduleModal({ isOpen, onClose, report, onSave }: ReportSchedule
                   'px-4 py-2 rounded-lg text-sm',
                   formData.format === format
                     ? 'bg-brand-500 text-white'
-                    : 'bg-surface-700 text-surface-700 hover:bg-surface-600'
+                    : 'bg-surface-200 text-surface-700 hover:bg-surface-600'
                 )}
               >
                 {format.toUpperCase()}
@@ -469,7 +469,7 @@ function ReportScheduleModal({ isOpen, onClose, report, onSave }: ReportSchedule
           <SelectNative
             value={formData.frequency}
             onChange={(e) => setFormData({ ...formData, frequency: e.target.value as any })}
-            className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+            className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
           >
             {FREQUENCY_OPTIONS.map((opt) => (
               <option key={opt.value} value={opt.value}>
@@ -486,7 +486,7 @@ function ReportScheduleModal({ isOpen, onClose, report, onSave }: ReportSchedule
             <SelectNative
               value={formData.dayOfWeek}
               onChange={(e) => setFormData({ ...formData, dayOfWeek: Number(e.target.value) })}
-              className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+              className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
             >
               {DAYS_OF_WEEK.map((day) => (
                 <option key={day.value} value={day.value}>
@@ -503,7 +503,7 @@ function ReportScheduleModal({ isOpen, onClose, report, onSave }: ReportSchedule
             <SelectNative
               value={formData.dayOfMonth}
               onChange={(e) => setFormData({ ...formData, dayOfMonth: Number(e.target.value) })}
-              className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+              className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
             >
               {Array.from({ length: 31 }, (_, i) => i + 1).map((day) => (
                 <option key={day} value={day}>
@@ -525,7 +525,7 @@ function ReportScheduleModal({ isOpen, onClose, report, onSave }: ReportSchedule
             type="time"
             value={formData.time}
             onChange={(e) => setFormData({ ...formData, time: e.target.value })}
-            className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+            className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
           />
         </div>
 
@@ -539,12 +539,12 @@ function ReportScheduleModal({ isOpen, onClose, report, onSave }: ReportSchedule
             value={formData.recipients}
             onChange={(e) => setFormData({ ...formData, recipients: e.target.value })}
             placeholder="john@example.com, jane@example.com"
-            className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white placeholder-surface-500"
+            className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white placeholder-surface-500"
           />
         </div>
 
         {/* Actions */}
-        <div className="flex justify-end gap-3 pt-4 border-t border-surface-700">
+        <div className="flex justify-end gap-3 pt-4 border-t border-surface-200">
           <Button variant="secondary" onClick={onClose}>
             Cancel
           </Button>

--- a/frontend/src/components/SetupWizard.tsx
+++ b/frontend/src/components/SetupWizard.tsx
@@ -194,7 +194,7 @@ export function SetupWizard({ onClose }: { onClose: () => void }) {
             <span className="text-foreground/60">Setup Progress</span>
             <span className="text-foreground font-medium">{progress}%</span>
           </div>
-          <div className="h-2 bg-surface-700 rounded-full overflow-hidden">
+          <div className="h-2 bg-surface-200 rounded-full overflow-hidden">
             <div
               className={`h-full transition-all duration-500 ${
                 progress === 100 ? 'bg-green-500' : 'bg-primary'
@@ -227,7 +227,7 @@ export function SetupWizard({ onClose }: { onClose: () => void }) {
                           ? 'bg-green-500/20 text-green-600'
                           : isActive
                             ? 'bg-primary/20 text-primary'
-                            : 'bg-surface-700 text-foreground/40'
+                            : 'bg-surface-200 text-foreground/40'
                       }`}
                     >
                       {isCompleted ? (
@@ -286,7 +286,7 @@ export function SetupWizard({ onClose }: { onClose: () => void }) {
 
                 {currentStepData.status !== 'completed' && (
                   <>
-                    <div className="bg-surface-700/50 rounded-lg p-4 mb-4">
+                    <div className="bg-surface-200/50 rounded-lg p-4 mb-4">
                       <h4 className="text-sm font-medium text-foreground mb-3">Instructions</h4>
                       <ol className="space-y-2">
                         {currentStepData.instructions.map((instruction, i) => (
@@ -299,7 +299,7 @@ export function SetupWizard({ onClose }: { onClose: () => void }) {
                     </div>
 
                     {currentStepData.commands && currentStepData.commands.length > 0 && (
-                      <div className="bg-surface-900 rounded-lg p-4">
+                      <div className="bg-white rounded-lg p-4">
                         <h4 className="text-sm font-medium text-foreground mb-3">Commands</h4>
                         <div className="space-y-2">
                           {currentStepData.commands.map((command, i) => (

--- a/frontend/src/components/TasksPanel.tsx
+++ b/frontend/src/components/TasksPanel.tsx
@@ -120,7 +120,7 @@ export default function TasksPanel({ entityType, entityId }: TasksPanelProps) {
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <ClipboardDocumentListIcon className="w-5 h-5 text-surface-600" />
-          <h3 className="text-sm font-semibold text-surface-100">
+          <h3 className="text-sm font-semibold text-surface-900">
             Tasks ({openTasks.length} open)
           </h3>
         </div>
@@ -374,7 +374,7 @@ function TaskCard({
   return (
     <div
       className={clsx(
-        'card p-3 cursor-pointer hover:bg-surface-800 transition-colors',
+        'card p-3 cursor-pointer hover:bg-white transition-colors',
         task.status === 'completed' && 'opacity-60'
       )}
       onClick={onEdit}
@@ -389,7 +389,7 @@ function TaskCard({
           </div>
           <p
             className={clsx(
-              'text-sm font-medium text-surface-200',
+              'text-sm font-medium text-surface-800',
               task.status === 'completed' && 'line-through'
             )}
           >
@@ -421,7 +421,7 @@ function TaskCard({
                 e.stopPropagation();
                 onUpdate({ status: 'completed' });
               }}
-              className="p-1 rounded text-surface-500 hover:text-green-600 hover:bg-surface-700 transition-colors"
+              className="p-1 rounded text-surface-500 hover:text-green-600 hover:bg-surface-200 transition-colors"
               title="Mark complete"
             >
               <CheckIcon className="w-4 h-4" />
@@ -432,7 +432,7 @@ function TaskCard({
               e.stopPropagation();
               onDelete();
             }}
-            className="p-1 rounded text-surface-500 hover:text-red-600 hover:bg-surface-700 transition-colors"
+            className="p-1 rounded text-surface-500 hover:text-red-600 hover:bg-surface-200 transition-colors"
             title="Delete"
           >
             <TrashIcon className="w-4 h-4" />

--- a/frontend/src/components/VirtualTable.tsx
+++ b/frontend/src/components/VirtualTable.tsx
@@ -63,13 +63,13 @@ function VirtualTableInner<T>({
     return (
       <div className={clsx('card overflow-hidden', className)}>
         <div className="animate-pulse">
-          <div className="h-12 bg-surface-800 border-b border-surface-700" />
+          <div className="h-12 bg-white border-b border-surface-200" />
           {Array.from({ length: 10 }).map((_, i) => (
-            <div key={i} className="h-13 border-b border-surface-800 flex items-center px-4 gap-4">
-              <div className="h-4 bg-surface-700 rounded w-1/4" />
-              <div className="h-4 bg-surface-700 rounded w-1/3" />
-              <div className="h-4 bg-surface-700 rounded w-1/6" />
-              <div className="h-4 bg-surface-700 rounded w-1/6" />
+            <div key={i} className="h-13 border-b border-surface-200 flex items-center px-4 gap-4">
+              <div className="h-4 bg-surface-200 rounded w-1/4" />
+              <div className="h-4 bg-surface-200 rounded w-1/3" />
+              <div className="h-4 bg-surface-200 rounded w-1/6" />
+              <div className="h-4 bg-surface-200 rounded w-1/6" />
             </div>
           ))}
         </div>
@@ -92,7 +92,7 @@ function VirtualTableInner<T>({
       {/* Fixed header */}
       <div
         className={clsx(
-          'flex items-center bg-surface-800 border-b border-surface-700 sticky top-0 z-10',
+          'flex items-center bg-white border-b border-surface-200 sticky top-0 z-10',
           headerClassName
         )}
         style={{ height: rowHeight }}
@@ -134,8 +134,8 @@ function VirtualTableInner<T>({
                 key={rowKey}
                 data-index={virtualRow.index}
                 className={clsx(
-                  'absolute top-0 left-0 w-full flex items-center border-b border-surface-800 transition-colors',
-                  onRowClick && 'cursor-pointer hover:bg-surface-800/50',
+                  'absolute top-0 left-0 w-full flex items-center border-b border-surface-200 transition-colors',
+                  onRowClick && 'cursor-pointer hover:bg-white/50',
                   isSelected && 'bg-brand-500/10',
                   rowClasses
                 )}

--- a/frontend/src/components/VirtualizedTable.tsx
+++ b/frontend/src/components/VirtualizedTable.tsx
@@ -121,17 +121,17 @@ export function VirtualizedTable<T>({
   }
 
   return (
-    <div className={clsx('border border-surface-700 rounded-lg overflow-hidden', className)}>
+    <div className={clsx('border border-surface-200 rounded-lg overflow-hidden', className)}>
       {/* Header */}
       <div
         className={clsx(
-          'flex bg-surface-800 border-b border-surface-700',
+          'flex bg-white border-b border-surface-200',
           stickyHeader && 'sticky top-0 z-10'
         )}
         style={{ minHeight: rowHeight }}
       >
         {selectedIds && onSelectionChange && (
-          <div className="flex items-center justify-center w-12 px-3 border-r border-surface-700">
+          <div className="flex items-center justify-center w-12 px-3 border-r border-surface-200">
             <input
               type="checkbox"
               checked={allSelected}
@@ -139,7 +139,7 @@ export function VirtualizedTable<T>({
                 if (el) el.indeterminate = someSelected ?? false;
               }}
               onChange={(e) => handleSelectAll(e.target.checked)}
-              className="w-4 h-4 rounded border-surface-600 bg-surface-700 text-brand-500 focus:ring-brand-500 focus:ring-offset-0"
+              className="w-4 h-4 rounded border-surface-300 bg-surface-200 text-brand-500 focus:ring-brand-500 focus:ring-offset-0"
             />
           </div>
         )}
@@ -180,8 +180,8 @@ export function VirtualizedTable<T>({
                 key={rowKey}
                 data-index={virtualRow.index}
                 className={clsx(
-                  'flex absolute top-0 left-0 w-full border-b border-surface-800 transition-colors',
-                  onRowClick && 'cursor-pointer hover:bg-surface-800/50',
+                  'flex absolute top-0 left-0 w-full border-b border-surface-200 transition-colors',
+                  onRowClick && 'cursor-pointer hover:bg-white/50',
                   isSelected && 'bg-brand-500/10'
                 )}
                 style={{
@@ -192,14 +192,14 @@ export function VirtualizedTable<T>({
               >
                 {selectedIds && onSelectionChange && (
                   <div
-                    className="flex items-center justify-center w-12 px-3 border-r border-surface-800"
+                    className="flex items-center justify-center w-12 px-3 border-r border-surface-200"
                     onClick={(e) => e.stopPropagation()}
                   >
                     <input
                       type="checkbox"
                       checked={isSelected}
                       onChange={(e) => handleRowSelect(rowKey, e.target.checked)}
-                      className="w-4 h-4 rounded border-surface-600 bg-surface-700 text-brand-500 focus:ring-brand-500 focus:ring-offset-0"
+                      className="w-4 h-4 rounded border-surface-300 bg-surface-200 text-brand-500 focus:ring-brand-500 focus:ring-offset-0"
                     />
                   </div>
                 )}
@@ -226,7 +226,7 @@ export function VirtualizedTable<T>({
       </div>
 
       {/* Footer with count */}
-      <div className="flex items-center justify-between px-4 py-2 bg-surface-800/50 border-t border-surface-700 text-xs text-muted-foreground">
+      <div className="flex items-center justify-between px-4 py-2 bg-white/50 border-t border-surface-200 text-xs text-muted-foreground">
         <span>
           {selectedIds && selectedIds.size > 0
             ? `${selectedIds.size} of ${data.length} selected`

--- a/frontend/src/components/WorkspaceSwitcher.tsx
+++ b/frontend/src/components/WorkspaceSwitcher.tsx
@@ -127,7 +127,7 @@ export function WorkspaceSwitcher() {
   return (
     <>
       <Menu as="div" className="relative">
-        <Menu.Button className="flex items-center gap-2 px-3 py-2 rounded-lg bg-surface-800 hover:bg-surface-700 border border-surface-600 transition-colors text-sm text-foreground">
+        <Menu.Button className="flex items-center gap-2 px-3 py-2 rounded-lg bg-white hover:bg-surface-200 border border-surface-300 transition-colors text-sm text-foreground">
           <BuildingOfficeIcon className="w-4 h-4 text-surface-700" />
           <span className="font-medium max-w-[160px] truncate">
             {currentWorkspace?.name || 'Select Workspace'}
@@ -144,7 +144,7 @@ export function WorkspaceSwitcher() {
           leaveFrom="transform opacity-100 scale-100"
           leaveTo="transform opacity-0 scale-95"
         >
-          <Menu.Items className="absolute left-0 mt-2 w-64 rounded-lg bg-surface-800 border border-surface-700 shadow-lg z-50 py-1 focus:outline-none">
+          <Menu.Items className="absolute left-0 mt-2 w-64 rounded-lg bg-white border border-surface-200 shadow-lg z-50 py-1 focus:outline-none">
             {/* Workspace List */}
             <div className="px-2 py-1">
               <p className="text-xs text-muted-foreground uppercase tracking-wider px-2 py-1">
@@ -159,7 +159,7 @@ export function WorkspaceSwitcher() {
                     <button
                       onClick={() => handleWorkspaceSelect(workspace)}
                       className={`w-full text-left px-4 py-2 text-sm flex items-center gap-2 ${
-                        active ? 'bg-surface-700' : ''
+                        active ? 'bg-surface-200' : ''
                       } ${
                         currentWorkspace?.id === workspace.id ? 'text-brand-400' : 'text-foreground'
                       }`}
@@ -185,7 +185,7 @@ export function WorkspaceSwitcher() {
             </div>
 
             {/* Actions */}
-            <div className="border-t border-surface-700 mt-1 pt-1">
+            <div className="border-t border-surface-200 mt-1 pt-1">
               {/* View All Workspaces (Admin) */}
               {user?.role === 'admin' && (
                 <Menu.Item>
@@ -193,7 +193,7 @@ export function WorkspaceSwitcher() {
                     <button
                       onClick={() => navigate('/settings/workspaces')}
                       className={`w-full text-left px-4 py-2 text-sm flex items-center gap-2 ${
-                        active ? 'bg-surface-700' : ''
+                        active ? 'bg-surface-200' : ''
                       } text-muted-foreground hover:text-foreground`}
                     >
                       <ChartBarIcon className="w-4 h-4" />
@@ -210,7 +210,7 @@ export function WorkspaceSwitcher() {
                     <button
                       onClick={() => navigate(`/settings/workspaces/${currentWorkspace.id}`)}
                       className={`w-full text-left px-4 py-2 text-sm flex items-center gap-2 ${
-                        active ? 'bg-surface-700' : ''
+                        active ? 'bg-surface-200' : ''
                       } text-muted-foreground hover:text-foreground`}
                     >
                       <Cog6ToothIcon className="w-4 h-4" />
@@ -227,7 +227,7 @@ export function WorkspaceSwitcher() {
                     <button
                       onClick={() => setShowCreateModal(true)}
                       className={`w-full text-left px-4 py-2 text-sm flex items-center gap-2 ${
-                        active ? 'bg-surface-700' : ''
+                        active ? 'bg-surface-200' : ''
                       } text-brand-400 hover:text-brand-300`}
                     >
                       <PlusIcon className="w-4 h-4" />

--- a/frontend/src/components/ai/AIAssistantPanel.tsx
+++ b/frontend/src/components/ai/AIAssistantPanel.tsx
@@ -94,9 +94,9 @@ export default function AIAssistantPanel({ isOpen, onClose }: AIAssistantPanelPr
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-y-0 right-0 w-96 bg-surface-900 border-l border-surface-800 shadow-2xl z-50 flex flex-col">
+    <div className="fixed inset-y-0 right-0 w-96 bg-white border-l border-surface-200 shadow-2xl z-50 flex flex-col">
       {/* Header */}
-      <div className="flex items-center justify-between p-4 border-b border-surface-800">
+      <div className="flex items-center justify-between p-4 border-b border-surface-200">
         <div className="flex items-center gap-3">
           <div className="p-2 bg-gradient-to-br from-purple-500 to-blue-500 rounded-lg">
             <SparklesIcon className="w-5 h-5 text-white" />
@@ -110,7 +110,7 @@ export default function AIAssistantPanel({ isOpen, onClose }: AIAssistantPanelPr
         </div>
         <button
           onClick={onClose}
-          className="p-1.5 text-surface-600 hover:text-white rounded-lg hover:bg-surface-800 transition-colors"
+          className="p-1.5 text-surface-600 hover:text-white rounded-lg hover:bg-white transition-colors"
         >
           <XMarkIcon className="w-5 h-5" />
         </button>
@@ -162,7 +162,7 @@ export default function AIAssistantPanel({ isOpen, onClose }: AIAssistantPanelPr
 
       {/* Mock Mode Info Banner */}
       {isMockMode && (
-        <div className="mx-4 mt-2 p-2 rounded-lg bg-surface-800/50 border border-surface-700">
+        <div className="mx-4 mt-2 p-2 rounded-lg bg-white/50 border border-surface-200">
           <p className="text-xs text-surface-600">
             <span className="text-amber-600 font-medium">Demo Mode:</span> AI responses are
             generated from policy templates. Perfect for testing and demonstrations. Add an API key
@@ -182,8 +182,8 @@ export default function AIAssistantPanel({ isOpen, onClose }: AIAssistantPanelPr
               className={clsx(
                 'w-full p-4 rounded-xl border transition-all text-left group',
                 isUsable
-                  ? 'border-surface-700 hover:border-purple-500/50 hover:bg-surface-800/50'
-                  : 'border-surface-800 opacity-50 cursor-not-allowed',
+                  ? 'border-surface-200 hover:border-purple-500/50 hover:bg-white/50'
+                  : 'border-surface-200 opacity-50 cursor-not-allowed',
                 selectedFeature === feature.id && 'border-purple-500 bg-purple-500/10'
               )}
             >
@@ -218,7 +218,7 @@ export default function AIAssistantPanel({ isOpen, onClose }: AIAssistantPanelPr
 
       {/* Feature Detail Panel */}
       {selectedFeature && isUsable && (
-        <div className="border-t border-surface-800 p-4 max-h-[40%] overflow-y-auto">
+        <div className="border-t border-surface-200 p-4 max-h-[40%] overflow-y-auto">
           {selectedFeature === 'risk-scoring' && <RiskScoringPanel isMockMode={isMockMode} />}
           {selectedFeature === 'categorization' && <CategorizationPanel isMockMode={isMockMode} />}
           {selectedFeature === 'mapping' && <MappingPanel isMockMode={isMockMode} />}
@@ -235,7 +235,7 @@ export default function AIAssistantPanel({ isOpen, onClose }: AIAssistantPanelPr
       )}
 
       {/* Quick Tip */}
-      <div className="p-4 border-t border-surface-800 bg-surface-800/50">
+      <div className="p-4 border-t border-surface-200 bg-white/50">
         <p className="text-xs text-surface-600">
           <span className="text-purple-600 font-medium">Tip:</span> AI features are also available
           directly in forms. Look for the{' '}
@@ -418,10 +418,10 @@ function SettingsPanel({ config, isMockMode, mockModeReason }: SettingsPanelProp
 
       <p className="text-xs text-surface-500 mt-2">
         To enable full AI capabilities, set environment variables:
-        <code className="block mt-1 p-2 bg-surface-800 rounded text-surface-700">
+        <code className="block mt-1 p-2 bg-white rounded text-surface-700">
           OPENAI_API_KEY=sk-...
         </code>
-        <code className="block mt-1 p-2 bg-surface-800 rounded text-surface-700">
+        <code className="block mt-1 p-2 bg-white rounded text-surface-700">
           ANTHROPIC_API_KEY=sk-ant-...
         </code>
       </p>

--- a/frontend/src/components/ai/AICategorization.tsx
+++ b/frontend/src/components/ai/AICategorization.tsx
@@ -102,7 +102,7 @@ export default function AICategorization({
             <div className="text-xs text-surface-600">Suggested Category</div>
             <button
               onClick={() => handleSelectCategory(result.suggestedCategory)}
-              className="w-full flex items-center justify-between p-2 bg-surface-800/50 hover:bg-surface-800 rounded-lg transition-colors group"
+              className="w-full flex items-center justify-between p-2 bg-white/50 hover:bg-white rounded-lg transition-colors group"
             >
               <div className="flex items-center gap-2">
                 <span className="text-white font-medium">{result.suggestedCategory}</span>
@@ -129,7 +129,7 @@ export default function AICategorization({
                   <button
                     key={i}
                     onClick={() => handleSelectCategory(alt.category)}
-                    className="w-full flex items-center justify-between p-2 bg-surface-800/30 hover:bg-surface-800/50 rounded-lg transition-colors text-sm group"
+                    className="w-full flex items-center justify-between p-2 bg-white/30 hover:bg-white/50 rounded-lg transition-colors text-sm group"
                   >
                     <span className="text-surface-700">{alt.category}</span>
                     <div className="flex items-center gap-2">

--- a/frontend/src/components/ai/AIRiskScoring.tsx
+++ b/frontend/src/components/ai/AIRiskScoring.tsx
@@ -123,7 +123,7 @@ export default function AIRiskScoring({
         <div className="p-4 space-y-4">
           {/* Scores */}
           <div className="grid grid-cols-2 gap-4">
-            <div className="bg-surface-800/50 rounded-lg p-3">
+            <div className="bg-white/50 rounded-lg p-3">
               <div className="text-xs text-surface-600 mb-1">Suggested Likelihood</div>
               <div className="flex items-center gap-2">
                 <div
@@ -141,7 +141,7 @@ export default function AIRiskScoring({
               <p className="text-xs text-surface-600 mt-2">{result.likelihoodRationale}</p>
             </div>
 
-            <div className="bg-surface-800/50 rounded-lg p-3">
+            <div className="bg-white/50 rounded-lg p-3">
               <div className="text-xs text-surface-600 mb-1">Suggested Impact</div>
               <div className="flex items-center gap-2">
                 <div
@@ -197,7 +197,7 @@ export default function AIRiskScoring({
                 {result.relatedRisks.map((risk, i) => (
                   <span
                     key={i}
-                    className="px-2 py-1 bg-surface-700/50 rounded text-xs text-surface-700"
+                    className="px-2 py-1 bg-surface-200/50 rounded text-xs text-surface-700"
                   >
                     {risk}
                   </span>

--- a/frontend/src/components/ai/AISmartSearch.tsx
+++ b/frontend/src/components/ai/AISmartSearch.tsx
@@ -108,7 +108,7 @@ export default function AISmartSearch({
           onChange={(e) => handleInputChange(e.target.value)}
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
-          className="w-full pl-10 pr-24 py-3 bg-surface-800 border border-surface-700 rounded-xl text-white placeholder-surface-500 focus:outline-none focus:ring-2 focus:ring-purple-500/50 focus:border-purple-500 transition-all"
+          className="w-full pl-10 pr-24 py-3 bg-white border border-surface-200 rounded-xl text-white placeholder-surface-500 focus:outline-none focus:ring-2 focus:ring-purple-500/50 focus:border-purple-500 transition-all"
         />
 
         <div className="absolute inset-y-0 right-0 flex items-center gap-1 pr-2">
@@ -133,7 +133,7 @@ export default function AISmartSearch({
       </div>
       {/* Entity Filters */}
       {showFilters && (
-        <div className="flex flex-wrap gap-2 p-3 bg-surface-800/50 rounded-lg border border-surface-700">
+        <div className="flex flex-wrap gap-2 p-3 bg-white/50 rounded-lg border border-surface-200">
           <span className="text-xs text-surface-600 mr-2 self-center">Search in:</span>
           {ENTITY_OPTIONS.map((option) => (
             <button
@@ -143,7 +143,7 @@ export default function AISmartSearch({
                 'px-2.5 py-1 rounded-lg text-xs font-medium transition-all',
                 selectedEntities.includes(option.value)
                   ? 'bg-purple-500/30 text-purple-700 border border-purple-500/50'
-                  : 'bg-surface-700/50 text-surface-600 hover:text-white border border-transparent'
+                  : 'bg-surface-200/50 text-surface-600 hover:text-white border border-transparent'
               )}
             >
               {option.label}

--- a/frontend/src/components/charts/LazyCharts.tsx
+++ b/frontend/src/components/charts/LazyCharts.tsx
@@ -9,8 +9,8 @@ import React, { Suspense } from 'react';
 // Loading placeholder for charts
 function ChartLoading({ height = 200 }: { height?: number }) {
   return (
-    <div 
-      className="animate-pulse bg-surface-700/30 rounded-lg flex items-center justify-center"
+    <div
+      className="animate-pulse bg-surface-200/30 rounded-lg flex items-center justify-center"
       style={{ height }}
     >
       <div className="text-surface-500 text-sm">Loading chart...</div>
@@ -87,17 +87,17 @@ export function LazyPieChart({
 
 function LazyPieChartInner(props: LazyPieChartProps) {
   const { data, height, innerRadius, outerRadius, showLabel, showLegend, labelFormatter } = props;
-  
+
   const [recharts, setRecharts] = React.useState<typeof import('recharts') | null>(null);
-  
+
   React.useEffect(() => {
     import('recharts').then(setRecharts);
   }, []);
-  
+
   if (!recharts) return <ChartLoading height={height} />;
-  
+
   const { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } = recharts;
-  
+
   return (
     <ResponsiveContainer width="100%" height={height}>
       <PieChart>
@@ -108,12 +108,12 @@ function LazyPieChartInner(props: LazyPieChartProps) {
           innerRadius={innerRadius}
           outerRadius={outerRadius}
           dataKey="value"
-          label={showLabel ? (labelFormatter || (({ name, value }) => `${name}: ${value}`)) : false}
+          label={showLabel ? labelFormatter || (({ name, value }) => `${name}: ${value}`) : false}
         >
           {data.map((entry, index) => (
-            <Cell 
-              key={`cell-${index}`} 
-              fill={entry.color || CHART_COLORS[index % CHART_COLORS.length]} 
+            <Cell
+              key={`cell-${index}`}
+              fill={entry.color || CHART_COLORS[index % CHART_COLORS.length]}
             />
           ))}
         </Pie>
@@ -149,28 +149,28 @@ export function LazyBarChart({
 
 function LazyBarChartInner(props: LazyBarChartProps) {
   const { data, dataKey, xAxisKey, height, barColor, showGrid } = props;
-  
+
   const [recharts, setRecharts] = React.useState<typeof import('recharts') | null>(null);
-  
+
   React.useEffect(() => {
     import('recharts').then(setRecharts);
   }, []);
-  
+
   if (!recharts) return <ChartLoading height={height} />;
-  
+
   const { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid } = recharts;
-  
+
   return (
     <ResponsiveContainer width="100%" height={height}>
       <BarChart data={data}>
         {showGrid && <CartesianGrid strokeDasharray="3 3" stroke="#374151" />}
         <XAxis dataKey={xAxisKey} tick={{ fill: '#9ca3af', fontSize: 12 }} />
         <YAxis tick={{ fill: '#9ca3af', fontSize: 12 }} />
-        <Tooltip 
-          contentStyle={{ 
+        <Tooltip
+          contentStyle={{
             backgroundColor: '#1f2937',
             border: '1px solid #374151',
-            borderRadius: '0.5rem'
+            borderRadius: '0.5rem',
           }}
         />
         <Bar dataKey={dataKey} fill={barColor} radius={[4, 4, 0, 0]} />
@@ -206,34 +206,35 @@ export function LazyLineChart({
 
 function LazyLineChartInner(props: LazyLineChartProps) {
   const { data, dataKey, xAxisKey, height, lineColor, showGrid, showArea } = props;
-  
+
   const [recharts, setRecharts] = React.useState<typeof import('recharts') | null>(null);
-  
+
   React.useEffect(() => {
     import('recharts').then(setRecharts);
   }, []);
-  
+
   if (!recharts) return <ChartLoading height={height} />;
-  
-  const { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid, Area } = recharts;
-  
+
+  const { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid, Area } =
+    recharts;
+
   return (
     <ResponsiveContainer width="100%" height={height}>
       <LineChart data={data}>
         {showGrid && <CartesianGrid strokeDasharray="3 3" stroke="#374151" />}
         <XAxis dataKey={xAxisKey} tick={{ fill: '#9ca3af', fontSize: 12 }} />
         <YAxis tick={{ fill: '#9ca3af', fontSize: 12 }} />
-        <Tooltip 
-          contentStyle={{ 
+        <Tooltip
+          contentStyle={{
             backgroundColor: '#1f2937',
             border: '1px solid #374151',
-            borderRadius: '0.5rem'
+            borderRadius: '0.5rem',
           }}
         />
         {showArea && <Area type="monotone" dataKey={dataKey} fill={lineColor} fillOpacity={0.1} />}
-        <Line 
-          type="monotone" 
-          dataKey={dataKey} 
+        <Line
+          type="monotone"
+          dataKey={dataKey}
           stroke={lineColor}
           strokeWidth={2}
           dot={{ fill: lineColor }}
@@ -262,32 +263,31 @@ export default {
  */
 export function useRecharts() {
   const [recharts, setRecharts] = React.useState<typeof import('recharts') | null>(null);
-  
+
   React.useEffect(() => {
     import('recharts').then(setRecharts);
   }, []);
-  
+
   return recharts;
 }
 
 /**
  * Wrapper component that lazily loads Recharts and renders children only when loaded
  */
-export function LazyRechartsWrapper({ 
-  children, 
+export function LazyRechartsWrapper({
+  children,
   height = 200,
   fallback,
-}: { 
+}: {
   children: (recharts: typeof import('recharts')) => React.ReactNode;
   height?: number;
   fallback?: React.ReactNode;
 }) {
   const recharts = useRecharts();
-  
+
   if (!recharts) {
     return fallback || <ChartLoading height={height} />;
   }
-  
+
   return <>{children(recharts)}</>;
 }
-

--- a/frontend/src/components/config-as-code/ConfigIDE.tsx
+++ b/frontend/src/components/config-as-code/ConfigIDE.tsx
@@ -426,12 +426,12 @@ export default function ConfigIDE({ workspaceId }: Props) {
   }
 
   return (
-    <div className="flex h-[calc(100vh-200px)] border border-surface-700 rounded-lg overflow-hidden bg-surface-900">
+    <div className="flex h-[calc(100vh-200px)] border border-surface-200 rounded-lg overflow-hidden bg-white">
       {/* File Explorer Sidebar */}
-      <div className="w-64 border-r border-surface-700 bg-surface-800 overflow-y-auto">
-        <div className="p-4 border-b border-surface-700">
+      <div className="w-64 border-r border-surface-200 bg-white overflow-y-auto">
+        <div className="p-4 border-b border-surface-200">
           <div className="flex items-center justify-between mb-2">
-            <h3 className="text-sm font-semibold text-surface-200">Files</h3>
+            <h3 className="text-sm font-semibold text-surface-800">Files</h3>
             <button
               onClick={() => {
                 const path = prompt('Enter file path (e.g., controls/main.tf):');
@@ -441,7 +441,7 @@ export default function ConfigIDE({ workspaceId }: Props) {
                   setIsEditing(true);
                 }
               }}
-              className="p-1 text-surface-600 hover:text-surface-200"
+              className="p-1 text-surface-600 hover:text-surface-800"
               title="New File"
             >
               <PlusIcon className="w-4 h-4" />
@@ -513,7 +513,7 @@ export default function ConfigIDE({ workspaceId }: Props) {
                   <div>
                     <button
                       onClick={() => toggleFolder(node.path)}
-                      className="w-full flex items-center gap-2 px-2 py-1 text-sm text-surface-700 hover:bg-surface-700 rounded"
+                      className="w-full flex items-center gap-2 px-2 py-1 text-sm text-surface-700 hover:bg-surface-200 rounded"
                     >
                       <FolderIcon className="w-4 h-4" />
                       <span>{node.name}</span>
@@ -528,7 +528,7 @@ export default function ConfigIDE({ workspaceId }: Props) {
                               'w-full flex items-center gap-2 px-2 py-1 text-sm rounded',
                               selectedFile === child.path
                                 ? 'bg-brand-500/20 text-brand-300'
-                                : 'text-surface-600 hover:bg-surface-700'
+                                : 'text-surface-600 hover:bg-surface-200'
                             )}
                           >
                             <DocumentTextIcon className="w-4 h-4" />
@@ -545,7 +545,7 @@ export default function ConfigIDE({ workspaceId }: Props) {
                       'w-full flex items-center gap-2 px-2 py-1 text-sm rounded',
                       selectedFile === node.path
                         ? 'bg-brand-500/20 text-brand-300'
-                        : 'text-surface-600 hover:bg-surface-700'
+                        : 'text-surface-600 hover:bg-surface-200'
                     )}
                   >
                     <DocumentTextIcon className="w-4 h-4" />
@@ -562,10 +562,10 @@ export default function ConfigIDE({ workspaceId }: Props) {
         {selectedFile ? (
           <>
             {/* Editor Header */}
-            <div className="h-12 border-b border-surface-700 bg-surface-800 flex items-center justify-between px-4">
+            <div className="h-12 border-b border-surface-200 bg-white flex items-center justify-between px-4">
               <div className="flex items-center gap-2">
                 <DocumentTextIcon className="w-5 h-5 text-surface-600" />
-                <span className="text-sm font-medium text-surface-200">{selectedFile}</span>
+                <span className="text-sm font-medium text-surface-800">{selectedFile}</span>
                 {fileData && <span className="text-xs text-surface-500">v{fileData.version}</span>}
                 {isEditing && <span className="text-xs text-yellow-600">● Modified</span>}
               </div>
@@ -596,7 +596,7 @@ export default function ConfigIDE({ workspaceId }: Props) {
                   placeholder="Commit message (optional)"
                   value={commitMessage}
                   onChange={(e) => setCommitMessage(e.target.value)}
-                  className="px-2 py-1 text-xs bg-surface-700 border border-surface-600 rounded text-surface-200 placeholder-surface-500"
+                  className="px-2 py-1 text-xs bg-surface-200 border border-surface-300 rounded text-surface-800 placeholder-surface-500"
                   style={{ width: '200px' }}
                 />
                 <Button
@@ -656,10 +656,10 @@ export default function ConfigIDE({ workspaceId }: Props) {
 
             {/* Preview Panel */}
             {previewData && (
-              <div className="h-48 border-t border-surface-700 bg-surface-800 p-4 overflow-y-auto">
+              <div className="h-48 border-t border-surface-200 bg-white p-4 overflow-y-auto">
                 <div className="flex items-center gap-2 mb-2">
                   <EyeIcon className="w-5 h-5 text-brand-400" />
-                  <h4 className="font-semibold text-surface-200">Preview Changes</h4>
+                  <h4 className="font-semibold text-surface-800">Preview Changes</h4>
                 </div>
                 <div className="space-y-2 text-sm">
                   <div className="flex items-center gap-2">

--- a/frontend/src/components/controls/CollectorConfigModal.tsx
+++ b/frontend/src/components/controls/CollectorConfigModal.tsx
@@ -230,16 +230,16 @@ export default function CollectorConfigModal({
   return (
     <Dialog open onClose={onClose}>
       {/* Header */}
-      <div className="flex items-center justify-between px-6 py-4 border-b border-surface-700">
+      <div className="flex items-center justify-between px-6 py-4 border-b border-surface-200">
         <div>
-          <h2 className="text-lg font-semibold text-surface-100">
+          <h2 className="text-lg font-semibold text-surface-900">
             {isEditing ? 'Edit Evidence Collector' : 'Create Evidence Collector'}
           </h2>
           <p className="text-sm text-surface-600">
             Configure an API endpoint to automatically collect evidence
           </p>
         </div>
-        <button onClick={onClose} className="p-2 text-surface-600 hover:text-surface-200">
+        <button onClick={onClose} className="p-2 text-surface-600 hover:text-surface-800">
           <XMarkIcon className="w-5 h-5" />
         </button>
       </div>
@@ -285,8 +285,8 @@ export default function CollectorConfigModal({
         </div>
 
         {/* Mode Selection */}
-        <div className="border border-surface-700 rounded-lg p-4">
-          <h3 className="text-sm font-medium text-surface-200 mb-3">Configuration Mode</h3>
+        <div className="border border-surface-200 rounded-lg p-4">
+          <h3 className="text-sm font-medium text-surface-800 mb-3">Configuration Mode</h3>
           <div className="flex gap-4">
             <label className="flex items-center gap-2 cursor-pointer">
               <input
@@ -353,8 +353,8 @@ export default function CollectorConfigModal({
         </div>
 
         {/* Endpoint Configuration */}
-        <div className="border border-surface-700 rounded-lg p-4 space-y-4">
-          <h3 className="text-sm font-medium text-surface-200">Endpoint Configuration</h3>
+        <div className="border border-surface-200 rounded-lg p-4 space-y-4">
+          <h3 className="text-sm font-medium text-surface-800">Endpoint Configuration</h3>
 
           <div className="flex gap-4">
             <div className="w-32">
@@ -421,8 +421,8 @@ export default function CollectorConfigModal({
 
         {/* Authentication (Standalone mode only) */}
         {mode === 'standalone' && (
-          <div className="border border-surface-700 rounded-lg p-4 space-y-4">
-            <h3 className="text-sm font-medium text-surface-200">Authentication</h3>
+          <div className="border border-surface-200 rounded-lg p-4 space-y-4">
+            <h3 className="text-sm font-medium text-surface-800">Authentication</h3>
 
             <div>
               <label className="label">Auth Type</label>
@@ -561,8 +561,8 @@ export default function CollectorConfigModal({
         )}
 
         {/* Evidence Configuration */}
-        <div className="border border-surface-700 rounded-lg p-4 space-y-4">
-          <h3 className="text-sm font-medium text-surface-200">Evidence Configuration</h3>
+        <div className="border border-surface-200 rounded-lg p-4 space-y-4">
+          <h3 className="text-sm font-medium text-surface-800">Evidence Configuration</h3>
 
           <div>
             <label className="label">Evidence Title Template</label>
@@ -619,15 +619,15 @@ export default function CollectorConfigModal({
         </div>
 
         {/* Schedule */}
-        <div className="border border-surface-700 rounded-lg p-4 space-y-4">
+        <div className="border border-surface-200 rounded-lg p-4 space-y-4">
           <div className="flex items-center justify-between">
-            <h3 className="text-sm font-medium text-surface-200">Schedule</h3>
+            <h3 className="text-sm font-medium text-surface-800">Schedule</h3>
             <label className="flex items-center gap-2 cursor-pointer">
               <input
                 type="checkbox"
                 checked={scheduleEnabled}
                 onChange={(e) => setScheduleEnabled(e.target.checked)}
-                className="rounded border-surface-600 text-brand-500 focus:ring-brand-500"
+                className="rounded border-surface-300 text-brand-500 focus:ring-brand-500"
               />
               <span className="text-sm text-surface-700">Enable scheduled collection</span>
             </label>
@@ -677,7 +677,7 @@ export default function CollectorConfigModal({
                   {testResult.message}
                 </p>
                 {testResult.data && (
-                  <pre className="mt-2 p-2 bg-surface-900/50 rounded text-xs text-surface-600 overflow-auto max-h-32">
+                  <pre className="mt-2 p-2 bg-white/50 rounded text-xs text-surface-600 overflow-auto max-h-32">
                     {JSON.stringify(testResult.data, null, 2)}
                   </pre>
                 )}
@@ -688,7 +688,7 @@ export default function CollectorConfigModal({
       </div>
 
       {/* Footer */}
-      <div className="flex items-center justify-between px-6 py-4 border-t border-surface-700 bg-surface-800/50">
+      <div className="flex items-center justify-between px-6 py-4 border-t border-surface-200 bg-white/50">
         <div>
           {isEditing && (
             <Button

--- a/frontend/src/components/controls/ControlEvidencePanel.tsx
+++ b/frontend/src/components/controls/ControlEvidencePanel.tsx
@@ -27,7 +27,7 @@ export default function ControlEvidencePanel({
   };
 
   return (
-    <div className="bg-surface-800 rounded-lg border border-surface-700 p-6">
+    <div className="bg-white rounded-lg border border-surface-200 p-6">
       <div className="flex items-center justify-between mb-4">
         <h3 className="text-lg font-medium text-white">Evidence</h3>
         <Link
@@ -55,11 +55,11 @@ export default function ControlEvidencePanel({
           {evidence.map((item) => (
             <div
               key={item.id}
-              className="flex items-center justify-between p-3 bg-surface-900 rounded-lg"
+              className="flex items-center justify-between p-3 bg-white rounded-lg"
             >
               <Link
                 to={`/evidence/${item.id}`}
-                className="flex items-center gap-3 text-surface-100 hover:text-primary-400"
+                className="flex items-center gap-3 text-surface-900 hover:text-primary-400"
               >
                 <DocumentTextIcon className="w-5 h-5 text-surface-600" />
                 <div>

--- a/frontend/src/components/controls/ControlImplementationCard.tsx
+++ b/frontend/src/components/controls/ControlImplementationCard.tsx
@@ -111,7 +111,7 @@ export default function ControlImplementationCard({
   };
 
   return (
-    <div className="bg-surface-800 rounded-lg border border-surface-700 p-6">
+    <div className="bg-white rounded-lg border border-surface-200 p-6">
       <div className="flex items-center justify-between mb-4">
         <h3 className="text-lg font-medium text-white">Implementation Status</h3>
         {!isEditing && (
@@ -132,7 +132,7 @@ export default function ControlImplementationCard({
               className={`px-3 py-1.5 rounded-full text-sm font-medium transition-all ${
                 implementation?.status === option.value
                   ? `${option.color} text-white`
-                  : 'bg-surface-700 text-surface-700 hover:bg-surface-600'
+                  : 'bg-surface-200 text-surface-700 hover:bg-surface-600'
               }`}
             >
               {option.label}
@@ -217,17 +217,17 @@ export default function ControlImplementationCard({
           <div className="grid grid-cols-2 gap-4">
             <div>
               <p className="text-xs text-surface-600">Owner</p>
-              <p className="text-surface-100">{getUserName(implementation?.owner)}</p>
+              <p className="text-surface-900">{getUserName(implementation?.owner)}</p>
             </div>
             <div>
               <p className="text-xs text-surface-600">Testing Frequency</p>
-              <p className="text-surface-100 capitalize">
+              <p className="text-surface-900 capitalize">
                 {implementation?.testingFrequency?.replace('_', ' ') || 'Not set'}
               </p>
             </div>
             <div>
               <p className="text-xs text-surface-600">Effectiveness</p>
-              <p className="text-surface-100">
+              <p className="text-surface-900">
                 {implementation?.effectivenessScore !== undefined
                   ? `${implementation.effectivenessScore}%`
                   : 'Not assessed'}
@@ -235,7 +235,7 @@ export default function ControlImplementationCard({
             </div>
             <div>
               <p className="text-xs text-surface-600">Last Tested</p>
-              <p className="text-surface-100">{formatDate(implementation?.lastTestedAt)}</p>
+              <p className="text-surface-900">{formatDate(implementation?.lastTestedAt)}</p>
             </div>
           </div>
 
@@ -249,7 +249,7 @@ export default function ControlImplementationCard({
           {implementation?.implementationNotes && (
             <div>
               <p className="text-xs text-surface-600 mb-1">Notes</p>
-              <p className="text-surface-200 text-sm">{implementation.implementationNotes}</p>
+              <p className="text-surface-800 text-sm">{implementation.implementationNotes}</p>
             </div>
           )}
         </div>

--- a/frontend/src/components/controls/EvidenceCollectors.tsx
+++ b/frontend/src/components/controls/EvidenceCollectors.tsx
@@ -104,7 +104,7 @@ export default function EvidenceCollectors({ controlId, implementationId }: Prop
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h3 className="text-lg font-semibold text-surface-100">Evidence Collectors</h3>
+          <h3 className="text-lg font-semibold text-surface-900">Evidence Collectors</h3>
           <p className="text-sm text-surface-600">
             Configure API endpoints to automatically collect evidence for this control
           </p>
@@ -116,7 +116,7 @@ export default function EvidenceCollectors({ controlId, implementationId }: Prop
       </div>
       {/* Collectors List */}
       {collectors?.length === 0 ? (
-        <div className="text-center py-8 border border-dashed border-surface-700 rounded-lg">
+        <div className="text-center py-8 border border-dashed border-surface-200 rounded-lg">
           <Cog6ToothIcon className="w-10 h-10 mx-auto text-surface-600 mb-3" />
           <p className="text-surface-600 mb-3">No evidence collectors configured</p>
           <Button onClick={handleCreateNew} className="text-sm" variant="secondary">
@@ -201,17 +201,17 @@ function CollectorCard({
   const statusColor = lastStatus ? statusConfig[lastStatus]?.color : 'text-surface-600';
 
   return (
-    <div className="border border-surface-700 rounded-lg overflow-hidden">
+    <div className="border border-surface-200 rounded-lg overflow-hidden">
       {/* Header */}
       <div
-        className="flex items-center justify-between p-4 bg-surface-800/50 cursor-pointer"
+        className="flex items-center justify-between p-4 bg-white/50 cursor-pointer"
         onClick={onToggle}
       >
         <div className="flex items-center gap-3">
           <div
             className={clsx(
               'p-2 rounded-lg',
-              collector.mode === 'integration' ? 'bg-brand-500/20' : 'bg-surface-700'
+              collector.mode === 'integration' ? 'bg-brand-500/20' : 'bg-surface-200'
             )}
           >
             {collector.mode === 'integration' ? (
@@ -221,12 +221,12 @@ function CollectorCard({
             )}
           </div>
           <div>
-            <h4 className="font-medium text-surface-100">{collector.name}</h4>
+            <h4 className="font-medium text-surface-900">{collector.name}</h4>
             <div className="flex items-center gap-2 text-xs text-surface-500">
               <span className="uppercase">{collector.method}</span>
               <span>{collector.endpoint || '/'}</span>
               {collector.scheduleEnabled && (
-                <span className="px-1.5 py-0.5 bg-surface-700 rounded">
+                <span className="px-1.5 py-0.5 bg-surface-200 rounded">
                   <ClockIcon className="w-3 h-3 inline mr-1" />
                   {collector.scheduleFrequency}
                 </span>
@@ -258,7 +258,7 @@ function CollectorCard({
             <button
               onClick={onRun}
               disabled={isRunning}
-              className="p-1.5 text-surface-600 hover:text-green-600 hover:bg-surface-700 rounded transition-colors"
+              className="p-1.5 text-surface-600 hover:text-green-600 hover:bg-surface-200 rounded transition-colors"
               title="Run now"
             >
               {isRunning ? (
@@ -269,14 +269,14 @@ function CollectorCard({
             </button>
             <button
               onClick={onEdit}
-              className="p-1.5 text-surface-600 hover:text-surface-200 hover:bg-surface-700 rounded transition-colors"
+              className="p-1.5 text-surface-600 hover:text-surface-800 hover:bg-surface-200 rounded transition-colors"
               title="Edit"
             >
               <PencilIcon className="w-4 h-4" />
             </button>
             <button
               onClick={onDelete}
-              className="p-1.5 text-surface-600 hover:text-red-600 hover:bg-surface-700 rounded transition-colors"
+              className="p-1.5 text-surface-600 hover:text-red-600 hover:bg-surface-200 rounded transition-colors"
               title="Delete"
             >
               <TrashIcon className="w-4 h-4" />
@@ -294,7 +294,7 @@ function CollectorCard({
 
       {/* Expanded Content */}
       {isExpanded && (
-        <div className="p-4 border-t border-surface-700 space-y-4">
+        <div className="p-4 border-t border-surface-200 space-y-4">
           {/* Description */}
           {collector.description && (
             <p className="text-sm text-surface-600">{collector.description}</p>
@@ -329,7 +329,7 @@ function CollectorCard({
 
           {/* Schedule Info */}
           {collector.scheduleEnabled && (
-            <div className="p-3 bg-surface-800/50 rounded-lg">
+            <div className="p-3 bg-white/50 rounded-lg">
               <div className="flex items-center gap-2 text-sm">
                 <ClockIcon className="w-4 h-4 text-surface-500" />
                 <span className="text-surface-700">
@@ -355,7 +355,7 @@ function CollectorCard({
                   return (
                     <div
                       key={run.id}
-                      className="flex items-center justify-between p-2 bg-surface-800/30 rounded text-xs"
+                      className="flex items-center justify-between p-2 bg-white/30 rounded text-xs"
                     >
                       <div className="flex items-center gap-2">
                         <RunIcon className={clsx('w-4 h-4', statusConfig[runStatus]?.color)} />

--- a/frontend/src/components/dashboard/WorkspaceComparisonWidget.tsx
+++ b/frontend/src/components/dashboard/WorkspaceComparisonWidget.tsx
@@ -50,12 +50,12 @@ export function WorkspaceComparisonWidget() {
 
   if (isLoading) {
     return (
-      <div className="bg-surface-800 rounded-lg border border-surface-700 p-4">
+      <div className="bg-white rounded-lg border border-surface-200 p-4">
         <div className="animate-pulse">
-          <div className="h-5 bg-surface-700 rounded w-1/3 mb-4"></div>
+          <div className="h-5 bg-surface-200 rounded w-1/3 mb-4"></div>
           <div className="space-y-3">
-            <div className="h-12 bg-surface-700 rounded"></div>
-            <div className="h-12 bg-surface-700 rounded"></div>
+            <div className="h-12 bg-surface-200 rounded"></div>
+            <div className="h-12 bg-surface-200 rounded"></div>
           </div>
         </div>
       </div>
@@ -79,9 +79,9 @@ export function WorkspaceComparisonWidget() {
   };
 
   return (
-    <div className="bg-surface-800 rounded-lg border border-surface-700 overflow-hidden">
+    <div className="bg-white rounded-lg border border-surface-200 overflow-hidden">
       {/* Header */}
-      <div className="flex items-center justify-between p-4 border-b border-surface-700">
+      <div className="flex items-center justify-between p-4 border-b border-surface-200">
         <div className="flex items-center gap-2">
           <BuildingOfficeIcon className="w-5 h-5 text-brand-400" />
           <h3 className="font-semibold text-foreground">Workspace Comparison</h3>
@@ -96,25 +96,25 @@ export function WorkspaceComparisonWidget() {
       </div>
 
       {/* Org-wide Stats */}
-      <div className="grid grid-cols-3 gap-px bg-surface-700">
-        <div className="bg-surface-800 p-3 text-center">
+      <div className="grid grid-cols-3 gap-px bg-surface-200">
+        <div className="bg-white p-3 text-center">
           <p className="text-xs text-muted-foreground">Avg Score</p>
           <p className={`text-lg font-bold ${getScoreColor(data.avgComplianceScore)}`}>
             {data.avgComplianceScore}%
           </p>
         </div>
-        <div className="bg-surface-800 p-3 text-center">
+        <div className="bg-white p-3 text-center">
           <p className="text-xs text-muted-foreground">Total Controls</p>
           <p className="text-lg font-bold text-foreground">{data.totals.controls}</p>
         </div>
-        <div className="bg-surface-800 p-3 text-center">
+        <div className="bg-white p-3 text-center">
           <p className="text-xs text-muted-foreground">Total Risks</p>
           <p className="text-lg font-bold text-foreground">{data.totals.risks}</p>
         </div>
       </div>
 
       {/* Workspace List */}
-      <div className="divide-y divide-surface-700">
+      <div className="divide-y divide-surface-200">
         {sortedWorkspaces.slice(0, 5).map((workspace) => (
           <button
             key={workspace.id}
@@ -131,7 +131,7 @@ export function WorkspaceComparisonWidget() {
               });
               navigate('/dashboard');
             }}
-            className="w-full flex items-center justify-between p-3 hover:bg-surface-700/50 transition-colors"
+            className="w-full flex items-center justify-between p-3 hover:bg-surface-200/50 transition-colors"
           >
             <div className="flex items-center gap-3">
               <div className="w-8 h-8 rounded-full bg-brand-600/20 flex items-center justify-center">
@@ -160,7 +160,7 @@ export function WorkspaceComparisonWidget() {
 
       {/* Show more link if there are more workspaces */}
       {data.workspaces.length > 5 && (
-        <div className="p-3 text-center border-t border-surface-700">
+        <div className="p-3 text-center border-t border-surface-200">
           <button
             onClick={() => navigate('/settings/workspaces')}
             className="text-sm text-muted-foreground hover:text-foreground"

--- a/frontend/src/components/dashboards/DashboardEditor.tsx
+++ b/frontend/src/components/dashboards/DashboardEditor.tsx
@@ -208,7 +208,7 @@ export default function DashboardEditor({ dashboardId, onBack }: DashboardEditor
   if (isLoading) {
     return (
       <div className="flex items-center justify-center h-96">
-        <div className="animate-spin w-8 h-8 border-4 border-surface-700 rounded-full border-t-brand-500" />
+        <div className="animate-spin w-8 h-8 border-4 border-surface-200 rounded-full border-t-brand-500" />
       </div>
     );
   }
@@ -231,13 +231,13 @@ export default function DashboardEditor({ dashboardId, onBack }: DashboardEditor
         <div className="flex items-center gap-4">
           <button
             onClick={onBack}
-            className="text-surface-600 hover:text-surface-200 transition-colors"
+            className="text-surface-600 hover:text-surface-800 transition-colors"
           >
             ← Back to dashboards
           </button>
           <div>
             <div className="flex items-center gap-2">
-              <h1 className="text-2xl font-bold text-surface-100">{dashboard.name}</h1>
+              <h1 className="text-2xl font-bold text-surface-900">{dashboard.name}</h1>
               {dashboard.isDefault && (
                 <StarIconSolid className="w-5 h-5 text-yellow-600" title="Default dashboard" />
               )}
@@ -326,7 +326,7 @@ export default function DashboardEditor({ dashboardId, onBack }: DashboardEditor
           <div className="text-surface-500 mb-4">
             <Cog6ToothIcon className="w-12 h-12 mx-auto" />
           </div>
-          <h3 className="text-lg font-medium text-surface-200 mb-2">No widgets yet</h3>
+          <h3 className="text-lg font-medium text-surface-800 mb-2">No widgets yet</h3>
           <p className="text-surface-600 mb-4">Add widgets to customize your dashboard</p>
           <Button onClick={() => setShowPalette(true)} variant="primary">
             <PlusIcon className="w-4 h-4 mr-1" /> Add Widget

--- a/frontend/src/components/dashboards/TemplateGallery.tsx
+++ b/frontend/src/components/dashboards/TemplateGallery.tsx
@@ -52,7 +52,7 @@ export default function TemplateGallery({ onClose, onSelectTemplate }: TemplateG
       <div className="overflow-y-auto max-h-[60vh]">
         {isLoading ? (
           <div className="flex items-center justify-center py-12">
-            <div className="animate-spin w-8 h-8 border-4 border-surface-700 rounded-full border-t-brand-500" />
+            <div className="animate-spin w-8 h-8 border-4 border-surface-200 rounded-full border-t-brand-500" />
           </div>
         ) : templates?.length === 0 ? (
           <div className="text-center py-12">
@@ -66,11 +66,11 @@ export default function TemplateGallery({ onClose, onSelectTemplate }: TemplateG
             {templates?.map((template: Dashboard) => (
               <div
                 key={template.id}
-                className="bg-surface-800 border border-surface-700 rounded-lg p-4 hover:border-brand-500/50 transition-colors"
+                className="bg-white border border-surface-200 rounded-lg p-4 hover:border-brand-500/50 transition-colors"
               >
                 <div className="flex items-start justify-between mb-3">
                   <div>
-                    <h3 className="font-medium text-surface-200">{template.name}</h3>
+                    <h3 className="font-medium text-surface-800">{template.name}</h3>
                     {template.description && (
                       <p className="text-sm text-surface-600 mt-1">{template.description}</p>
                     )}
@@ -83,12 +83,12 @@ export default function TemplateGallery({ onClose, onSelectTemplate }: TemplateG
                 </div>
 
                 {/* Widget preview */}
-                <div className="bg-surface-900 rounded p-3 mb-4">
+                <div className="bg-white rounded p-3 mb-4">
                   <div className="grid grid-cols-4 gap-1 h-20">
                     {template.widgets?.slice(0, 8).map((widget, i) => (
                       <div
                         key={widget.id || i}
-                        className="bg-surface-700 rounded"
+                        className="bg-surface-200 rounded"
                         style={{
                           gridColumn: `span ${Math.min(widget.position.w, 2)}`,
                           gridRow: `span ${Math.min(widget.position.h, 1)}`,

--- a/frontend/src/components/dashboards/WidgetConfigModal.tsx
+++ b/frontend/src/components/dashboards/WidgetConfigModal.tsx
@@ -73,28 +73,28 @@ export default function WidgetConfigModal({ widget, onSave, onClose }: WidgetCon
   return (
     <Dialog open onClose={onClose}>
       {/* Header */}
-      <div className="flex items-center justify-between p-4 border-b border-surface-700">
+      <div className="flex items-center justify-between p-4 border-b border-surface-200">
         <div>
-          <h2 className="text-lg font-semibold text-surface-100">Configure Widget</h2>
+          <h2 className="text-lg font-semibold text-surface-900">Configure Widget</h2>
           <p className="text-sm text-surface-600">{widgetDef?.name}</p>
         </div>
         <button
           onClick={onClose}
-          className="p-1 hover:bg-surface-700 rounded text-surface-600 hover:text-surface-200"
+          className="p-1 hover:bg-surface-200 rounded text-surface-600 hover:text-surface-800"
         >
           <XMarkIcon className="w-5 h-5" />
         </button>
       </div>
 
       {/* Tabs */}
-      <div className="flex border-b border-surface-700">
+      <div className="flex border-b border-surface-200">
         <button
           onClick={() => setActiveTab('data')}
           className={clsx(
             'px-4 py-2 text-sm font-medium transition-colors',
             activeTab === 'data'
               ? 'text-brand-400 border-b-2 border-brand-400'
-              : 'text-surface-600 hover:text-surface-200'
+              : 'text-surface-600 hover:text-surface-800'
           )}
         >
           Data Source
@@ -105,7 +105,7 @@ export default function WidgetConfigModal({ widget, onSave, onClose }: WidgetCon
             'px-4 py-2 text-sm font-medium transition-colors',
             activeTab === 'appearance'
               ? 'text-brand-400 border-b-2 border-brand-400'
-              : 'text-surface-600 hover:text-surface-200'
+              : 'text-surface-600 hover:text-surface-800'
           )}
         >
           Appearance
@@ -218,7 +218,7 @@ export default function WidgetConfigModal({ widget, onSave, onClose }: WidgetCon
 
             {/* Preview Results */}
             {previewData && (
-              <div className="bg-surface-800 rounded-lg p-4">
+              <div className="bg-white rounded-lg p-4">
                 <h4 className="text-sm font-medium text-surface-700 mb-2">
                   Preview ({previewData.length} results)
                 </h4>
@@ -240,7 +240,7 @@ export default function WidgetConfigModal({ widget, onSave, onClose }: WidgetCon
                   id="showLegend"
                   checked={config.showLegend || false}
                   onChange={(e) => setConfig({ ...config, showLegend: e.target.checked })}
-                  className="w-4 h-4 rounded border-surface-600 bg-surface-800 text-brand-500 focus:ring-brand-500"
+                  className="w-4 h-4 rounded border-surface-300 bg-white text-brand-500 focus:ring-brand-500"
                 />
                 <label htmlFor="showLegend" className="text-sm text-surface-700">
                   Show Legend
@@ -256,7 +256,7 @@ export default function WidgetConfigModal({ widget, onSave, onClose }: WidgetCon
                   id="showValues"
                   checked={config.showValues || false}
                   onChange={(e) => setConfig({ ...config, showValues: e.target.checked })}
-                  className="w-4 h-4 rounded border-surface-600 bg-surface-800 text-brand-500 focus:ring-brand-500"
+                  className="w-4 h-4 rounded border-surface-300 bg-white text-brand-500 focus:ring-brand-500"
                 />
                 <label htmlFor="showValues" className="text-sm text-surface-700">
                   Show Values on Chart
@@ -401,7 +401,7 @@ export default function WidgetConfigModal({ widget, onSave, onClose }: WidgetCon
       </div>
 
       {/* Footer */}
-      <div className="flex items-center justify-end gap-3 p-4 border-t border-surface-700">
+      <div className="flex items-center justify-end gap-3 p-4 border-t border-surface-200">
         <Button onClick={onClose} variant="ghost">
           Cancel
         </Button>

--- a/frontend/src/components/dashboards/WidgetContainer.tsx
+++ b/frontend/src/components/dashboards/WidgetContainer.tsx
@@ -44,25 +44,25 @@ export default function WidgetContainer({
   return (
     <div
       className={clsx(
-        'h-full w-full bg-surface-900 border border-surface-700 rounded-lg overflow-hidden flex flex-col',
+        'h-full w-full bg-white border border-surface-200 rounded-lg overflow-hidden flex flex-col',
         isEditing && 'ring-2 ring-brand-500/30'
       )}
     >
       {/* Header */}
-      <div className="flex items-center justify-between px-4 py-2 border-b border-surface-700 bg-surface-800/50">
+      <div className="flex items-center justify-between px-4 py-2 border-b border-surface-200 bg-white/50">
         <div className="flex items-center gap-2">
           {isEditing && (
-            <div className="widget-drag-handle cursor-move p-1 hover:bg-surface-700 rounded">
+            <div className="widget-drag-handle cursor-move p-1 hover:bg-surface-200 rounded">
               <Bars3Icon className="w-4 h-4 text-surface-600" />
             </div>
           )}
-          <h3 className="text-sm font-medium text-surface-200 truncate">{widget.title}</h3>
+          <h3 className="text-sm font-medium text-surface-800 truncate">{widget.title}</h3>
         </div>
         <div className="flex items-center gap-1">
           {widgetDef?.requiresDataSource && (
             <button
               onClick={handleRefresh}
-              className="p-1 hover:bg-surface-700 rounded text-surface-600 hover:text-surface-200 transition-colors"
+              className="p-1 hover:bg-surface-200 rounded text-surface-600 hover:text-surface-800 transition-colors"
               title="Refresh data"
             >
               <ArrowPathIcon className={clsx('w-4 h-4', isLoading && 'animate-spin')} />
@@ -72,7 +72,7 @@ export default function WidgetContainer({
             <>
               <button
                 onClick={onEdit}
-                className="p-1 hover:bg-surface-700 rounded text-surface-600 hover:text-surface-200 transition-colors"
+                className="p-1 hover:bg-surface-200 rounded text-surface-600 hover:text-surface-800 transition-colors"
                 title="Edit widget"
               >
                 <PencilIcon className="w-4 h-4" />
@@ -97,7 +97,7 @@ export default function WidgetContainer({
           </div>
         ) : isLoading && widgetDef?.requiresDataSource ? (
           <div className="flex items-center justify-center h-full">
-            <div className="animate-spin w-6 h-6 border-2 border-surface-600 rounded-full border-t-brand-500" />
+            <div className="animate-spin w-6 h-6 border-2 border-surface-300 rounded-full border-t-brand-500" />
           </div>
         ) : (
           <WidgetRenderer widget={widget} data={data?.data || []} />

--- a/frontend/src/components/dashboards/WidgetPalette.tsx
+++ b/frontend/src/components/dashboards/WidgetPalette.tsx
@@ -55,11 +55,11 @@ export default function WidgetPalette({ onSelect, onClose }: WidgetPaletteProps)
   return (
     <Dialog open onClose={onClose}>
       {/* Header */}
-      <div className="flex items-center justify-between p-4 border-b border-surface-700">
-        <h2 className="text-lg font-semibold text-surface-100">Add Widget</h2>
+      <div className="flex items-center justify-between p-4 border-b border-surface-200">
+        <h2 className="text-lg font-semibold text-surface-900">Add Widget</h2>
         <button
           onClick={onClose}
-          className="p-1 hover:bg-surface-700 rounded text-surface-600 hover:text-surface-200"
+          className="p-1 hover:bg-surface-200 rounded text-surface-600 hover:text-surface-800"
         >
           <XMarkIcon className="w-5 h-5" />
         </button>
@@ -80,15 +80,15 @@ export default function WidgetPalette({ onSelect, onClose }: WidgetPaletteProps)
                     key={widget.type}
                     onClick={() => onSelect(widget.type)}
                     className={clsx(
-                      'flex flex-col items-center p-4 rounded-lg border border-surface-700',
-                      'bg-surface-800 hover:bg-surface-700 hover:border-brand-500/50',
+                      'flex flex-col items-center p-4 rounded-lg border border-surface-200',
+                      'bg-white hover:bg-surface-200 hover:border-brand-500/50',
                       'transition-all duration-200 text-left'
                     )}
                   >
-                    <div className="p-2 bg-surface-700 rounded-lg mb-2">
+                    <div className="p-2 bg-surface-200 rounded-lg mb-2">
                       <Icon className="w-6 h-6 text-brand-400" />
                     </div>
-                    <span className="text-sm font-medium text-surface-200">{widget.name}</span>
+                    <span className="text-sm font-medium text-surface-800">{widget.name}</span>
                     <span className="text-xs text-surface-500 text-center mt-1">
                       {widget.description}
                     </span>
@@ -104,7 +104,7 @@ export default function WidgetPalette({ onSelect, onClose }: WidgetPaletteProps)
       </div>
 
       {/* Footer */}
-      <div className="p-4 border-t border-surface-700 bg-surface-800/50">
+      <div className="p-4 border-t border-surface-200 bg-white/50">
         <p className="text-sm text-surface-500">
           Click a widget to add it to your dashboard. You can configure it after adding.
         </p>

--- a/frontend/src/components/dashboards/WidgetRenderer.tsx
+++ b/frontend/src/components/dashboards/WidgetRenderer.tsx
@@ -7,7 +7,7 @@ import { AlertTriangle } from 'lucide-react';
 // Loading state for chart widgets
 function ChartLoading() {
   return (
-    <div className="flex items-center justify-center h-full animate-pulse bg-surface-700/30 rounded-lg">
+    <div className="flex items-center justify-center h-full animate-pulse bg-surface-200/30 rounded-lg">
       <div className="text-surface-500 text-sm">Loading chart...</div>
     </div>
   );
@@ -349,7 +349,7 @@ function TableWidget({ data, config }: { data: any[]; config: any }) {
     <div className="overflow-auto h-full">
       <table className="w-full text-sm">
         <thead>
-          <tr className="border-b border-surface-700">
+          <tr className="border-b border-surface-200">
             {columns.map((col: any) => (
               <th
                 key={col.field}
@@ -363,7 +363,7 @@ function TableWidget({ data, config }: { data: any[]; config: any }) {
         </thead>
         <tbody>
           {displayData.map((row, i) => (
-            <tr key={i} className="border-b border-surface-800 hover:bg-surface-800/50">
+            <tr key={i} className="border-b border-surface-200 hover:bg-white/50">
               {columns.map((col: any) => (
                 <td key={col.field} className="py-2 px-3 text-surface-600">
                   {formatValue(row[col.field])}
@@ -411,9 +411,9 @@ function ProgressWidget({ data, config }: { data: any[]; config: any }) {
         <span className="text-surface-600 text-sm">
           {value} / {target}
         </span>
-        <span className="text-surface-200 font-medium">{percentage}%</span>
+        <span className="text-surface-800 font-medium">{percentage}%</span>
       </div>
-      <div className="w-full h-3 bg-surface-800 rounded-full overflow-hidden">
+      <div className="w-full h-3 bg-white rounded-full overflow-hidden">
         <div
           className="h-full rounded-full transition-all duration-500"
           style={{ width: `${percentage}%`, backgroundColor: color }}
@@ -438,9 +438,9 @@ function ListWidget({ data, config: _config }: { data: any[]; config: any }) {
         return (
           <div
             key={i}
-            className="flex items-center justify-between p-2 bg-surface-800/50 rounded hover:bg-surface-800"
+            className="flex items-center justify-between p-2 bg-white/50 rounded hover:bg-white"
           >
-            <span className="text-surface-200 truncate">{formatValue(displayFields[0]?.[1])}</span>
+            <span className="text-surface-800 truncate">{formatValue(displayFields[0]?.[1])}</span>
             {displayFields[1] && (
               <span className="text-surface-600 text-sm">{formatValue(displayFields[1][1])}</span>
             )}
@@ -481,7 +481,7 @@ function GaugeWidget({ data, config }: { data: any[]; config: any }) {
     <div className="flex flex-col items-center justify-center h-full">
       <div className="relative w-32 h-16 overflow-hidden">
         <div
-          className="absolute inset-0 border-8 border-surface-700 rounded-t-full"
+          className="absolute inset-0 border-8 border-surface-200 rounded-t-full"
           style={{ borderBottomWidth: 0 }}
         />
         <div
@@ -493,7 +493,7 @@ function GaugeWidget({ data, config }: { data: any[]; config: any }) {
           }}
         />
       </div>
-      <div className="text-2xl font-bold text-surface-100 mt-2">{value}%</div>
+      <div className="text-2xl font-bold text-surface-900 mt-2">{value}%</div>
     </div>
   );
 }

--- a/frontend/src/components/integrations/AdvancedBuilderTab.tsx
+++ b/frontend/src/components/integrations/AdvancedBuilderTab.tsx
@@ -147,7 +147,7 @@ export default function AdvancedBuilderTab({ config, onChange }: AdvancedBuilder
     return (
       <button
         onClick={() => toggleSection(section)}
-        className="w-full flex items-center justify-between p-4 bg-surface-800/50 hover:bg-surface-800 transition-colors"
+        className="w-full flex items-center justify-between p-4 bg-white/50 hover:bg-white transition-colors"
       >
         <div className="flex items-center gap-2">
           {isExpanded ? (
@@ -155,9 +155,9 @@ export default function AdvancedBuilderTab({ config, onChange }: AdvancedBuilder
           ) : (
             <ChevronRightIcon className="w-4 h-4 text-surface-600" />
           )}
-          <span className="font-medium text-surface-200">{title}</span>
+          <span className="font-medium text-surface-800">{title}</span>
           {count !== undefined && (
-            <span className="text-xs text-surface-500 bg-surface-700 px-2 py-0.5 rounded">
+            <span className="text-xs text-surface-500 bg-surface-200 px-2 py-0.5 rounded">
               {count}
             </span>
           )}
@@ -167,10 +167,10 @@ export default function AdvancedBuilderTab({ config, onChange }: AdvancedBuilder
   };
 
   return (
-    <div className="divide-y divide-surface-800">
+    <div className="divide-y divide-surface-200">
       {/* Basic Info */}
       <div className="p-6">
-        <h3 className="text-sm font-semibold text-surface-200 mb-4">Basic Information</h3>
+        <h3 className="text-sm font-semibold text-surface-800 mb-4">Basic Information</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
             <label className="block text-sm text-surface-600 mb-1.5">Integration Name</label>
@@ -197,7 +197,7 @@ export default function AdvancedBuilderTab({ config, onChange }: AdvancedBuilder
       <div>
         <SectionHeader section="auth" title="Authentication" />
         {expandedSections.has('auth') && (
-          <div className="p-6 bg-surface-900/50">
+          <div className="p-6 bg-white/50">
             <AuthConfigPanel config={config.authConfig} onChange={updateAuthConfig} />
           </div>
         )}
@@ -206,7 +206,7 @@ export default function AdvancedBuilderTab({ config, onChange }: AdvancedBuilder
       <div>
         <SectionHeader section="endpoints" title="API Endpoints" count={config.endpoints.length} />
         {expandedSections.has('endpoints') && (
-          <div className="p-6 bg-surface-900/50">
+          <div className="p-6 bg-white/50">
             <div className="flex flex-col lg:flex-row gap-6">
               {/* Endpoint List */}
               <div className="w-full lg:w-64 space-y-2">
@@ -218,7 +218,7 @@ export default function AdvancedBuilderTab({ config, onChange }: AdvancedBuilder
                       'w-full text-left p-3 rounded-lg border transition-colors',
                       selectedEndpointId === endpoint.id
                         ? 'bg-brand-500/10 border-brand-500/30'
-                        : 'bg-surface-800 border-surface-700 hover:border-surface-600'
+                        : 'bg-white border-surface-200 hover:border-surface-300'
                     )}
                   >
                     <div className="flex items-center gap-2">
@@ -234,7 +234,7 @@ export default function AdvancedBuilderTab({ config, onChange }: AdvancedBuilder
                       >
                         {endpoint.method}
                       </span>
-                      <span className="text-sm text-surface-200 truncate">{endpoint.name}</span>
+                      <span className="text-sm text-surface-800 truncate">{endpoint.name}</span>
                     </div>
                     <div className="text-xs text-surface-500 truncate mt-1 font-mono">
                       {endpoint.path}
@@ -243,7 +243,7 @@ export default function AdvancedBuilderTab({ config, onChange }: AdvancedBuilder
                 ))}
                 <button
                   onClick={addEndpoint}
-                  className="w-full p-3 rounded-lg border border-dashed border-surface-700 hover:border-surface-500 text-surface-600 hover:text-surface-200 transition-colors flex items-center justify-center gap-2"
+                  className="w-full p-3 rounded-lg border border-dashed border-surface-200 hover:border-surface-500 text-surface-600 hover:text-surface-800 transition-colors flex items-center justify-center gap-2"
                 >
                   <PlusIcon className="w-4 h-4" />
                   Add Endpoint
@@ -259,7 +259,7 @@ export default function AdvancedBuilderTab({ config, onChange }: AdvancedBuilder
                     onDelete={() => deleteEndpoint(selectedEndpoint.id)}
                   />
                 ) : (
-                  <div className="h-64 flex items-center justify-center text-surface-500 bg-surface-800/50 rounded-lg border border-surface-700">
+                  <div className="h-64 flex items-center justify-center text-surface-500 bg-white/50 rounded-lg border border-surface-200">
                     Select an endpoint to configure or add a new one
                   </div>
                 )}
@@ -276,7 +276,7 @@ export default function AdvancedBuilderTab({ config, onChange }: AdvancedBuilder
           count={config.responseMappings.length}
         />
         {expandedSections.has('mapping') && (
-          <div className="p-6 bg-surface-900/50">
+          <div className="p-6 bg-white/50">
             <ResponseMapper
               mappings={config.responseMappings}
               onChange={(mappings) => onChange({ ...config, responseMappings: mappings })}
@@ -289,7 +289,7 @@ export default function AdvancedBuilderTab({ config, onChange }: AdvancedBuilder
       <div>
         <SectionHeader section="testing" title="Test & Preview" />
         {expandedSections.has('testing') && (
-          <div className="p-6 bg-surface-900/50">
+          <div className="p-6 bg-white/50">
             <RequestTester
               endpoints={config.endpoints}
               authConfig={config.authConfig}

--- a/frontend/src/components/integrations/AuthConfigPanel.tsx
+++ b/frontend/src/components/integrations/AuthConfigPanel.tsx
@@ -88,7 +88,7 @@ export default function AuthConfigPanel({ config, onChange }: AuthConfigPanelPro
               className={`p-3 text-left rounded-lg border transition-colors ${
                 config.type === authType.value
                   ? 'bg-brand-500/10 border-brand-500/30 text-brand-400'
-                  : 'bg-surface-800 border-surface-700 hover:border-surface-600 text-surface-700'
+                  : 'bg-white border-surface-200 hover:border-surface-300 text-surface-700'
               }`}
             >
               <div className="font-medium text-sm">{authType.label}</div>
@@ -99,7 +99,7 @@ export default function AuthConfigPanel({ config, onChange }: AuthConfigPanelPro
       </div>
       {/* API Key Configuration */}
       {config.type === 'api_key' && (
-        <div className="space-y-4 p-4 bg-surface-800/50 rounded-lg border border-surface-700">
+        <div className="space-y-4 p-4 bg-white/50 rounded-lg border border-surface-200">
           <div>
             <label className="text-sm text-surface-600 block mb-1.5">API Key</label>
             <Input
@@ -144,7 +144,7 @@ export default function AuthConfigPanel({ config, onChange }: AuthConfigPanelPro
       )}
       {/* Bearer Token Configuration */}
       {config.type === 'bearer' && (
-        <div className="space-y-4 p-4 bg-surface-800/50 rounded-lg border border-surface-700">
+        <div className="space-y-4 p-4 bg-white/50 rounded-lg border border-surface-200">
           <div>
             <label className="text-sm text-surface-600 block mb-1.5">Bearer Token</label>
             <Input
@@ -173,7 +173,7 @@ export default function AuthConfigPanel({ config, onChange }: AuthConfigPanelPro
       )}
       {/* Basic Auth Configuration */}
       {config.type === 'basic' && (
-        <div className="space-y-4 p-4 bg-surface-800/50 rounded-lg border border-surface-700">
+        <div className="space-y-4 p-4 bg-white/50 rounded-lg border border-surface-200">
           <div>
             <label className="text-sm text-surface-600 block mb-1.5">Username</label>
             <Input
@@ -202,7 +202,7 @@ export default function AuthConfigPanel({ config, onChange }: AuthConfigPanelPro
       )}
       {/* OAuth 2.0 Configuration */}
       {config.type === 'oauth2' && (
-        <div className="space-y-4 p-4 bg-surface-800/50 rounded-lg border border-surface-700">
+        <div className="space-y-4 p-4 bg-white/50 rounded-lg border border-surface-200">
           <div>
             <label className="text-sm text-surface-600 block mb-2">Grant Type</label>
             <div className="grid grid-cols-2 gap-2">
@@ -213,10 +213,10 @@ export default function AuthConfigPanel({ config, onChange }: AuthConfigPanelPro
                   className={`p-3 text-left rounded-lg border transition-colors ${
                     config.oauth2Config?.grantType === grant.value
                       ? 'bg-brand-500/10 border-brand-500/30'
-                      : 'bg-surface-900 border-surface-700 hover:border-surface-600'
+                      : 'bg-white border-surface-200 hover:border-surface-300'
                   }`}
                 >
-                  <div className="font-medium text-sm text-surface-200">{grant.label}</div>
+                  <div className="font-medium text-sm text-surface-800">{grant.label}</div>
                   <div className="text-xs text-surface-500">{grant.description}</div>
                 </button>
               ))}
@@ -269,7 +269,7 @@ export default function AuthConfigPanel({ config, onChange }: AuthConfigPanelPro
       )}
       {/* Custom Authentication */}
       {config.type === 'custom' && (
-        <div className="space-y-4 p-4 bg-surface-800/50 rounded-lg border border-surface-700">
+        <div className="space-y-4 p-4 bg-white/50 rounded-lg border border-surface-200">
           <div>
             <label className="text-sm text-surface-600 block mb-1.5">Header Name</label>
             <Input

--- a/frontend/src/components/integrations/CodeEditor.tsx
+++ b/frontend/src/components/integrations/CodeEditor.tsx
@@ -175,7 +175,7 @@ export default function CodeEditor({
   return (
     <div className="h-full flex flex-col">
       {/* Toolbar */}
-      <div className="flex items-center justify-between px-4 py-2 bg-surface-800/50 border-b border-surface-700">
+      <div className="flex items-center justify-between px-4 py-2 bg-white/50 border-b border-surface-200">
         <div className="flex items-center gap-2">
           <Button
             onClick={handleValidate}
@@ -207,14 +207,14 @@ export default function CodeEditor({
         <div className="flex items-center gap-2">
           <button
             onClick={handleCopy}
-            className="p-2 text-surface-600 hover:text-surface-200"
+            className="p-2 text-surface-600 hover:text-surface-800"
             title="Copy code"
           >
             <DocumentDuplicateIcon className="w-4 h-4" />
           </button>
           <button
             onClick={handleReset}
-            className="p-2 text-surface-600 hover:text-surface-200"
+            className="p-2 text-surface-600 hover:text-surface-800"
             title="Reset to template"
           >
             <ArrowPathIcon className="w-4 h-4" />
@@ -223,7 +223,7 @@ export default function CodeEditor({
       </div>
       {/* Validation/Test Results */}
       {(validation || testResult) && (
-        <div className="px-4 py-2 bg-surface-800/30 border-b border-surface-700">
+        <div className="px-4 py-2 bg-white/30 border-b border-surface-200">
           {validation && (
             <div
               className={clsx(
@@ -275,7 +275,7 @@ export default function CodeEditor({
               <div>
                 <div>{testResult.message}</div>
                 {testResult.data && (
-                  <pre className="mt-2 p-2 bg-surface-900 rounded text-xs text-surface-700 overflow-auto max-h-32">
+                  <pre className="mt-2 p-2 bg-white rounded text-xs text-surface-700 overflow-auto max-h-32">
                     {JSON.stringify(testResult.data, null, 2)}
                   </pre>
                 )}
@@ -305,10 +305,10 @@ export default function CodeEditor({
         />
       </div>
       {/* Help Text */}
-      <div className="px-4 py-2 bg-surface-800/30 border-t border-surface-700 text-xs text-surface-500">
-        <strong>Tip:</strong> The <code className="bg-surface-700 px-1 rounded">sync(context)</code>{' '}
+      <div className="px-4 py-2 bg-white/30 border-t border-surface-200 text-xs text-surface-500">
+        <strong>Tip:</strong> The <code className="bg-surface-200 px-1 rounded">sync(context)</code>{' '}
         function is called when syncing. Return an object with an{' '}
-        <code className="bg-surface-700 px-1 rounded">evidence</code> array containing data to save.
+        <code className="bg-surface-200 px-1 rounded">evidence</code> array containing data to save.
       </div>
     </div>
   );

--- a/frontend/src/components/integrations/CustomConfigModal.tsx
+++ b/frontend/src/components/integrations/CustomConfigModal.tsx
@@ -279,9 +279,9 @@ export default function CustomConfigModal({
   return (
     <Dialog open onClose={onClose}>
       {/* Header */}
-      <div className="flex items-center justify-between px-6 py-4 border-b border-surface-700">
+      <div className="flex items-center justify-between px-6 py-4 border-b border-surface-200">
         <div>
-          <h2 className="text-lg font-semibold text-surface-100">Configure Custom Integration</h2>
+          <h2 className="text-lg font-semibold text-surface-900">Configure Custom Integration</h2>
           <p className="text-sm text-surface-600">{integrationName}</p>
         </div>
         <div className="flex items-center gap-3">
@@ -300,21 +300,21 @@ export default function CustomConfigModal({
               </span>
             </div>
           )}
-          <button onClick={onClose} className="p-2 text-surface-600 hover:text-surface-200">
+          <button onClick={onClose} className="p-2 text-surface-600 hover:text-surface-800">
             <XMarkIcon className="w-5 h-5" />
           </button>
         </div>
       </div>
 
       {/* Tabs */}
-      <div className="flex border-b border-surface-700">
+      <div className="flex border-b border-surface-200">
         <button
           onClick={() => handleTabChange('visual')}
           className={clsx(
             'flex items-center gap-2 px-6 py-3 text-sm font-medium border-b-2 transition-colors',
             activeTab === 'visual'
               ? 'border-brand-500 text-brand-400'
-              : 'border-transparent text-surface-600 hover:text-surface-200'
+              : 'border-transparent text-surface-600 hover:text-surface-800'
           )}
         >
           <Cog6ToothIcon className="w-4 h-4" />
@@ -326,7 +326,7 @@ export default function CustomConfigModal({
             'flex items-center gap-2 px-6 py-3 text-sm font-medium border-b-2 transition-colors',
             activeTab === 'code'
               ? 'border-brand-500 text-brand-400'
-              : 'border-transparent text-surface-600 hover:text-surface-200'
+              : 'border-transparent text-surface-600 hover:text-surface-800'
           )}
         >
           <CodeBracketIcon className="w-4 h-4" />
@@ -374,7 +374,7 @@ export default function CustomConfigModal({
       </div>
 
       {/* Footer */}
-      <div className="flex items-center justify-between px-6 py-4 border-t border-surface-700 bg-surface-800/50">
+      <div className="flex items-center justify-between px-6 py-4 border-t border-surface-200 bg-white/50">
         <div className="flex items-center gap-2">
           {hasChanges && <span className="text-xs text-yellow-600">• Unsaved changes</span>}
         </div>

--- a/frontend/src/components/integrations/EndpointBuilder.tsx
+++ b/frontend/src/components/integrations/EndpointBuilder.tsx
@@ -80,12 +80,12 @@ export default function EndpointBuilder({ endpoint, onChange, onDelete }: Endpoi
           type="text"
           value={endpoint.name}
           onChange={(e) => onChange({ name: e.target.value })}
-          className="text-lg font-semibold bg-transparent border-none text-surface-100 focus:outline-none focus:ring-0 p-0"
+          className="text-lg font-semibold bg-transparent border-none text-surface-900 focus:outline-none focus:ring-0 p-0"
           placeholder="Endpoint Name"
         />
         <button
           onClick={onDelete}
-          className="p-2 text-surface-600 hover:text-red-600 hover:bg-surface-800 rounded-lg transition-colors"
+          className="p-2 text-surface-600 hover:text-red-600 hover:bg-white rounded-lg transition-colors"
           title="Delete endpoint"
         >
           <TrashIcon className="w-5 h-5" />
@@ -154,7 +154,7 @@ export default function EndpointBuilder({ endpoint, onChange, onDelete }: Endpoi
               />
               <button
                 onClick={() => removeHeader(key)}
-                className="p-2 text-surface-600 hover:text-red-600 hover:bg-surface-800 rounded-lg transition-colors"
+                className="p-2 text-surface-600 hover:text-red-600 hover:bg-white rounded-lg transition-colors"
               >
                 <XMarkIcon className="w-4 h-4" />
               </button>
@@ -196,7 +196,7 @@ export default function EndpointBuilder({ endpoint, onChange, onDelete }: Endpoi
               />
               <button
                 onClick={() => removeQueryParam(key)}
-                className="p-2 text-surface-600 hover:text-red-600 hover:bg-surface-800 rounded-lg transition-colors"
+                className="p-2 text-surface-600 hover:text-red-600 hover:bg-white rounded-lg transition-colors"
               >
                 <XMarkIcon className="w-4 h-4" />
               </button>
@@ -229,7 +229,7 @@ export default function EndpointBuilder({ endpoint, onChange, onDelete }: Endpoi
             />
           )}
           {!showBodyEditor && endpoint.body && (
-            <pre className="p-3 bg-surface-800 rounded-lg text-xs text-surface-700 overflow-x-auto">
+            <pre className="p-3 bg-white rounded-lg text-xs text-surface-700 overflow-x-auto">
               {endpoint.body.slice(0, 200)}
               {endpoint.body.length > 200 && '...'}
             </pre>

--- a/frontend/src/components/integrations/IntegrationConfigModal.tsx
+++ b/frontend/src/components/integrations/IntegrationConfigModal.tsx
@@ -125,9 +125,9 @@ export default function IntegrationConfigModal({
     <Dialog open onClose={onClose} size="xl">
       <div className="flex flex-col">
         {/* Header */}
-        <div className="flex items-center justify-between p-6 border-b border-surface-800">
+        <div className="flex items-center justify-between p-6 border-b border-surface-200">
           <div>
-            <h2 className="text-lg font-semibold text-surface-100">Configure {typeMeta.name}</h2>
+            <h2 className="text-lg font-semibold text-surface-900">Configure {typeMeta.name}</h2>
             <p className="text-sm text-surface-600 mt-1">
               {existingIntegration
                 ? 'Update your integration settings'
@@ -137,12 +137,12 @@ export default function IntegrationConfigModal({
         </div>
 
         {/* Tabs */}
-        <div className="flex border-b border-surface-800">
+        <div className="flex border-b border-surface-200">
           <button
             onClick={() => setActiveTab('quick')}
             className={clsx(
               'flex-1 px-4 py-3 text-sm font-medium transition-colors relative',
-              activeTab === 'quick' ? 'text-brand-400' : 'text-surface-600 hover:text-surface-200'
+              activeTab === 'quick' ? 'text-brand-400' : 'text-surface-600 hover:text-surface-800'
             )}
           >
             Quick Setup
@@ -157,7 +157,7 @@ export default function IntegrationConfigModal({
               'flex-1 px-4 py-3 text-sm font-medium transition-colors relative',
               activeTab === 'advanced'
                 ? 'text-brand-400'
-                : 'text-surface-600 hover:text-surface-200'
+                : 'text-surface-600 hover:text-surface-800'
             )}
           >
             Advanced Builder
@@ -172,7 +172,7 @@ export default function IntegrationConfigModal({
             onClick={() => setActiveTab('raw')}
             className={clsx(
               'flex-1 px-4 py-3 text-sm font-medium transition-colors relative',
-              activeTab === 'raw' ? 'text-brand-400' : 'text-surface-600 hover:text-surface-200'
+              activeTab === 'raw' ? 'text-brand-400' : 'text-surface-600 hover:text-surface-800'
             )}
           >
             Raw API
@@ -201,7 +201,7 @@ export default function IntegrationConfigModal({
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-between p-6 border-t border-surface-800 bg-surface-900">
+        <div className="flex items-center justify-between p-6 border-t border-surface-200 bg-white">
           <div className="text-sm text-surface-500">
             {activeTab === 'quick' &&
               `${quickSetupConfig.evidenceTypes.length} evidence types selected`}

--- a/frontend/src/components/integrations/QuickSetupTab.tsx
+++ b/frontend/src/components/integrations/QuickSetupTab.tsx
@@ -237,7 +237,7 @@ export default function QuickSetupTab({ typeMeta, config, onChange }: QuickSetup
     <div className="p-6 space-y-8">
       {/* Basic Info */}
       <section>
-        <h3 className="text-sm font-semibold text-surface-200 mb-4">Basic Information</h3>
+        <h3 className="text-sm font-semibold text-surface-800 mb-4">Basic Information</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
             <label className="block text-sm text-surface-600 mb-1.5">Name</label>
@@ -276,7 +276,7 @@ export default function QuickSetupTab({ typeMeta, config, onChange }: QuickSetup
       </section>
       {/* Connection Settings */}
       <section>
-        <h3 className="text-sm font-semibold text-surface-200 mb-4">Connection Settings</h3>
+        <h3 className="text-sm font-semibold text-surface-800 mb-4">Connection Settings</h3>
         <div className="space-y-4">
           {typeMeta.configFields?.map((field) => (
             <div key={field.key}>
@@ -299,7 +299,7 @@ export default function QuickSetupTab({ typeMeta, config, onChange }: QuickSetup
       {typeMeta.evidenceTypes && typeMeta.evidenceTypes.length > 0 && (
         <section>
           <div className="flex items-center justify-between mb-4">
-            <h3 className="text-sm font-semibold text-surface-200">Data to Collect</h3>
+            <h3 className="text-sm font-semibold text-surface-800">Data to Collect</h3>
             <span className="text-xs text-surface-500">
               {config.evidenceTypes.length} of {typeMeta.evidenceTypes.length} selected
             </span>
@@ -311,7 +311,7 @@ export default function QuickSetupTab({ typeMeta, config, onChange }: QuickSetup
               <button
                 key={key}
                 onClick={() => applyPreset(key as keyof typeof PRESETS)}
-                className="px-3 py-1.5 text-xs bg-surface-800 hover:bg-surface-700 border border-surface-700 rounded-lg transition-colors"
+                className="px-3 py-1.5 text-xs bg-white hover:bg-surface-200 border border-surface-200 rounded-lg transition-colors"
                 title={preset.description}
               >
                 {preset.label}
@@ -332,7 +332,7 @@ export default function QuickSetupTab({ typeMeta, config, onChange }: QuickSetup
           </div>
 
           {/* Category Groups */}
-          <div className="space-y-2 border border-surface-800 rounded-lg overflow-hidden">
+          <div className="space-y-2 border border-surface-200 rounded-lg overflow-hidden">
             {Object.entries(filteredGroups).map(([category, types]) => {
               const isExpanded = expandedCategories.has(category);
               const selectedCount = types.filter((t) =>
@@ -341,10 +341,10 @@ export default function QuickSetupTab({ typeMeta, config, onChange }: QuickSetup
               const allSelected = selectedCount === types.length;
 
               return (
-                <div key={category} className="bg-surface-800/50">
+                <div key={category} className="bg-white/50">
                   {/* Category Header */}
                   <div
-                    className="flex items-center justify-between px-4 py-3 cursor-pointer hover:bg-surface-800 transition-colors"
+                    className="flex items-center justify-between px-4 py-3 cursor-pointer hover:bg-white transition-colors"
                     onClick={() => toggleCategory(category)}
                   >
                     <div className="flex items-center gap-2">
@@ -353,7 +353,7 @@ export default function QuickSetupTab({ typeMeta, config, onChange }: QuickSetup
                       ) : (
                         <ChevronRightIcon className="w-4 h-4 text-surface-600" />
                       )}
-                      <span className="font-medium text-surface-200">{category}</span>
+                      <span className="font-medium text-surface-800">{category}</span>
                       <span className="text-xs text-surface-500">
                         ({selectedCount}/{types.length})
                       </span>
@@ -382,7 +382,7 @@ export default function QuickSetupTab({ typeMeta, config, onChange }: QuickSetup
                               'flex items-start gap-3 p-3 rounded-lg cursor-pointer transition-colors',
                               isSelected
                                 ? 'bg-brand-500/10 border border-brand-500/30'
-                                : 'bg-surface-900/50 border border-transparent hover:border-surface-700'
+                                : 'bg-white/50 border border-transparent hover:border-surface-200'
                             )}
                           >
                             <div
@@ -390,13 +390,13 @@ export default function QuickSetupTab({ typeMeta, config, onChange }: QuickSetup
                                 'w-5 h-5 rounded flex items-center justify-center flex-shrink-0 mt-0.5 transition-colors',
                                 isSelected
                                   ? 'bg-brand-500 text-white'
-                                  : 'bg-surface-700 border border-surface-600'
+                                  : 'bg-surface-200 border border-surface-300'
                               )}
                             >
                               {isSelected && <CheckIcon className="w-3.5 h-3.5" />}
                             </div>
                             <div className="flex-1 min-w-0">
-                              <div className="font-medium text-sm text-surface-200">
+                              <div className="font-medium text-sm text-surface-800">
                                 {evidenceType.label}
                               </div>
                               <div className="text-xs text-surface-500 mt-0.5">
@@ -415,7 +415,7 @@ export default function QuickSetupTab({ typeMeta, config, onChange }: QuickSetup
 
           {/* Summary */}
           {config.evidenceTypes.length > 0 && (
-            <div className="mt-4 p-4 bg-surface-800/50 rounded-lg border border-surface-700">
+            <div className="mt-4 p-4 bg-white/50 rounded-lg border border-surface-200">
               <h4 className="text-xs font-semibold text-surface-700 uppercase mb-2">
                 Collection Summary
               </h4>
@@ -425,14 +425,14 @@ export default function QuickSetupTab({ typeMeta, config, onChange }: QuickSetup
                   return (
                     <span
                       key={key}
-                      className="px-2 py-1 text-xs bg-surface-700 rounded text-surface-700"
+                      className="px-2 py-1 text-xs bg-surface-200 rounded text-surface-700"
                     >
                       {et?.label || key}
                     </span>
                   );
                 })}
                 {config.evidenceTypes.length > 10 && (
-                  <span className="px-2 py-1 text-xs bg-surface-700 rounded text-surface-600">
+                  <span className="px-2 py-1 text-xs bg-surface-200 rounded text-surface-600">
                     +{config.evidenceTypes.length - 10} more
                   </span>
                 )}

--- a/frontend/src/components/integrations/RawApiTab.tsx
+++ b/frontend/src/components/integrations/RawApiTab.tsx
@@ -281,15 +281,15 @@ export default function RawApiTab({ config, onChange }: RawApiTabProps) {
   return (
     <div className="h-full flex flex-col">
       {/* Mode Toggle */}
-      <div className="p-4 border-b border-surface-800">
-        <div className="flex items-center gap-2 p-1 bg-surface-800 rounded-lg w-fit">
+      <div className="p-4 border-b border-surface-200">
+        <div className="flex items-center gap-2 p-1 bg-white rounded-lg w-fit">
           <button
             onClick={() => setMode('requests')}
             className={clsx(
               'px-4 py-2 text-sm font-medium rounded-md transition-colors flex items-center gap-2',
               mode === 'requests'
-                ? 'bg-surface-700 text-surface-100'
-                : 'text-surface-600 hover:text-surface-200'
+                ? 'bg-surface-200 text-surface-900'
+                : 'text-surface-600 hover:text-surface-800'
             )}
           >
             <CommandLineIcon className="w-4 h-4" />
@@ -300,8 +300,8 @@ export default function RawApiTab({ config, onChange }: RawApiTabProps) {
             className={clsx(
               'px-4 py-2 text-sm font-medium rounded-md transition-colors flex items-center gap-2',
               mode === 'code'
-                ? 'bg-surface-700 text-surface-100'
-                : 'text-surface-600 hover:text-surface-200'
+                ? 'bg-surface-200 text-surface-900'
+                : 'text-surface-600 hover:text-surface-800'
             )}
           >
             <CodeBracketIcon className="w-4 h-4" />
@@ -312,8 +312,8 @@ export default function RawApiTab({ config, onChange }: RawApiTabProps) {
       {mode === 'requests' ? (
         <div className="flex-1 flex overflow-hidden">
           {/* Request List Sidebar */}
-          <div className="w-64 border-r border-surface-800 flex flex-col">
-            <div className="p-3 border-b border-surface-800">
+          <div className="w-64 border-r border-surface-200 flex flex-col">
+            <div className="p-3 border-b border-surface-200">
               <div className="flex gap-2">
                 <Button onClick={addRequest} className="flex-1 text-xs py-1.5" variant="secondary">
                   <PlusIcon className="w-3.5 h-3.5 mr-1" />
@@ -338,7 +338,7 @@ export default function RawApiTab({ config, onChange }: RawApiTabProps) {
                     'w-full text-left p-2 rounded-lg transition-colors group',
                     selectedRequestId === request.id
                       ? 'bg-brand-500/10 border border-brand-500/30'
-                      : 'hover:bg-surface-800 border border-transparent'
+                      : 'hover:bg-white border border-transparent'
                   )}
                 >
                   <div className="flex items-center gap-2">
@@ -354,7 +354,7 @@ export default function RawApiTab({ config, onChange }: RawApiTabProps) {
                     >
                       {request.method}
                     </span>
-                    <span className="text-xs text-surface-200 truncate flex-1">{request.name}</span>
+                    <span className="text-xs text-surface-800 truncate flex-1">{request.name}</span>
                   </div>
                   {request.url && (
                     <div className="text-[10px] text-surface-500 truncate mt-1 font-mono">
@@ -377,25 +377,25 @@ export default function RawApiTab({ config, onChange }: RawApiTabProps) {
           <div className="flex-1 flex flex-col overflow-hidden">
             {selectedRequest ? (
               <>
-                <div className="p-4 border-b border-surface-800 flex items-center justify-between">
+                <div className="p-4 border-b border-surface-200 flex items-center justify-between">
                   <Input
                     type="text"
                     value={selectedRequest.name}
                     onChange={(e) => updateRequest(selectedRequest.id, { name: e.target.value })}
-                    className="text-lg font-semibold bg-transparent border-none text-surface-100 focus:outline-none p-0"
+                    className="text-lg font-semibold bg-transparent border-none text-surface-900 focus:outline-none p-0"
                     placeholder="Request Name"
                   />
                   <div className="flex items-center gap-2">
                     <button
                       onClick={() => duplicateRequest(selectedRequest.id)}
-                      className="p-1.5 text-surface-600 hover:text-surface-200 hover:bg-surface-800 rounded transition-colors"
+                      className="p-1.5 text-surface-600 hover:text-surface-800 hover:bg-white rounded transition-colors"
                       title="Duplicate"
                     >
                       <DocumentDuplicateIcon className="w-4 h-4" />
                     </button>
                     <button
                       onClick={() => deleteRequest(selectedRequest.id)}
-                      className="p-1.5 text-surface-600 hover:text-red-600 hover:bg-surface-800 rounded transition-colors"
+                      className="p-1.5 text-surface-600 hover:text-red-600 hover:bg-white rounded transition-colors"
                       title="Delete"
                     >
                       <TrashIcon className="w-4 h-4" />
@@ -484,7 +484,7 @@ export default function RawApiTab({ config, onChange }: RawApiTabProps) {
                   </div>
 
                   {/* Test Button & Results */}
-                  <div className="pt-4 border-t border-surface-800">
+                  <div className="pt-4 border-t border-surface-200">
                     <Button
                       onClick={testRequest}
                       disabled={isTesting || !selectedRequest.url}
@@ -549,7 +549,7 @@ export default function RawApiTab({ config, onChange }: RawApiTabProps) {
       ) : (
         /* Custom Code Mode */
         <div className="flex-1 flex flex-col overflow-hidden p-4 space-y-4">
-          <div className="p-4 bg-surface-800/50 rounded-lg border border-surface-700">
+          <div className="p-4 bg-white/50 rounded-lg border border-surface-200">
             <div className="flex items-start gap-2">
               <InformationCircleIcon className="w-5 h-5 text-brand-400 flex-shrink-0 mt-0.5" />
               <div className="text-sm text-surface-600">
@@ -584,7 +584,7 @@ export default function RawApiTab({ config, onChange }: RawApiTabProps) {
       )}
       {/* Parse Modal */}
       <Dialog open={showParseModal} onClose={() => setShowParseModal(false)}>
-        <h3 className="text-lg font-semibold text-surface-100 mb-4">Paste cURL or HTTP Request</h3>
+        <h3 className="text-lg font-semibold text-surface-900 mb-4">Paste cURL or HTTP Request</h3>
         <p className="text-sm text-surface-600 mb-4">
           Paste a cURL command or raw HTTP request and we'll parse it for you.
         </p>

--- a/frontend/src/components/integrations/RequestTester.tsx
+++ b/frontend/src/components/integrations/RequestTester.tsx
@@ -202,7 +202,7 @@ export default function RequestTester({
       </div>
       {/* Request Preview */}
       {selectedEndpoint && baseUrl && (
-        <div className="p-4 bg-surface-800/50 rounded-lg border border-surface-700">
+        <div className="p-4 bg-white/50 rounded-lg border border-surface-200">
           <div className="flex items-center justify-between mb-2">
             <span className="text-xs text-surface-500 uppercase font-medium">Request Preview</span>
           </div>
@@ -241,7 +241,7 @@ export default function RequestTester({
         className={clsx(
           'w-full py-3 rounded-lg font-medium flex items-center justify-center gap-2 transition-colors',
           isTesting
-            ? 'bg-surface-700 text-surface-600 cursor-wait'
+            ? 'bg-surface-200 text-surface-600 cursor-wait'
             : 'bg-brand-500 hover:bg-brand-600 text-white'
         )}
       >
@@ -299,7 +299,7 @@ export default function RequestTester({
               {testResult.data && (
                 <button
                   onClick={copyResponse}
-                  className="flex items-center gap-1 hover:text-surface-200 transition-colors"
+                  className="flex items-center gap-1 hover:text-surface-800 transition-colors"
                 >
                   <DocumentDuplicateIcon className="w-4 h-4" />
                   Copy
@@ -317,10 +317,10 @@ export default function RequestTester({
 
           {/* Response Headers */}
           {testResult.success && Object.keys(testResult.headers).length > 0 && (
-            <div className="border-t border-surface-800">
+            <div className="border-t border-surface-200">
               <button
                 onClick={() => setShowHeaders(!showHeaders)}
-                className="w-full flex items-center gap-2 p-3 text-sm text-surface-600 hover:text-surface-200 transition-colors"
+                className="w-full flex items-center gap-2 p-3 text-sm text-surface-600 hover:text-surface-800 transition-colors"
               >
                 {showHeaders ? (
                   <ChevronDownIcon className="w-4 h-4" />
@@ -331,7 +331,7 @@ export default function RequestTester({
               </button>
               {showHeaders && (
                 <div className="px-4 pb-3">
-                  <div className="p-3 bg-surface-800/50 rounded font-mono text-xs space-y-1">
+                  <div className="p-3 bg-white/50 rounded font-mono text-xs space-y-1">
                     {Object.entries(testResult.headers).map(([key, value]) => (
                       <div key={key}>
                         <span className="text-surface-500">{key}:</span>{' '}
@@ -346,10 +346,10 @@ export default function RequestTester({
 
           {/* Response Body */}
           {testResult.data && (
-            <div className="border-t border-surface-800">
+            <div className="border-t border-surface-200">
               <button
                 onClick={() => setShowRawResponse(!showRawResponse)}
-                className="w-full flex items-center gap-2 p-3 text-sm text-surface-600 hover:text-surface-200 transition-colors"
+                className="w-full flex items-center gap-2 p-3 text-sm text-surface-600 hover:text-surface-800 transition-colors"
               >
                 {showRawResponse ? (
                   <ChevronDownIcon className="w-4 h-4" />
@@ -360,7 +360,7 @@ export default function RequestTester({
               </button>
               {showRawResponse && (
                 <div className="px-4 pb-4">
-                  <pre className="p-4 bg-surface-900 rounded-lg overflow-x-auto text-xs font-mono text-surface-700 max-h-96">
+                  <pre className="p-4 bg-white rounded-lg overflow-x-auto text-xs font-mono text-surface-700 max-h-96">
                     {JSON.stringify(testResult.data, null, 2)}
                   </pre>
                 </div>

--- a/frontend/src/components/integrations/ResponseMapper.tsx
+++ b/frontend/src/components/integrations/ResponseMapper.tsx
@@ -117,7 +117,7 @@ export default function ResponseMapper({
   return (
     <div className="space-y-6">
       {/* Instructions */}
-      <div className="p-4 bg-surface-800/50 rounded-lg border border-surface-700">
+      <div className="p-4 bg-white/50 rounded-lg border border-surface-200">
         <div className="flex items-start gap-2">
           <InformationCircleIcon className="w-5 h-5 text-brand-400 flex-shrink-0 mt-0.5" />
           <div className="text-sm text-surface-600">
@@ -138,12 +138,12 @@ export default function ResponseMapper({
           {showSuggestions ? 'Hide suggestions' : 'Show common field suggestions'}
         </button>
         {showSuggestions && (
-          <div className="flex flex-wrap gap-2 p-3 bg-surface-800/30 rounded-lg">
+          <div className="flex flex-wrap gap-2 p-3 bg-white/30 rounded-lg">
             {SUGGESTED_FIELDS.map(({ field, description }) => (
               <button
                 key={field}
                 onClick={() => addSuggestedField(field)}
-                className="px-2 py-1 text-xs bg-surface-700 hover:bg-surface-600 rounded border border-surface-600 hover:border-surface-500 transition-colors"
+                className="px-2 py-1 text-xs bg-surface-200 hover:bg-surface-600 rounded border border-surface-300 hover:border-surface-500 transition-colors"
                 title={description}
               >
                 {field}
@@ -179,10 +179,7 @@ export default function ResponseMapper({
       {/* Mapping List */}
       <div className="space-y-3">
         {mappings.map((mapping) => (
-          <div
-            key={mapping.id}
-            className="p-4 bg-surface-800/50 rounded-lg border border-surface-700"
-          >
+          <div key={mapping.id} className="p-4 bg-white/50 rounded-lg border border-surface-200">
             <div className="flex items-start gap-4">
               <div className="flex-1 grid grid-cols-1 md:grid-cols-2 gap-4">
                 {/* Source Path */}
@@ -262,7 +259,7 @@ export default function ResponseMapper({
               {/* Delete Button */}
               <button
                 onClick={() => deleteMapping(mapping.id)}
-                className="p-2 text-surface-600 hover:text-red-600 hover:bg-surface-800 rounded-lg transition-colors"
+                className="p-2 text-surface-600 hover:text-red-600 hover:bg-white rounded-lg transition-colors"
               >
                 <TrashIcon className="w-4 h-4" />
               </button>
@@ -270,7 +267,7 @@ export default function ResponseMapper({
 
             {/* Preview */}
             {mapping.sourcePath && mapping.targetField && (
-              <div className="mt-3 pt-3 border-t border-surface-700 text-xs text-surface-500">
+              <div className="mt-3 pt-3 border-t border-surface-200 text-xs text-surface-500">
                 <code className="text-brand-400">{mapping.sourcePath}</code>
                 {' → '}
                 <code className="text-green-600">{mapping.targetField}</code>
@@ -283,7 +280,7 @@ export default function ResponseMapper({
         ))}
 
         {mappings.length === 0 && (
-          <div className="text-center py-8 text-surface-500 bg-surface-800/30 rounded-lg border border-dashed border-surface-700">
+          <div className="text-center py-8 text-surface-500 bg-white/30 rounded-lg border border-dashed border-surface-200">
             No field mappings configured. Add mappings to extract data from API responses.
           </div>
         )}
@@ -291,7 +288,7 @@ export default function ResponseMapper({
       {/* Add Button */}
       <button
         onClick={addMapping}
-        className="w-full p-3 rounded-lg border border-dashed border-surface-700 hover:border-surface-500 text-surface-600 hover:text-surface-200 transition-colors flex items-center justify-center gap-2"
+        className="w-full p-3 rounded-lg border border-dashed border-surface-200 hover:border-surface-500 text-surface-600 hover:text-surface-800 transition-colors flex items-center justify-center gap-2"
       >
         <PlusIcon className="w-4 h-4" />
         Add Field Mapping

--- a/frontend/src/components/integrations/VisualConfigBuilder.tsx
+++ b/frontend/src/components/integrations/VisualConfigBuilder.tsx
@@ -119,8 +119,8 @@ export default function VisualConfigBuilder({ config, onChange, onTest, isTestLo
         <p className="text-xs text-surface-500 mt-1">The base URL for all API requests</p>
       </div>
       {/* Authentication */}
-      <div className="border border-surface-700 rounded-lg p-4">
-        <h3 className="text-sm font-medium text-surface-200 mb-4">Authentication</h3>
+      <div className="border border-surface-200 rounded-lg p-4">
+        <h3 className="text-sm font-medium text-surface-800 mb-4">Authentication</h3>
 
         <div className="flex gap-4 mb-4">
           <label className="flex items-center gap-2 cursor-pointer">
@@ -258,7 +258,7 @@ export default function VisualConfigBuilder({ config, onChange, onTest, isTestLo
       {/* Endpoints */}
       <div>
         <div className="flex items-center justify-between mb-4">
-          <h3 className="text-sm font-medium text-surface-200">Endpoints</h3>
+          <h3 className="text-sm font-medium text-surface-800">Endpoints</h3>
           <Button
             onClick={addEndpoint}
             className="text-sm flex items-center gap-1"
@@ -270,7 +270,7 @@ export default function VisualConfigBuilder({ config, onChange, onTest, isTestLo
         </div>
 
         {config.endpoints.length === 0 ? (
-          <div className="text-center py-8 text-surface-500 border border-dashed border-surface-700 rounded-lg">
+          <div className="text-center py-8 text-surface-500 border border-dashed border-surface-200 rounded-lg">
             No endpoints configured. Add an endpoint to get started.
           </div>
         ) : (
@@ -346,10 +346,10 @@ function EndpointCard({
   };
 
   return (
-    <div className="border border-surface-700 rounded-lg overflow-hidden">
+    <div className="border border-surface-200 rounded-lg overflow-hidden">
       {/* Header */}
       <div
-        className="flex items-center justify-between px-4 py-3 bg-surface-800/50 cursor-pointer"
+        className="flex items-center justify-between px-4 py-3 bg-white/50 cursor-pointer"
         onClick={onToggle}
       >
         <div className="flex items-center gap-3">
@@ -361,7 +361,7 @@ function EndpointCard({
           >
             {endpoint.method}
           </span>
-          <span className="text-surface-200 font-medium">{endpoint.name || endpoint.path}</span>
+          <span className="text-surface-800 font-medium">{endpoint.name || endpoint.path}</span>
         </div>
         <div className="flex items-center gap-2">
           <button
@@ -392,7 +392,7 @@ function EndpointCard({
       </div>
       {/* Expanded Content */}
       {isExpanded && (
-        <div className="p-4 space-y-4 bg-surface-900/30">
+        <div className="p-4 space-y-4 bg-white/30">
           {/* Name & Description */}
           <div className="grid grid-cols-2 gap-4">
             <div>
@@ -502,7 +502,7 @@ function EndpointCard({
           )}
 
           {/* Response Mapping */}
-          <div className="border-t border-surface-700 pt-4">
+          <div className="border-t border-surface-200 pt-4">
             <h4 className="text-xs font-medium text-surface-700 mb-3">
               Response Mapping (JSONPath)
             </h4>

--- a/frontend/src/components/mappings/MappingEditorModal.tsx
+++ b/frontend/src/components/mappings/MappingEditorModal.tsx
@@ -401,7 +401,7 @@ export function MappingEditorModal({
           <button
             type="button"
             onClick={handleBack}
-            className="inline-flex items-center gap-1 text-sm text-surface-600 hover:text-surface-200"
+            className="inline-flex items-center gap-1 text-sm text-surface-600 hover:text-surface-800"
           >
             <ArrowLeftIcon className="h-4 w-4" aria-hidden="true" />
             Back
@@ -556,7 +556,7 @@ function SearchStage({
             onChange={(e) => onSelectFramework(e.target.value || undefined)}
             disabled={frameworksLoading}
             aria-label="Framework"
-            className="w-full rounded-lg bg-surface-700 border border-surface-600 text-surface-100 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500"
+            className="w-full rounded-lg bg-surface-200 border border-surface-300 text-surface-900 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500"
           >
             <option value="">Select a framework…</option>
             {frameworks.map((fw) => (
@@ -583,7 +583,7 @@ function SearchStage({
                 ? 'Filter controls by ID or title…'
                 : 'Filter requirements by reference or title…'
             }
-            className="w-full rounded-lg bg-surface-700 border border-surface-600 text-surface-100 pl-9 pr-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500"
+            className="w-full rounded-lg bg-surface-200 border border-surface-300 text-surface-900 pl-9 pr-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500"
           />
         </div>
       </label>
@@ -624,7 +624,7 @@ function MultiSelectStage({
             value={search}
             onChange={(e) => onSearchChange(e.target.value)}
             placeholder="Filter…"
-            className="w-full rounded-lg bg-surface-700 border border-surface-600 text-surface-100 pl-9 pr-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500"
+            className="w-full rounded-lg bg-surface-200 border border-surface-300 text-surface-900 pl-9 pr-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500"
           />
         </div>
       </label>
@@ -638,7 +638,7 @@ function MultiSelectStage({
           aria-label={
             mode === 'requirement-to-controls' ? 'Candidate controls' : 'Candidate requirements'
           }
-          className="max-h-72 overflow-y-auto space-y-1 border border-surface-700 rounded-lg p-2 bg-surface-900/40"
+          className="max-h-72 overflow-y-auto space-y-1 border border-surface-200 rounded-lg p-2 bg-white/40"
         >
           {candidates.map((c) => {
             const id = c.id;
@@ -655,17 +655,17 @@ function MultiSelectStage({
                     'flex items-start gap-3 rounded-md px-3 py-2 cursor-pointer',
                     checked
                       ? 'bg-brand-600/20 border border-brand-500/40'
-                      : 'hover:bg-surface-800 border border-transparent'
+                      : 'hover:bg-white border border-transparent'
                   )}
                 >
                   <input
                     type="checkbox"
                     checked={checked}
                     onChange={() => onToggle(id)}
-                    className="mt-1 h-4 w-4 rounded border-surface-600 bg-surface-800 text-brand-500 focus:ring-brand-500"
+                    className="mt-1 h-4 w-4 rounded border-surface-300 bg-white text-brand-500 focus:ring-brand-500"
                   />
                   <span className="flex-1">
-                    <span className="block font-mono text-sm text-surface-200">{primary}</span>
+                    <span className="block font-mono text-sm text-surface-800">{primary}</span>
                     <span className="block text-sm text-surface-600">{secondary}</span>
                   </span>
                 </label>
@@ -702,10 +702,10 @@ function PerRowFormStage({ rows, getLabel, onChange, disabled, isEditMode }: Per
         {rows.map((row) => (
           <li
             key={row.candidateId}
-            className="rounded-lg border border-surface-700 p-3 bg-surface-900/40"
+            className="rounded-lg border border-surface-200 p-3 bg-white/40"
           >
             {!isEditMode && (
-              <p className="text-sm font-medium text-surface-200 mb-2">
+              <p className="text-sm font-medium text-surface-800 mb-2">
                 {getLabel(row.candidateId)}
               </p>
             )}
@@ -723,7 +723,7 @@ function PerRowFormStage({ rows, getLabel, onChange, disabled, isEditMode }: Per
                   }
                   disabled={disabled}
                   aria-label={`Mapping type for ${getLabel(row.candidateId)}`}
-                  className="w-full rounded-lg bg-surface-700 border border-surface-600 text-surface-100 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500 disabled:opacity-50"
+                  className="w-full rounded-lg bg-surface-200 border border-surface-300 text-surface-900 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500 disabled:opacity-50"
                 >
                   <option value="primary">Primary</option>
                   <option value="supporting">Supporting</option>
@@ -738,7 +738,7 @@ function PerRowFormStage({ rows, getLabel, onChange, disabled, isEditMode }: Per
                   disabled={disabled}
                   aria-label={`Notes for ${getLabel(row.candidateId)}`}
                   placeholder="Optional"
-                  className="w-full rounded-lg bg-surface-700 border border-surface-600 text-surface-100 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500 disabled:opacity-50"
+                  className="w-full rounded-lg bg-surface-200 border border-surface-300 text-surface-900 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500 disabled:opacity-50"
                 />
               </label>
             </div>
@@ -768,12 +768,12 @@ function SuggestionsPanel({
   return (
     <section
       aria-label="AI mapping suggestions"
-      className="rounded-lg border border-surface-700 bg-surface-900/40 p-3 space-y-3"
+      className="rounded-lg border border-surface-200 bg-white/40 p-3 space-y-3"
     >
       <div className="flex items-center justify-between gap-3">
         <div className="flex items-center gap-2">
           <SparklesIcon className="h-4 w-4 text-brand-400" aria-hidden="true" />
-          <h3 className="text-sm font-medium text-surface-200">AI suggestions</h3>
+          <h3 className="text-sm font-medium text-surface-800">AI suggestions</h3>
         </div>
         <button
           type="button"
@@ -836,12 +836,12 @@ function SuggestionsPanel({
             return (
               <li
                 key={s.candidateId}
-                className="rounded-md border border-surface-700 bg-surface-900/60 p-2.5"
+                className="rounded-md border border-surface-200 bg-white/60 p-2.5"
               >
                 <div className="flex items-start justify-between gap-3">
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2 flex-wrap">
-                      <span className="font-mono text-xs text-surface-200">
+                      <span className="font-mono text-xs text-surface-800">
                         {s.candidateReference}
                       </span>
                       <ConfidenceBadge value={s.confidence} />
@@ -854,7 +854,7 @@ function SuggestionsPanel({
                     onClick={() => onUse(s.candidateId)}
                     disabled={already}
                     aria-label={`Use suggestion ${s.candidateReference}`}
-                    className="shrink-0 rounded-md border border-surface-600 bg-surface-700 px-2 py-1 text-xs font-medium text-surface-100 hover:bg-surface-600 disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="shrink-0 rounded-md border border-surface-300 bg-surface-200 px-2 py-1 text-xs font-medium text-surface-900 hover:bg-surface-600 disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     {already ? 'Added' : 'Use'}
                   </button>

--- a/frontend/src/components/mappings/MappingHistoryDrawer.tsx
+++ b/frontend/src/components/mappings/MappingHistoryDrawer.tsx
@@ -138,7 +138,7 @@ function DiffRows({ prev, current }: DiffRowsProps) {
         return (
           <div
             key={field}
-            className="flex flex-col gap-1 p-2 rounded-lg bg-surface-900/40 border border-surface-700"
+            className="flex flex-col gap-1 p-2 rounded-lg bg-white/40 border border-surface-200"
           >
             <span className="text-xs text-surface-600 font-medium">{FIELD_LABELS[field]}</span>
             <div className="flex items-center gap-2 text-sm flex-wrap">
@@ -217,7 +217,7 @@ function HistoryEntryItem({
       className="relative pl-8 pb-6 last:pb-0"
     >
       {/* Timeline line */}
-      <div className="absolute left-[11px] top-6 bottom-0 w-px bg-surface-700" aria-hidden="true" />
+      <div className="absolute left-[11px] top-6 bottom-0 w-px bg-surface-200" aria-hidden="true" />
       {/* Timeline dot */}
       <div
         className={clsx(
@@ -229,7 +229,7 @@ function HistoryEntryItem({
       >
         <Icon className={clsx('w-3.5 h-3.5', meta.text)} />
       </div>
-      <div className="bg-surface-800 rounded-lg border border-surface-700 p-3">
+      <div className="bg-white rounded-lg border border-surface-200 p-3">
         <div className="flex items-start justify-between gap-3">
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 flex-wrap">
@@ -311,7 +311,7 @@ function HistoryEntryItem({
                 disabled={isRestoring}
                 aria-label="Restore reason"
                 placeholder="Why are you restoring this version?"
-                className="w-full rounded-md bg-surface-900 border border-surface-700 text-surface-100 px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-purple-500 disabled:opacity-50"
+                className="w-full rounded-md bg-white border border-surface-200 text-surface-900 px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-purple-500 disabled:opacity-50"
               />
             </label>
             <div className="flex justify-end gap-2">
@@ -322,7 +322,7 @@ function HistoryEntryItem({
                   setReason('');
                 }}
                 disabled={isRestoring}
-                className="text-xs px-2 py-1 text-surface-700 hover:text-surface-100 disabled:opacity-50"
+                className="text-xs px-2 py-1 text-surface-700 hover:text-surface-900 disabled:opacity-50"
               >
                 Cancel
               </button>
@@ -345,10 +345,10 @@ function HistoryEntryItem({
 function SkeletonRow() {
   return (
     <div className="relative pl-8 pb-6" aria-hidden="true">
-      <div className="absolute left-0 top-0 w-6 h-6 rounded-full bg-surface-700 animate-pulse" />
-      <div className="bg-surface-800 rounded-lg border border-surface-700 p-4 animate-pulse">
-        <div className="h-4 bg-surface-700 rounded w-1/3 mb-2" />
-        <div className="h-3 bg-surface-700 rounded w-2/3" />
+      <div className="absolute left-0 top-0 w-6 h-6 rounded-full bg-surface-200 animate-pulse" />
+      <div className="bg-white rounded-lg border border-surface-200 p-4 animate-pulse">
+        <div className="h-4 bg-surface-200 rounded w-1/3 mb-2" />
+        <div className="h-3 bg-surface-200 rounded w-2/3" />
       </div>
     </div>
   );
@@ -422,7 +422,7 @@ export function MappingHistoryDrawer({
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <div className="fixed inset-0 bg-surface-900 opacity-60" aria-hidden="true" />
+          <div className="fixed inset-0 bg-white opacity-60" aria-hidden="true" />
         </Transition.Child>
 
         <div className="fixed inset-0 overflow-hidden">
@@ -438,15 +438,15 @@ export function MappingHistoryDrawer({
                 leaveTo="translate-x-full"
               >
                 <Dialog.Panel
-                  className="pointer-events-auto w-screen max-w-xl h-full bg-surface-800 border-l border-surface-700 shadow-xl flex flex-col"
+                  className="pointer-events-auto w-screen max-w-xl h-full bg-white border-l border-surface-200 shadow-xl flex flex-col"
                   aria-labelledby="mapping-history-drawer-title"
                 >
-                  <header className="flex items-start justify-between p-4 border-b border-surface-700">
+                  <header className="flex items-start justify-between p-4 border-b border-surface-200">
                     <div>
                       <Dialog.Title
                         as="h2"
                         id="mapping-history-drawer-title"
-                        className="text-lg font-semibold text-surface-100"
+                        className="text-lg font-semibold text-surface-900"
                       >
                         Mapping change history
                       </Dialog.Title>
@@ -458,7 +458,7 @@ export function MappingHistoryDrawer({
                       type="button"
                       onClick={onClose}
                       aria-label="Close history drawer"
-                      className="rounded-lg p-1.5 text-surface-600 hover:bg-surface-700 hover:text-surface-200 focus:outline-none focus:ring-2 focus:ring-brand-500"
+                      className="rounded-lg p-1.5 text-surface-600 hover:bg-surface-200 hover:text-surface-800 focus:outline-none focus:ring-2 focus:ring-brand-500"
                     >
                       <XMarkIcon className="h-5 w-5" aria-hidden="true" />
                     </button>
@@ -497,7 +497,7 @@ export function MappingHistoryDrawer({
                     )}
 
                     {!isLoading && !error && entries.length === 0 && (
-                      <div className="text-center py-12 bg-surface-900/40 rounded-lg border border-surface-700">
+                      <div className="text-center py-12 bg-white/40 rounded-lg border border-surface-200">
                         <ClockIcon
                           className="w-10 h-10 mx-auto text-surface-600 mb-3"
                           aria-hidden="true"

--- a/frontend/src/components/mappings/MappingImportWizard.tsx
+++ b/frontend/src/components/mappings/MappingImportWizard.tsx
@@ -189,10 +189,10 @@ export function MappingImportWizard({
           onClick={handleClose}
         />
 
-        <div className="relative w-full max-w-3xl bg-surface-900 rounded-xl shadow-2xl border border-surface-700">
-          <div className="flex items-center justify-between p-6 border-b border-surface-700">
+        <div className="relative w-full max-w-3xl bg-white rounded-xl shadow-2xl border border-surface-200">
+          <div className="flex items-center justify-between p-6 border-b border-surface-200">
             <div>
-              <h2 className="text-xl font-semibold text-surface-100">Import mappings</h2>
+              <h2 className="text-xl font-semibold text-surface-900">Import mappings</h2>
               <p className="text-sm text-surface-600 mt-1">
                 {stage === 'upload' && 'Upload a CSV or XLSX file to validate before committing.'}
                 {stage === 'preview' && 'Review parsed rows before importing.'}
@@ -203,7 +203,7 @@ export function MappingImportWizard({
               type="button"
               onClick={handleClose}
               aria-label="Close import wizard"
-              className="p-2 text-surface-600 hover:text-surface-200 hover:bg-surface-800 rounded-lg transition-colors"
+              className="p-2 text-surface-600 hover:text-surface-800 hover:bg-white rounded-lg transition-colors"
             >
               <XMarkIcon className="w-5 h-5" />
             </button>
@@ -239,7 +239,7 @@ export function MappingImportWizard({
             )}
           </div>
 
-          <div className="flex items-center justify-between gap-3 p-6 border-t border-surface-700">
+          <div className="flex items-center justify-between gap-3 p-6 border-t border-surface-200">
             {stage === 'upload' && (
               <>
                 <Button type="button" onClick={handleClose} variant="secondary">
@@ -319,8 +319,8 @@ function UploadStage({
 }: UploadStageProps) {
   return (
     <div className="space-y-4">
-      <div className="p-4 bg-surface-800/50 rounded-lg border border-surface-700 text-sm text-surface-700">
-        <p className="font-medium text-surface-200 mb-2">Required columns</p>
+      <div className="p-4 bg-white/50 rounded-lg border border-surface-200 text-sm text-surface-700">
+        <p className="font-medium text-surface-800 mb-2">Required columns</p>
         <ul className="space-y-1 text-xs text-surface-600 list-disc list-inside">
           <li>
             <span className="font-mono text-surface-700">framework_code</span> — e.g.{' '}
@@ -357,7 +357,7 @@ function UploadStage({
             id="mapping-import-framework"
             value={selectedFrameworkId}
             onChange={(e) => onFrameworkChange(e.target.value)}
-            className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-sm text-surface-100 focus:outline-none focus:border-brand-500"
+            className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-sm text-surface-900 focus:outline-none focus:border-brand-500"
           >
             <option value="">Select a framework…</option>
             {frameworks.map((fw) => (
@@ -379,7 +379,7 @@ function UploadStage({
             ? 'border-brand-500 bg-brand-500/10'
             : file
               ? 'border-green-500 bg-green-500/10'
-              : 'border-surface-700 hover:border-surface-600'
+              : 'border-surface-200 hover:border-surface-300'
         )}
         onDragEnter={onDrag}
         onDragLeave={onDrag}
@@ -398,7 +398,7 @@ function UploadStage({
         {file ? (
           <div className="space-y-2">
             <DocumentTextIcon className="w-12 h-12 mx-auto text-green-600" />
-            <p className="text-surface-100 font-medium">{file.name}</p>
+            <p className="text-surface-900 font-medium">{file.name}</p>
             <p className="text-surface-600 text-sm">{(file.size / 1024).toFixed(1)} KB</p>
             <button
               type="button"
@@ -433,15 +433,15 @@ function PreviewStage({ result }: { result: ImportResult }) {
   return (
     <div className="space-y-4">
       <div className="grid grid-cols-4 gap-4">
-        <SummaryTile label="Total rows" value={result.totalRows} accent="text-surface-200" />
+        <SummaryTile label="Total rows" value={result.totalRows} accent="text-surface-800" />
         <SummaryTile label="Will create" value={result.successful} accent="text-green-600" />
         <SummaryTile label="Duplicates" value={result.duplicates} accent="text-yellow-600" />
         <SummaryTile label="Errors" value={result.errors.length} accent="text-red-600" />
       </div>
 
-      <div className="border border-surface-700 rounded-lg overflow-hidden">
+      <div className="border border-surface-200 rounded-lg overflow-hidden">
         <table className="w-full text-sm" aria-label="Import preview rows">
-          <thead className="bg-surface-800 text-xs uppercase text-surface-600">
+          <thead className="bg-white text-xs uppercase text-surface-600">
             <tr>
               <th className="px-3 py-2 text-left">Row</th>
               <th className="px-3 py-2 text-left">Framework</th>
@@ -452,7 +452,7 @@ function PreviewStage({ result }: { result: ImportResult }) {
               <th className="px-3 py-2 text-left">Status</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-surface-800 max-h-80">
+          <tbody className="divide-y divide-surface-200 max-h-80">
             {result.rows.length === 0 ? (
               <tr>
                 <td colSpan={7} className="px-3 py-4 text-center text-surface-500 italic">
@@ -465,17 +465,17 @@ function PreviewStage({ result }: { result: ImportResult }) {
                   key={row.row}
                   data-testid={`preview-row-${row.row}`}
                   data-status={row.status}
-                  className="hover:bg-surface-800/40"
+                  className="hover:bg-white/40"
                 >
                   <td className="px-3 py-2 font-mono text-surface-600">{row.row}</td>
-                  <td className="px-3 py-2 text-surface-200">
+                  <td className="px-3 py-2 text-surface-800">
                     {getRowValue(row, 'framework_code')}
                   </td>
-                  <td className="px-3 py-2 text-surface-200">
+                  <td className="px-3 py-2 text-surface-800">
                     {getRowValue(row, 'requirement_ref')}
                   </td>
-                  <td className="px-3 py-2 text-surface-200">{getRowValue(row, 'control_code')}</td>
-                  <td className="px-3 py-2 text-surface-200">{getRowValue(row, 'mapping_type')}</td>
+                  <td className="px-3 py-2 text-surface-800">{getRowValue(row, 'control_code')}</td>
+                  <td className="px-3 py-2 text-surface-800">{getRowValue(row, 'mapping_type')}</td>
                   <td className="px-3 py-2 text-surface-600 truncate max-w-xs">
                     {getRowValue(row, 'notes')}
                   </td>
@@ -513,7 +513,7 @@ function ResultStage({ result }: { result: ImportResult }) {
           <CheckCircleIcon className="w-8 h-8 text-green-600" />
         )}
         <div>
-          <h3 className="text-lg font-medium text-surface-100">Import complete</h3>
+          <h3 className="text-lg font-medium text-surface-900">Import complete</h3>
           <p className="text-surface-600">
             Processed {result.totalRows} row{result.totalRows === 1 ? '' : 's'} from the file
           </p>
@@ -521,7 +521,7 @@ function ResultStage({ result }: { result: ImportResult }) {
       </div>
 
       <div className="grid grid-cols-4 gap-4">
-        <SummaryTile label="Total rows" value={result.totalRows} accent="text-surface-200" />
+        <SummaryTile label="Total rows" value={result.totalRows} accent="text-surface-800" />
         <SummaryTile label="Created" value={result.successful} accent="text-green-600" />
         <SummaryTile label="Duplicates" value={result.duplicates} accent="text-yellow-600" />
         <SummaryTile label="Errors" value={result.errors.length} accent="text-red-600" />
@@ -548,7 +548,7 @@ function ResultStage({ result }: { result: ImportResult }) {
 
 function SummaryTile({ label, value, accent }: { label: string; value: number; accent: string }) {
   return (
-    <div className="bg-surface-800 rounded-lg p-4 text-center">
+    <div className="bg-white rounded-lg p-4 text-center">
       <div className={clsx('text-2xl font-bold', accent)}>{value}</div>
       <div className="text-sm text-surface-600">{label}</div>
     </div>

--- a/frontend/src/components/mcp/MCPWorkflowBuilder.tsx
+++ b/frontend/src/components/mcp/MCPWorkflowBuilder.tsx
@@ -143,8 +143,8 @@ export default function MCPWorkflowBuilder() {
       </div>
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Workflows List */}
-        <div className="lg:col-span-1 bg-white dark:bg-surface-800 rounded-lg border border-gray-200 dark:border-surface-700">
-          <div className="p-4 border-b border-gray-200 dark:border-surface-700">
+        <div className="lg:col-span-1 bg-white dark:bg-white rounded-lg border border-gray-200 dark:border-surface-200">
+          <div className="p-4 border-b border-gray-200 dark:border-surface-200">
             <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
               Available Workflows
             </h2>
@@ -155,7 +155,7 @@ export default function MCPWorkflowBuilder() {
               <ArrowPathIcon className="w-8 h-8 animate-spin mx-auto text-gray-400" />
             </div>
           ) : (
-            <div className="divide-y divide-gray-200 dark:divide-surface-700">
+            <div className="divide-y divide-gray-200 dark:divide-surface-200">
               {workflows.map((workflow) => (
                 <div
                   key={workflow.id}
@@ -163,7 +163,7 @@ export default function MCPWorkflowBuilder() {
                   className={`p-4 cursor-pointer transition-colors ${
                     selectedWorkflow === workflow.id
                       ? 'bg-brand-50 dark:bg-brand-900/20'
-                      : 'hover:bg-gray-50 dark:hover:bg-surface-700/50'
+                      : 'hover:bg-gray-50 dark:hover:bg-surface-200/50'
                   }`}
                 >
                   <div className="flex items-center justify-between">
@@ -172,7 +172,7 @@ export default function MCPWorkflowBuilder() {
                         className={`p-2 rounded-lg ${
                           selectedWorkflow === workflow.id
                             ? 'bg-brand-100 dark:bg-brand-900/30'
-                            : 'bg-gray-100 dark:bg-surface-700'
+                            : 'bg-gray-100 dark:bg-surface-200'
                         }`}
                       >
                         {getTriggerIcon(workflow.trigger.type)}
@@ -198,8 +198,8 @@ export default function MCPWorkflowBuilder() {
         <div className="lg:col-span-2 space-y-6">
           {/* Workflow Details */}
           {selectedWorkflowData ? (
-            <div className="bg-white dark:bg-surface-800 rounded-lg border border-gray-200 dark:border-surface-700">
-              <div className="p-4 border-b border-gray-200 dark:border-surface-700 flex justify-between items-center">
+            <div className="bg-white dark:bg-white rounded-lg border border-gray-200 dark:border-surface-200">
+              <div className="p-4 border-b border-gray-200 dark:border-surface-200 flex justify-between items-center">
                 <div>
                   <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
                     {selectedWorkflowData.name}
@@ -222,7 +222,7 @@ export default function MCPWorkflowBuilder() {
 
               <div className="p-4">
                 <div className="grid grid-cols-2 gap-4 mb-4">
-                  <div className="p-3 bg-gray-50 dark:bg-surface-700 rounded-lg">
+                  <div className="p-3 bg-gray-50 dark:bg-surface-200 rounded-lg">
                     <p className="text-sm text-gray-500 dark:text-gray-400">Trigger Type</p>
                     <p className="font-medium text-gray-900 dark:text-white capitalize">
                       {selectedWorkflowData.trigger.type}
@@ -238,7 +238,7 @@ export default function MCPWorkflowBuilder() {
                       </p>
                     )}
                   </div>
-                  <div className="p-3 bg-gray-50 dark:bg-surface-700 rounded-lg">
+                  <div className="p-3 bg-gray-50 dark:bg-surface-200 rounded-lg">
                     <p className="text-sm text-gray-500 dark:text-gray-400">Total Steps</p>
                     <p className="font-medium text-gray-900 dark:text-white">
                       {selectedWorkflowData.stepCount}
@@ -248,7 +248,7 @@ export default function MCPWorkflowBuilder() {
               </div>
             </div>
           ) : (
-            <div className="bg-white dark:bg-surface-800 rounded-lg border border-gray-200 dark:border-surface-700 p-8 text-center">
+            <div className="bg-white dark:bg-white rounded-lg border border-gray-200 dark:border-surface-200 p-8 text-center">
               <BoltIcon className="w-12 h-12 mx-auto text-gray-400" />
               <p className="mt-2 text-gray-600 dark:text-gray-400">
                 Select a workflow to view details
@@ -257,8 +257,8 @@ export default function MCPWorkflowBuilder() {
           )}
 
           {/* Recent Executions */}
-          <div className="bg-white dark:bg-surface-800 rounded-lg border border-gray-200 dark:border-surface-700">
-            <div className="p-4 border-b border-gray-200 dark:border-surface-700">
+          <div className="bg-white dark:bg-white rounded-lg border border-gray-200 dark:border-surface-200">
+            <div className="p-4 border-b border-gray-200 dark:border-surface-200">
               <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
                 Recent Executions
               </h2>
@@ -270,7 +270,7 @@ export default function MCPWorkflowBuilder() {
                 <p className="mt-2 text-gray-600 dark:text-gray-400">No executions yet</p>
               </div>
             ) : (
-              <div className="divide-y divide-gray-200 dark:divide-surface-700">
+              <div className="divide-y divide-gray-200 dark:divide-surface-200">
                 {executions
                   .filter((e) => !selectedWorkflow || e.workflowId === selectedWorkflow)
                   .slice(0, 10)
@@ -340,7 +340,7 @@ export default function MCPWorkflowBuilder() {
       {/* Execution Modal */}
       {selectedWorkflowData && (
         <Dialog open={showExecutionModal} onClose={() => setShowExecutionModal(false)}>
-          <div className="p-4 border-b border-gray-200 dark:border-surface-700 flex justify-between items-center">
+          <div className="p-4 border-b border-gray-200 dark:border-surface-200 flex justify-between items-center">
             <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
               Run {selectedWorkflowData.name}
             </h2>
@@ -374,7 +374,7 @@ export default function MCPWorkflowBuilder() {
                     }
                   }}
                   rows={4}
-                  className="w-full px-3 py-2 border border-gray-300 dark:border-surface-600 rounded-lg bg-white dark:bg-surface-700 text-gray-900 dark:text-white font-mono text-sm"
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-surface-300 rounded-lg bg-white dark:bg-surface-200 text-gray-900 dark:text-white font-mono text-sm"
                   placeholder="{}"
                 />
               </div>

--- a/frontend/src/components/notifications/NotificationBell.tsx
+++ b/frontend/src/components/notifications/NotificationBell.tsx
@@ -123,7 +123,7 @@ export default function NotificationBell() {
       {/* Bell Button */}
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="relative p-2 rounded-lg text-surface-600 hover:text-surface-100 hover:bg-surface-800 focus:outline-none focus:ring-2 focus:ring-brand-500 transition-colors"
+        className="relative p-2 rounded-lg text-surface-600 hover:text-surface-900 hover:bg-white focus:outline-none focus:ring-2 focus:ring-brand-500 transition-colors"
         aria-label="Notifications"
       >
         {unreadCount > 0 ? (
@@ -142,10 +142,10 @@ export default function NotificationBell() {
 
       {/* Dropdown Panel */}
       {isOpen && (
-        <div className="absolute left-0 mt-2 w-80 bg-surface-900 rounded-xl shadow-2xl border border-surface-700 z-[100] overflow-hidden">
+        <div className="absolute left-0 mt-2 w-80 bg-white rounded-xl shadow-2xl border border-surface-200 z-[100] overflow-hidden">
           {/* Header */}
-          <div className="flex items-center justify-between px-4 py-3 bg-surface-800 border-b border-surface-700">
-            <h3 className="text-sm font-semibold text-surface-100">Notifications</h3>
+          <div className="flex items-center justify-between px-4 py-3 bg-white border-b border-surface-200">
+            <h3 className="text-sm font-semibold text-surface-900">Notifications</h3>
             <div className="flex items-center space-x-2">
               {unreadCount > 0 && (
                 <button
@@ -160,7 +160,7 @@ export default function NotificationBell() {
               <Link
                 to="/settings/notifications"
                 onClick={() => setIsOpen(false)}
-                className="p-1 text-surface-600 hover:text-surface-100 rounded"
+                className="p-1 text-surface-600 hover:text-surface-900 rounded"
                 title="Notification settings"
               >
                 <Cog6ToothIcon className="h-4 w-4" />
@@ -181,7 +181,7 @@ export default function NotificationBell() {
                 <p className="text-sm">No notifications yet</p>
               </div>
             ) : (
-              <ul className="divide-y divide-surface-700">
+              <ul className="divide-y divide-surface-200">
                 {notifications.map((notification) => {
                   const link = getEntityLink(
                     notification.entityType,
@@ -191,7 +191,7 @@ export default function NotificationBell() {
 
                   const NotificationContent = (
                     <div
-                      className={`p-3 hover:bg-surface-800 transition-colors cursor-pointer ${!notification.isRead ? 'bg-surface-800/50' : ''}`}
+                      className={`p-3 hover:bg-white transition-colors cursor-pointer ${!notification.isRead ? 'bg-white/50' : ''}`}
                     >
                       <div className="flex items-start space-x-2">
                         {/* Severity Icon */}
@@ -203,7 +203,7 @@ export default function NotificationBell() {
                           {/* Title with unread indicator */}
                           <div className="flex items-center justify-between">
                             <p
-                              className={`text-xs font-medium truncate ${notification.isRead ? 'text-surface-700' : 'text-surface-100'}`}
+                              className={`text-xs font-medium truncate ${notification.isRead ? 'text-surface-700' : 'text-surface-900'}`}
                             >
                               {notification.title}
                             </p>
@@ -276,7 +276,7 @@ export default function NotificationBell() {
 
           {/* Footer */}
           {notifications.length > 0 && (
-            <div className="px-3 py-2 bg-surface-800 border-t border-surface-700 text-center">
+            <div className="px-3 py-2 bg-white border-t border-surface-200 text-center">
               <Link
                 to="/settings/notifications"
                 onClick={() => setIsOpen(false)}

--- a/frontend/src/components/reports/ReportBuilder.tsx
+++ b/frontend/src/components/reports/ReportBuilder.tsx
@@ -290,7 +290,7 @@ export default function ReportBuilder({ initialConfig, onSave, className }: Repo
   return (
     <div className={clsx('flex h-full', className)}>
       {/* Sidebar - Section Types */}
-      <div className="w-64 bg-surface-900 border-r border-surface-800 p-4 space-y-4">
+      <div className="w-64 bg-white border-r border-surface-200 p-4 space-y-4">
         <div>
           <h3 className="text-sm font-medium text-surface-600 mb-2">Add Section</h3>
           <div className="space-y-1">
@@ -298,7 +298,7 @@ export default function ReportBuilder({ initialConfig, onSave, className }: Repo
               <button
                 key={type}
                 onClick={() => addSection(type)}
-                className="w-full flex items-center gap-2 px-3 py-2 text-sm text-surface-700 hover:text-white hover:bg-surface-800 rounded-lg transition-colors"
+                className="w-full flex items-center gap-2 px-3 py-2 text-sm text-surface-700 hover:text-white hover:bg-white rounded-lg transition-colors"
               >
                 <Icon className="w-4 h-4" />
                 {label}
@@ -307,28 +307,28 @@ export default function ReportBuilder({ initialConfig, onSave, className }: Repo
           </div>
         </div>
 
-        <div className="border-t border-surface-800 pt-4">
+        <div className="border-t border-surface-200 pt-4">
           <h3 className="text-sm font-medium text-surface-600 mb-2">Report Settings</h3>
           <Input
             type="text"
             value={config.name}
             onChange={(e) => setConfig((prev) => ({ ...prev, name: e.target.value }))}
             placeholder="Report Name"
-            className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-white text-sm focus:outline-none focus:border-brand-500"
+            className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-white text-sm focus:outline-none focus:border-brand-500"
           />
           <Textarea
             value={config.description || ''}
             onChange={(e) => setConfig((prev) => ({ ...prev, description: e.target.value }))}
             placeholder="Description (optional)"
             rows={2}
-            className="w-full mt-2 px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-white text-sm focus:outline-none focus:border-brand-500 resize-none"
+            className="w-full mt-2 px-3 py-2 bg-white border border-surface-200 rounded-lg text-white text-sm focus:outline-none focus:border-brand-500 resize-none"
           />
         </div>
 
-        <div className="border-t border-surface-800 pt-4 space-y-2">
+        <div className="border-t border-surface-200 pt-4 space-y-2">
           <button
             onClick={() => setIsPreviewMode(!isPreviewMode)}
-            className="w-full flex items-center justify-center gap-2 px-3 py-2 bg-surface-800 hover:bg-surface-700 text-white rounded-lg text-sm transition-colors"
+            className="w-full flex items-center justify-center gap-2 px-3 py-2 bg-white hover:bg-surface-200 text-white rounded-lg text-sm transition-colors"
           >
             <EyeIcon className="w-4 h-4" />
             {isPreviewMode ? 'Edit Mode' : 'Preview'}
@@ -353,14 +353,14 @@ export default function ReportBuilder({ initialConfig, onSave, className }: Repo
             <div className="flex items-center gap-2">
               <button
                 onClick={() => handleExport('pdf')}
-                className="flex items-center gap-1.5 px-3 py-1.5 bg-surface-800 hover:bg-surface-700 text-white rounded-lg text-sm"
+                className="flex items-center gap-1.5 px-3 py-1.5 bg-white hover:bg-surface-200 text-white rounded-lg text-sm"
               >
                 <ArrowDownTrayIcon className="w-4 h-4" />
                 PDF
               </button>
               <button
                 onClick={() => handleExport('xlsx')}
-                className="flex items-center gap-1.5 px-3 py-1.5 bg-surface-800 hover:bg-surface-700 text-white rounded-lg text-sm"
+                className="flex items-center gap-1.5 px-3 py-1.5 bg-white hover:bg-surface-200 text-white rounded-lg text-sm"
               >
                 <ArrowDownTrayIcon className="w-4 h-4" />
                 Excel
@@ -370,7 +370,7 @@ export default function ReportBuilder({ initialConfig, onSave, className }: Repo
 
           {/* Sections */}
           {config.sections.length === 0 ? (
-            <div className="text-center py-16 border-2 border-dashed border-surface-700 rounded-xl">
+            <div className="text-center py-16 border-2 border-dashed border-surface-200 rounded-xl">
               <SparklesIcon className="w-12 h-12 text-surface-600 mx-auto mb-4" />
               <h3 className="text-lg font-medium text-surface-600 mb-2">
                 Start Building Your Report
@@ -459,7 +459,7 @@ function SectionEditor({
         'relative p-4 rounded-lg border transition-all cursor-pointer',
         isSelected
           ? 'border-brand-500 bg-brand-500/5'
-          : 'border-surface-700 hover:border-surface-600 bg-surface-800/50'
+          : 'border-surface-200 hover:border-surface-300 bg-white/50'
       )}
     >
       {/* Controls */}
@@ -521,7 +521,7 @@ function SectionEditor({
           </div>
           <div className="flex flex-wrap gap-1">
             {(section.fields || []).map((field) => (
-              <span key={field} className="px-2 py-0.5 bg-surface-700 rounded text-xs">
+              <span key={field} className="px-2 py-0.5 bg-surface-200 rounded text-xs">
                 {field}
               </span>
             ))}
@@ -547,7 +547,7 @@ function SectionEditor({
           </div>
         </div>
       )}
-      {section.type === 'divider' && <div className="border-t border-surface-600 my-2" />}
+      {section.type === 'divider' && <div className="border-t border-surface-300 my-2" />}
     </div>
   );
 }
@@ -566,12 +566,12 @@ function SectionPreview({ section }: { section: ReportSection }) {
   }
 
   if (section.type === 'divider') {
-    return <hr className="border-surface-700" />;
+    return <hr className="border-surface-200" />;
   }
 
   // Placeholder for dynamic content
   return (
-    <div className="p-4 bg-surface-800/50 rounded-lg border border-surface-700">
+    <div className="p-4 bg-white/50 rounded-lg border border-surface-200">
       <p className="text-sm text-surface-600">
         [Preview: {section.type} from {section.dataSource}]
       </p>
@@ -593,7 +593,7 @@ function SectionConfigPanel({ section, onUpdate, onClose }: SectionConfigPanelPr
   const showDataConfig = ['table', 'chart', 'summary'].includes(section.type);
 
   return (
-    <div className="w-80 bg-surface-900 border-l border-surface-800 p-4 overflow-y-auto">
+    <div className="w-80 bg-white border-l border-surface-200 p-4 overflow-y-auto">
       <div className="flex items-center justify-between mb-4">
         <h3 className="font-medium text-white">Section Settings</h3>
         <button onClick={onClose} className="text-surface-600 hover:text-white">
@@ -608,7 +608,7 @@ function SectionConfigPanel({ section, onUpdate, onClose }: SectionConfigPanelPr
               type="text"
               value={section.title || ''}
               onChange={(e) => onUpdate({ title: e.target.value })}
-              className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-white text-sm"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-white text-sm"
             />
           </div>
         )}
@@ -620,7 +620,7 @@ function SectionConfigPanel({ section, onUpdate, onClose }: SectionConfigPanelPr
               value={section.content || ''}
               onChange={(e) => onUpdate({ content: e.target.value })}
               rows={5}
-              className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-white text-sm resize-none"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-white text-sm resize-none"
             />
           </div>
         )}
@@ -632,7 +632,7 @@ function SectionConfigPanel({ section, onUpdate, onClose }: SectionConfigPanelPr
               <SelectNative
                 value={section.dataSource || 'controls'}
                 onChange={(e) => onUpdate({ dataSource: e.target.value as DataSource })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-white text-sm"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-white text-sm"
               >
                 {Object.entries(DATA_SOURCES).map(([key, { label }]) => (
                   <option key={key} value={key}>
@@ -658,7 +658,7 @@ function SectionConfigPanel({ section, onUpdate, onClose }: SectionConfigPanelPr
                             : fields.filter((f) => f !== field),
                         });
                       }}
-                      className="rounded border-surface-600 bg-surface-800 text-brand-500"
+                      className="rounded border-surface-300 bg-white text-brand-500"
                     />
                     <span className="text-surface-700">{field}</span>
                   </label>
@@ -672,7 +672,7 @@ function SectionConfigPanel({ section, onUpdate, onClose }: SectionConfigPanelPr
                 <SelectNative
                   value={section.chartType || 'bar'}
                   onChange={(e) => onUpdate({ chartType: e.target.value as ChartType })}
-                  className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-white text-sm"
+                  className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-white text-sm"
                 >
                   <option value="bar">Bar Chart</option>
                   <option value="pie">Pie Chart</option>
@@ -687,7 +687,7 @@ function SectionConfigPanel({ section, onUpdate, onClose }: SectionConfigPanelPr
               <SelectNative
                 value={section.groupBy || ''}
                 onChange={(e) => onUpdate({ groupBy: e.target.value || undefined })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-white text-sm"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-white text-sm"
               >
                 <option value="">No grouping</option>
                 {DATA_SOURCES[section.dataSource || 'controls'].fields.map((field) => (
@@ -704,7 +704,7 @@ function SectionConfigPanel({ section, onUpdate, onClose }: SectionConfigPanelPr
                 <SelectNative
                   value={section.sortBy || ''}
                   onChange={(e) => onUpdate({ sortBy: e.target.value || undefined })}
-                  className="flex-1 px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-white text-sm"
+                  className="flex-1 px-3 py-2 bg-white border border-surface-200 rounded-lg text-white text-sm"
                 >
                   <option value="">Default</option>
                   {DATA_SOURCES[section.dataSource || 'controls'].fields.map((field) => (
@@ -716,7 +716,7 @@ function SectionConfigPanel({ section, onUpdate, onClose }: SectionConfigPanelPr
                 <SelectNative
                   value={section.sortOrder || 'asc'}
                   onChange={(e) => onUpdate({ sortOrder: e.target.value as 'asc' | 'desc' })}
-                  className="w-20 px-2 py-2 bg-surface-800 border border-surface-700 rounded-lg text-white text-sm"
+                  className="w-20 px-2 py-2 bg-white border border-surface-200 rounded-lg text-white text-sm"
                 >
                   <option value="asc">↑</option>
                   <option value="desc">↓</option>

--- a/frontend/src/components/risk/RiskAssetsTab.tsx
+++ b/frontend/src/components/risk/RiskAssetsTab.tsx
@@ -71,7 +71,7 @@ function RiskAssetsTab({
           {assets.map((asset) => (
             <div
               key={asset.id}
-              className="flex items-center justify-between p-4 bg-surface-900 rounded-lg border border-surface-700"
+              className="flex items-center justify-between p-4 bg-white rounded-lg border border-surface-200"
             >
               <div className="flex items-center gap-4">
                 <Server className="w-5 h-5 text-surface-600" />

--- a/frontend/src/components/risk/RiskControlsTab.tsx
+++ b/frontend/src/components/risk/RiskControlsTab.tsx
@@ -81,7 +81,7 @@ function RiskControlsTab({
           {controls.map((control) => (
             <div
               key={control.id}
-              className="flex items-center justify-between p-4 bg-surface-900 rounded-lg border border-surface-700"
+              className="flex items-center justify-between p-4 bg-white rounded-lg border border-surface-200"
             >
               <div className="flex items-center gap-4">
                 <Target className="w-5 h-5 text-surface-600" />

--- a/frontend/src/components/risk/RiskEditModal.tsx
+++ b/frontend/src/components/risk/RiskEditModal.tsx
@@ -84,7 +84,7 @@ export default function RiskEditModal({
             type="text"
             value={formData.title}
             onChange={(e) => setFormData({ ...formData, title: e.target.value })}
-            className="w-full bg-surface-900 border border-surface-700 rounded-lg px-3 py-2 text-white"
+            className="w-full bg-white border border-surface-200 rounded-lg px-3 py-2 text-white"
             required
           />
         </div>
@@ -94,7 +94,7 @@ export default function RiskEditModal({
             value={formData.description}
             onChange={(e) => setFormData({ ...formData, description: e.target.value })}
             rows={3}
-            className="w-full bg-surface-900 border border-surface-700 rounded-lg px-3 py-2 text-white"
+            className="w-full bg-white border border-surface-200 rounded-lg px-3 py-2 text-white"
           />
         </div>
         <div>
@@ -102,7 +102,7 @@ export default function RiskEditModal({
           <SelectNative
             value={formData.category}
             onChange={(e) => setFormData({ ...formData, category: e.target.value })}
-            className="w-full bg-surface-900 border border-surface-700 rounded-lg px-3 py-2 text-white"
+            className="w-full bg-white border border-surface-200 rounded-lg px-3 py-2 text-white"
           >
             {RISK_CATEGORIES.map((cat) => (
               <option key={cat} value={cat}>
@@ -116,7 +116,7 @@ export default function RiskEditModal({
           <SelectNative
             value={formData.reviewFrequency}
             onChange={(e) => setFormData({ ...formData, reviewFrequency: e.target.value })}
-            className="w-full bg-surface-900 border border-surface-700 rounded-lg px-3 py-2 text-white"
+            className="w-full bg-white border border-surface-200 rounded-lg px-3 py-2 text-white"
           >
             {REVIEW_FREQUENCIES.map((freq) => (
               <option key={freq.value} value={freq.value}>

--- a/frontend/src/components/risk/RiskHeatMap.tsx
+++ b/frontend/src/components/risk/RiskHeatMap.tsx
@@ -194,11 +194,11 @@ export function RiskHeatMap({
                     {/* Hover tooltip */}
                     {isHovered && cellRisks.length > 0 && (
                       <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-50 pointer-events-none">
-                        <div className="bg-surface-900 border border-surface-700 rounded-lg shadow-xl p-3 min-w-[200px]">
+                        <div className="bg-white border border-surface-200 rounded-lg shadow-xl p-3 min-w-[200px]">
                           <p className="text-xs text-surface-600 mb-1">
                             {LIKELIHOOD_LABELS[likelihood]} × {IMPACT_LABELS[impact]}
                           </p>
-                          <p className="text-sm font-medium text-surface-100">
+                          <p className="text-sm font-medium text-surface-900">
                             {cellRisks.length} risk{cellRisks.length > 1 ? 's' : ''}
                           </p>
                         </div>
@@ -236,15 +236,15 @@ export function RiskHeatMap({
 
       {/* Selected Cell Details */}
       {selectedCell && risksByCell[selectedCell]?.length > 0 && (
-        <div className="bg-surface-800 border border-surface-700 rounded-lg p-4">
+        <div className="bg-white border border-surface-200 rounded-lg p-4">
           <div className="flex items-center justify-between mb-3">
-            <h4 className="font-medium text-surface-100">
+            <h4 className="font-medium text-surface-900">
               {LIKELIHOOD_LABELS[selectedCell.split('-')[0]]} ×{' '}
               {IMPACT_LABELS[selectedCell.split('-')[1]]}
             </h4>
             <button
               onClick={() => setSelectedCell(null)}
-              className="text-xs text-surface-600 hover:text-surface-200"
+              className="text-xs text-surface-600 hover:text-surface-800"
             >
               Close
             </button>
@@ -254,9 +254,9 @@ export function RiskHeatMap({
               <div
                 key={risk.id}
                 onClick={(e) => handleRiskClick(risk, e)}
-                className="p-2 bg-surface-700/50 hover:bg-surface-700 rounded-lg cursor-pointer transition-colors"
+                className="p-2 bg-surface-200/50 hover:bg-surface-200 rounded-lg cursor-pointer transition-colors"
               >
-                <p className="text-sm font-medium text-surface-100">{risk.title}</p>
+                <p className="text-sm font-medium text-surface-900">{risk.title}</p>
                 <p className="text-xs text-surface-600">
                   {risk.riskId} • {risk.category || 'Uncategorized'}
                 </p>
@@ -268,7 +268,7 @@ export function RiskHeatMap({
 
       {/* Legend */}
       {showLegend && (
-        <div className="flex items-center justify-between bg-surface-800/50 rounded-lg p-3">
+        <div className="flex items-center justify-between bg-white/50 rounded-lg p-3">
           <div className="flex items-center gap-4">
             <div className="flex items-center gap-2">
               <div className="w-3 h-3 rounded bg-emerald-400" />
@@ -344,7 +344,7 @@ export function CompactRiskHeatMap({
                 key={key}
                 className={clsx(
                   'aspect-square rounded flex items-center justify-center text-xs font-medium transition-transform hover:scale-105',
-                  count > 0 ? RISK_DOT_COLORS[riskLevel] : 'bg-surface-700/50',
+                  count > 0 ? RISK_DOT_COLORS[riskLevel] : 'bg-surface-200/50',
                   count > 0 ? 'text-white/90' : 'text-surface-500'
                 )}
                 title={`${LIKELIHOOD_LABELS[likelihood]} × ${IMPACT_LABELS[impact]}: ${count} risks`}

--- a/frontend/src/components/risk/RiskScenariosTab.tsx
+++ b/frontend/src/components/risk/RiskScenariosTab.tsx
@@ -61,10 +61,7 @@ export default function RiskScenariosTab({
       ) : (
         <div className="space-y-3">
           {scenarios.map((scenario) => (
-            <div
-              key={scenario.id}
-              className="p-4 bg-surface-900 rounded-lg border border-surface-700"
-            >
+            <div key={scenario.id} className="p-4 bg-white rounded-lg border border-surface-200">
               <div className="flex items-center justify-between mb-3">
                 <h4 className="text-white font-medium">{scenario.name}</h4>
                 <button

--- a/frontend/src/components/risk/RiskTreatmentModal.tsx
+++ b/frontend/src/components/risk/RiskTreatmentModal.tsx
@@ -94,7 +94,7 @@ export default function RiskTreatmentModal({
                 className={`p-3 rounded-lg border text-left ${
                   formData.treatmentPlan === plan.value
                     ? 'border-brand-500 bg-brand-500/10'
-                    : 'border-surface-700 hover:border-surface-600'
+                    : 'border-surface-200 hover:border-surface-300'
                 }`}
               >
                 <div className="text-white font-medium">{plan.label}</div>
@@ -108,7 +108,7 @@ export default function RiskTreatmentModal({
           <SelectNative
             value={formData.targetResidualRisk}
             onChange={(e) => setFormData({ ...formData, targetResidualRisk: e.target.value })}
-            className="w-full bg-surface-900 border border-surface-700 rounded-lg px-3 py-2 text-white"
+            className="w-full bg-white border border-surface-200 rounded-lg px-3 py-2 text-white"
           >
             {RISK_LEVELS.map((level) => (
               <option key={level.value} value={level.value}>
@@ -123,7 +123,7 @@ export default function RiskTreatmentModal({
             type="date"
             value={formData.treatmentDueDate}
             onChange={(e) => setFormData({ ...formData, treatmentDueDate: e.target.value })}
-            className="w-full bg-surface-900 border border-surface-700 rounded-lg px-3 py-2 text-white"
+            className="w-full bg-white border border-surface-200 rounded-lg px-3 py-2 text-white"
           />
         </div>
         <div>
@@ -133,7 +133,7 @@ export default function RiskTreatmentModal({
             onChange={(e) => setFormData({ ...formData, treatmentNotes: e.target.value })}
             rows={3}
             placeholder="Describe the treatment approach..."
-            className="w-full bg-surface-900 border border-surface-700 rounded-lg px-3 py-2 text-white"
+            className="w-full bg-white border border-surface-200 rounded-lg px-3 py-2 text-white"
           />
         </div>
         <div className="flex justify-end gap-3 pt-4">

--- a/frontend/src/components/risk/RiskWorkflowPanel.tsx
+++ b/frontend/src/components/risk/RiskWorkflowPanel.tsx
@@ -324,11 +324,11 @@ export default function RiskWorkflowPanel({ risk, onUpdate }: RiskWorkflowPanelP
   const actions = getAvailableActions();
 
   return (
-    <div className="bg-surface-800 rounded-xl border border-surface-700 overflow-hidden">
+    <div className="bg-white rounded-xl border border-surface-200 overflow-hidden">
       {/* Header */}
       <button
         onClick={() => setExpanded(!expanded)}
-        className="w-full p-4 flex items-center justify-between hover:bg-surface-700/50 transition-colors"
+        className="w-full p-4 flex items-center justify-between hover:bg-surface-200/50 transition-colors"
       >
         <div className="flex items-center gap-3">
           <div className={`p-2 rounded-lg ${statusInfo.color}`}>
@@ -347,9 +347,9 @@ export default function RiskWorkflowPanel({ risk, onUpdate }: RiskWorkflowPanelP
       </button>
 
       {expanded && (
-        <div className="border-t border-surface-700">
+        <div className="border-t border-surface-200">
           {/* Workflow Progress */}
-          <div className="p-4 border-b border-surface-700">
+          <div className="p-4 border-b border-surface-200">
             <h4 className="text-sm font-medium text-surface-600 mb-3">Workflow Progress</h4>
             <WorkflowProgressBar
               stage={stage}
@@ -383,7 +383,7 @@ export default function RiskWorkflowPanel({ risk, onUpdate }: RiskWorkflowPanelP
           )}
 
           {/* Role Assignments */}
-          <div className="p-4 border-t border-surface-700">
+          <div className="p-4 border-t border-surface-200">
             <h4 className="text-sm font-medium text-surface-600 mb-3">Assigned Roles</h4>
             <div className="grid grid-cols-2 gap-3">
               <RoleCard
@@ -622,7 +622,7 @@ function WorkflowProgressBar({
                   ? 'bg-emerald-500 text-white'
                   : getStageState(s.key) === 'active'
                     ? 'bg-brand-500 text-white'
-                    : 'bg-surface-700 text-surface-600'
+                    : 'bg-surface-200 text-surface-600'
               }`}
             >
               {getStageState(s.key) === 'complete' ? (
@@ -670,8 +670,8 @@ function RoleCard({
 }) {
   return (
     <div
-      className={`p-2 bg-surface-700/50 rounded-lg flex items-center justify-between ${
-        editable ? 'hover:bg-surface-700 cursor-pointer' : ''
+      className={`p-2 bg-surface-200/50 rounded-lg flex items-center justify-between ${
+        editable ? 'hover:bg-surface-200 cursor-pointer' : ''
       }`}
       onClick={editable ? onEdit : undefined}
     >
@@ -738,7 +738,7 @@ function UserPicker({
       <button
         type="button"
         onClick={() => setIsExpanded(!isExpanded)}
-        className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-left flex items-center justify-between hover:bg-surface-600 transition-colors"
+        className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-left flex items-center justify-between hover:bg-surface-600 transition-colors"
       >
         {selectedUser ? (
           <div className="flex items-center gap-3">
@@ -761,15 +761,15 @@ function UserPicker({
       {description && <p className="text-xs text-surface-500 mt-1">{description}</p>}
       {/* Expandable user list */}
       {isExpanded && (
-        <div className="mt-2 border border-surface-600 rounded-lg bg-surface-750 overflow-hidden">
+        <div className="mt-2 border border-surface-300 rounded-lg bg-surface-750 overflow-hidden">
           {/* Search */}
-          <div className="p-2 border-b border-surface-600">
+          <div className="p-2 border-b border-surface-300">
             <Input
               type="text"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               placeholder="Search by name or email..."
-              className="w-full px-3 py-1.5 bg-surface-700 border border-surface-600 rounded text-white text-sm"
+              className="w-full px-3 py-1.5 bg-surface-200 border border-surface-300 rounded text-white text-sm"
             />
           </div>
 
@@ -831,7 +831,7 @@ function UserPicker({
                   value={selectedUserId}
                   onChange={(e) => onSelect(e.target.value)}
                   placeholder="Enter user ID manually..."
-                  className="w-full px-3 py-1.5 bg-surface-700 border border-surface-600 rounded text-white text-sm"
+                  className="w-full px-3 py-1.5 bg-surface-200 border border-surface-300 rounded text-white text-sm"
                 />
               </div>
             )}
@@ -872,11 +872,11 @@ function ValidateRiskModal({
 
   return (
     <Dialog open onClose={onClose}>
-      <div className="p-4 border-b border-surface-700 flex justify-between items-center">
+      <div className="p-4 border-b border-surface-200 flex justify-between items-center">
         <h3 className="text-lg font-medium text-white">
           {approve ? 'Validate Risk' : 'Reject Risk'}
         </h3>
-        <button onClick={onClose} className="p-1 hover:bg-surface-700 rounded">
+        <button onClick={onClose} className="p-1 hover:bg-surface-200 rounded">
           <X className="w-5 h-5 text-surface-600" />
         </button>
       </div>
@@ -899,13 +899,13 @@ function ValidateRiskModal({
             onChange={(e) => setReason(e.target.value)}
             required={!approve}
             rows={3}
-            className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+            className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
             placeholder={approve ? 'Add any notes...' : 'Explain why this is not a valid risk...'}
           />
         </div>
       </div>
-      <div className="p-4 border-t border-surface-700 flex justify-end gap-3">
-        <button onClick={onClose} className="px-4 py-2 bg-surface-700 text-surface-700 rounded-lg">
+      <div className="p-4 border-t border-surface-200 flex justify-end gap-3">
+        <button onClick={onClose} className="px-4 py-2 bg-surface-200 text-surface-700 rounded-lg">
           Cancel
         </button>
         <button
@@ -945,9 +945,9 @@ function StartAssessmentModal({
 
   return (
     <Dialog open onClose={onClose}>
-      <div className="p-4 border-b border-surface-700 flex justify-between items-center">
+      <div className="p-4 border-b border-surface-200 flex justify-between items-center">
         <h3 className="text-lg font-medium text-white">Start Risk Assessment</h3>
-        <button onClick={onClose} className="p-1 hover:bg-surface-700 rounded">
+        <button onClick={onClose} className="p-1 hover:bg-surface-200 rounded">
           <X className="w-5 h-5 text-surface-600" />
         </button>
       </div>
@@ -960,8 +960,8 @@ function StartAssessmentModal({
           description="The SME who will analyze and assess this risk"
         />
       </div>
-      <div className="p-4 border-t border-surface-700 flex justify-end gap-3">
-        <button onClick={onClose} className="px-4 py-2 bg-surface-700 text-surface-700 rounded-lg">
+      <div className="p-4 border-t border-surface-200 flex justify-end gap-3">
+        <button onClick={onClose} className="px-4 py-2 bg-surface-200 text-surface-700 rounded-lg">
           Cancel
         </button>
         <button
@@ -1021,9 +1021,9 @@ function SubmitAssessmentModal({
 
   return (
     <Dialog open onClose={onClose}>
-      <div className="p-4 border-b border-surface-700 flex justify-between items-center sticky top-0 bg-surface-800">
+      <div className="p-4 border-b border-surface-200 flex justify-between items-center sticky top-0 bg-white">
         <h3 className="text-lg font-medium text-white">Risk Assessment Form</h3>
-        <button onClick={onClose} className="p-1 hover:bg-surface-700 rounded">
+        <button onClick={onClose} className="p-1 hover:bg-surface-200 rounded">
           <X className="w-5 h-5 text-surface-600" />
         </button>
       </div>
@@ -1037,7 +1037,7 @@ function SubmitAssessmentModal({
             }
             required
             rows={3}
-            className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+            className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
             placeholder="Describe the threat scenario..."
           />
         </div>
@@ -1049,7 +1049,7 @@ function SubmitAssessmentModal({
               type="text"
               value={formData.affectedAssets}
               onChange={(e) => setFormData((prev) => ({ ...prev, affectedAssets: e.target.value }))}
-              className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+              className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
               placeholder="Comma-separated list"
             />
           </div>
@@ -1061,7 +1061,7 @@ function SubmitAssessmentModal({
               onChange={(e) =>
                 setFormData((prev) => ({ ...prev, existingControls: e.target.value }))
               }
-              className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+              className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
               placeholder="Comma-separated list"
             />
           </div>
@@ -1073,7 +1073,7 @@ function SubmitAssessmentModal({
             value={formData.vulnerabilities}
             onChange={(e) => setFormData((prev) => ({ ...prev, vulnerabilities: e.target.value }))}
             rows={2}
-            className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+            className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
             placeholder="Describe any vulnerabilities..."
           />
         </div>
@@ -1086,7 +1086,7 @@ function SubmitAssessmentModal({
               onChange={(e) =>
                 setFormData((prev) => ({ ...prev, likelihoodScore: e.target.value }))
               }
-              className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+              className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
             >
               <option value="rare">Rare</option>
               <option value="unlikely">Unlikely</option>
@@ -1100,7 +1100,7 @@ function SubmitAssessmentModal({
             <SelectNative
               value={formData.impactScore}
               onChange={(e) => setFormData((prev) => ({ ...prev, impactScore: e.target.value }))}
-              className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+              className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
             >
               <option value="negligible">Negligible</option>
               <option value="minor">Minor</option>
@@ -1121,7 +1121,7 @@ function SubmitAssessmentModal({
               }
               required
               rows={2}
-              className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+              className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
               placeholder="Why this likelihood score?"
             />
           </div>
@@ -1134,7 +1134,7 @@ function SubmitAssessmentModal({
               }
               required
               rows={2}
-              className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+              className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
               placeholder="Why this impact score?"
             />
           </div>
@@ -1155,7 +1155,7 @@ function SubmitAssessmentModal({
               onChange={(e) =>
                 setFormData((prev) => ({ ...prev, treatmentRecommendation: e.target.value }))
               }
-              className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+              className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
             >
               <option value="">Select...</option>
               <option value="mitigate">Mitigate</option>
@@ -1172,13 +1172,13 @@ function SubmitAssessmentModal({
             value={formData.assessmentNotes}
             onChange={(e) => setFormData((prev) => ({ ...prev, assessmentNotes: e.target.value }))}
             rows={2}
-            className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+            className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
             placeholder="Any additional notes..."
           />
         </div>
       </div>
-      <div className="p-4 border-t border-surface-700 flex justify-end gap-3 sticky bottom-0 bg-surface-800">
-        <button onClick={onClose} className="px-4 py-2 bg-surface-700 text-surface-700 rounded-lg">
+      <div className="p-4 border-t border-surface-200 flex justify-end gap-3 sticky bottom-0 bg-white">
+        <button onClick={onClose} className="px-4 py-2 bg-surface-200 text-surface-700 rounded-lg">
           Cancel
         </button>
         <button
@@ -1229,11 +1229,11 @@ function ReviewAssessmentModal({
 
   return (
     <Dialog open onClose={onClose}>
-      <div className="p-4 border-b border-surface-700 flex justify-between items-center">
+      <div className="p-4 border-b border-surface-200 flex justify-between items-center">
         <h3 className="text-lg font-medium text-white">
           {approve ? 'Approve Assessment' : 'Request Revision'}
         </h3>
-        <button onClick={onClose} className="p-1 hover:bg-surface-700 rounded">
+        <button onClick={onClose} className="p-1 hover:bg-surface-200 rounded">
           <X className="w-5 h-5 text-surface-600" />
         </button>
       </div>
@@ -1245,7 +1245,7 @@ function ReviewAssessmentModal({
               value={notes}
               onChange={(e) => setNotes(e.target.value)}
               rows={3}
-              className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+              className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
               placeholder="Add any notes..."
             />
           </div>
@@ -1257,14 +1257,14 @@ function ReviewAssessmentModal({
               onChange={(e) => setDeclinedReason(e.target.value)}
               required
               rows={3}
-              className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+              className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
               placeholder="Explain what needs to be revised..."
             />
           </div>
         )}
       </div>
-      <div className="p-4 border-t border-surface-700 flex justify-end gap-3">
-        <button onClick={onClose} className="px-4 py-2 bg-surface-700 text-surface-700 rounded-lg">
+      <div className="p-4 border-t border-surface-200 flex justify-end gap-3">
+        <button onClick={onClose} className="px-4 py-2 bg-surface-200 text-surface-700 rounded-lg">
           Cancel
         </button>
         <button
@@ -1313,9 +1313,9 @@ function CompleteRevisionModal({
 
   return (
     <Dialog open onClose={onClose}>
-      <div className="p-4 border-b border-surface-700 flex justify-between items-center">
+      <div className="p-4 border-b border-surface-200 flex justify-between items-center">
         <h3 className="text-lg font-medium text-white">Complete Revision</h3>
-        <button onClick={onClose} className="p-1 hover:bg-surface-700 rounded">
+        <button onClick={onClose} className="p-1 hover:bg-surface-200 rounded">
           <X className="w-5 h-5 text-surface-600" />
         </button>
       </div>
@@ -1332,7 +1332,7 @@ function CompleteRevisionModal({
               onChange={(e) =>
                 setFormData((prev) => ({ ...prev, likelihoodScore: e.target.value }))
               }
-              className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+              className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
             >
               <option value="">Keep existing</option>
               <option value="rare">Rare</option>
@@ -1347,7 +1347,7 @@ function CompleteRevisionModal({
             <SelectNative
               value={formData.impactScore}
               onChange={(e) => setFormData((prev) => ({ ...prev, impactScore: e.target.value }))}
-              className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+              className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
             >
               <option value="">Keep existing</option>
               <option value="negligible">Negligible</option>
@@ -1365,13 +1365,13 @@ function CompleteRevisionModal({
             value={formData.assessmentNotes}
             onChange={(e) => setFormData((prev) => ({ ...prev, assessmentNotes: e.target.value }))}
             rows={3}
-            className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+            className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
             placeholder="Updated notes..."
           />
         </div>
       </div>
-      <div className="p-4 border-t border-surface-700 flex justify-end gap-3">
-        <button onClick={onClose} className="px-4 py-2 bg-surface-700 text-surface-700 rounded-lg">
+      <div className="p-4 border-t border-surface-200 flex justify-end gap-3">
+        <button onClick={onClose} className="px-4 py-2 bg-surface-200 text-surface-700 rounded-lg">
           Cancel
         </button>
         <button
@@ -1434,9 +1434,9 @@ function TreatmentDecisionModal({
 
   return (
     <Dialog open onClose={onClose}>
-      <div className="p-4 border-b border-surface-700 flex justify-between items-center">
+      <div className="p-4 border-b border-surface-200 flex justify-between items-center">
         <h3 className="text-lg font-medium text-white">Treatment Decision</h3>
-        <button onClick={onClose} className="p-1 hover:bg-surface-700 rounded">
+        <button onClick={onClose} className="p-1 hover:bg-surface-200 rounded">
           <X className="w-5 h-5 text-surface-600" />
         </button>
       </div>
@@ -1457,7 +1457,7 @@ function TreatmentDecisionModal({
                 className={`p-3 rounded-lg text-left ${
                   formData.decision === opt.value
                     ? 'bg-brand-500/20 border border-brand-500'
-                    : 'bg-surface-700 border border-surface-600'
+                    : 'bg-surface-200 border border-surface-300'
                 }`}
               >
                 <p className="text-white font-medium">{opt.label}</p>
@@ -1482,7 +1482,7 @@ function TreatmentDecisionModal({
             onChange={(e) => setFormData((prev) => ({ ...prev, justification: e.target.value }))}
             required
             rows={3}
-            className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+            className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
             placeholder="Explain why this treatment strategy..."
           />
         </div>
@@ -1498,7 +1498,7 @@ function TreatmentDecisionModal({
                   setFormData((prev) => ({ ...prev, mitigationDescription: e.target.value }))
                 }
                 rows={2}
-                className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+                className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
                 placeholder="Describe the mitigation plan..."
               />
             </div>
@@ -1510,7 +1510,7 @@ function TreatmentDecisionModal({
                 onChange={(e) =>
                   setFormData((prev) => ({ ...prev, mitigationTargetDate: e.target.value }))
                 }
-                className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+                className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
               />
             </div>
           </>
@@ -1525,7 +1525,7 @@ function TreatmentDecisionModal({
                 type="text"
                 value={formData.transferTo}
                 onChange={(e) => setFormData((prev) => ({ ...prev, transferTo: e.target.value }))}
-                className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+                className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
                 placeholder="Insurance provider..."
               />
             </div>
@@ -1535,7 +1535,7 @@ function TreatmentDecisionModal({
                 type="number"
                 value={formData.transferCost}
                 onChange={(e) => setFormData((prev) => ({ ...prev, transferCost: e.target.value }))}
-                className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+                className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
                 placeholder="0"
               />
             </div>
@@ -1550,7 +1550,7 @@ function TreatmentDecisionModal({
               value={formData.avoidStrategy}
               onChange={(e) => setFormData((prev) => ({ ...prev, avoidStrategy: e.target.value }))}
               rows={2}
-              className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+              className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
               placeholder="How will the risk be avoided..."
             />
           </div>
@@ -1567,7 +1567,7 @@ function TreatmentDecisionModal({
                   setFormData((prev) => ({ ...prev, acceptanceRationale: e.target.value }))
                 }
                 rows={2}
-                className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+                className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
                 placeholder="Why is accepting appropriate..."
               />
             </div>
@@ -1579,14 +1579,14 @@ function TreatmentDecisionModal({
                 onChange={(e) =>
                   setFormData((prev) => ({ ...prev, acceptanceExpiresAt: e.target.value }))
                 }
-                className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+                className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
               />
             </div>
           </>
         )}
       </div>
-      <div className="p-4 border-t border-surface-700 flex justify-end gap-3">
-        <button onClick={onClose} className="px-4 py-2 bg-surface-700 text-surface-700 rounded-lg">
+      <div className="p-4 border-t border-surface-200 flex justify-end gap-3">
+        <button onClick={onClose} className="px-4 py-2 bg-surface-200 text-surface-700 rounded-lg">
           Cancel
         </button>
         <button
@@ -1624,9 +1624,9 @@ function AssignApproverModal({
 
   return (
     <Dialog open onClose={onClose}>
-      <div className="p-4 border-b border-surface-700 flex justify-between items-center">
+      <div className="p-4 border-b border-surface-200 flex justify-between items-center">
         <h3 className="text-lg font-medium text-white">Assign Executive Approver</h3>
-        <button onClick={onClose} className="p-1 hover:bg-surface-700 rounded">
+        <button onClick={onClose} className="p-1 hover:bg-surface-200 rounded">
           <X className="w-5 h-5 text-surface-600" />
         </button>
       </div>
@@ -1642,8 +1642,8 @@ function AssignApproverModal({
           description="The executive who will approve this treatment decision"
         />
       </div>
-      <div className="p-4 border-t border-surface-700 flex justify-end gap-3">
-        <button onClick={onClose} className="px-4 py-2 bg-surface-700 text-surface-700 rounded-lg">
+      <div className="p-4 border-t border-surface-200 flex justify-end gap-3">
+        <button onClick={onClose} className="px-4 py-2 bg-surface-200 text-surface-700 rounded-lg">
           Cancel
         </button>
         <button
@@ -1688,11 +1688,11 @@ function ExecutiveApprovalModal({
 
   return (
     <Dialog open onClose={onClose}>
-      <div className="p-4 border-b border-surface-700 flex justify-between items-center">
+      <div className="p-4 border-b border-surface-200 flex justify-between items-center">
         <h3 className="text-lg font-medium text-white">
           {approve ? 'Approve Treatment' : 'Deny Treatment'}
         </h3>
-        <button onClick={onClose} className="p-1 hover:bg-surface-700 rounded">
+        <button onClick={onClose} className="p-1 hover:bg-surface-200 rounded">
           <X className="w-5 h-5 text-surface-600" />
         </button>
       </div>
@@ -1704,7 +1704,7 @@ function ExecutiveApprovalModal({
               value={notes}
               onChange={(e) => setNotes(e.target.value)}
               rows={3}
-              className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+              className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
               placeholder="Add any notes..."
             />
           </div>
@@ -1716,14 +1716,14 @@ function ExecutiveApprovalModal({
               onChange={(e) => setDeniedReason(e.target.value)}
               required
               rows={3}
-              className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+              className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
               placeholder="Explain why this decision is denied..."
             />
           </div>
         )}
       </div>
-      <div className="p-4 border-t border-surface-700 flex justify-end gap-3">
-        <button onClick={onClose} className="px-4 py-2 bg-surface-700 text-surface-700 rounded-lg">
+      <div className="p-4 border-t border-surface-200 flex justify-end gap-3">
+        <button onClick={onClose} className="px-4 py-2 bg-surface-200 text-surface-700 rounded-lg">
           Cancel
         </button>
         <button
@@ -1783,9 +1783,9 @@ function MitigationUpdateModal({
 
   return (
     <Dialog open onClose={onClose}>
-      <div className="p-4 border-b border-surface-700 flex justify-between items-center">
+      <div className="p-4 border-b border-surface-200 flex justify-between items-center">
         <h3 className="text-lg font-medium text-white">Update Mitigation Status</h3>
-        <button onClick={onClose} className="p-1 hover:bg-surface-700 rounded">
+        <button onClick={onClose} className="p-1 hover:bg-surface-200 rounded">
           <X className="w-5 h-5 text-surface-600" />
         </button>
       </div>
@@ -1795,7 +1795,7 @@ function MitigationUpdateModal({
           <SelectNative
             value={formData.status}
             onChange={(e) => setFormData((prev) => ({ ...prev, status: e.target.value }))}
-            className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+            className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
           >
             <option value="on_track">On Track</option>
             <option value="delayed">Delayed</option>
@@ -1826,7 +1826,7 @@ function MitigationUpdateModal({
             value={formData.notes}
             onChange={(e) => setFormData((prev) => ({ ...prev, notes: e.target.value }))}
             rows={2}
-            className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+            className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
             placeholder="Update notes..."
           />
         </div>
@@ -1841,7 +1841,7 @@ function MitigationUpdateModal({
                 onChange={(e) =>
                   setFormData((prev) => ({ ...prev, newTargetDate: e.target.value }))
                 }
-                className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+                className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
               />
             </div>
             <div>
@@ -1850,7 +1850,7 @@ function MitigationUpdateModal({
                 value={formData.delayReason}
                 onChange={(e) => setFormData((prev) => ({ ...prev, delayReason: e.target.value }))}
                 rows={2}
-                className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+                className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
                 placeholder="Why is it delayed..."
               />
             </div>
@@ -1867,7 +1867,7 @@ function MitigationUpdateModal({
               }
               required
               rows={2}
-              className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+              className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
               placeholder="Why is mitigation cancelled..."
             />
           </div>
@@ -1882,7 +1882,7 @@ function MitigationUpdateModal({
                 onChange={(e) =>
                   setFormData((prev) => ({ ...prev, residualLikelihood: e.target.value }))
                 }
-                className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+                className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
               >
                 <option value="">Select...</option>
                 <option value="rare">Rare</option>
@@ -1899,7 +1899,7 @@ function MitigationUpdateModal({
                 onChange={(e) =>
                   setFormData((prev) => ({ ...prev, residualImpact: e.target.value }))
                 }
-                className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+                className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
               >
                 <option value="">Select...</option>
                 <option value="negligible">Negligible</option>
@@ -1912,8 +1912,8 @@ function MitigationUpdateModal({
           </div>
         )}
       </div>
-      <div className="p-4 border-t border-surface-700 flex justify-end gap-3">
-        <button onClick={onClose} className="px-4 py-2 bg-surface-700 text-surface-700 rounded-lg">
+      <div className="p-4 border-t border-surface-200 flex justify-end gap-3">
+        <button onClick={onClose} className="px-4 py-2 bg-surface-200 text-surface-700 rounded-lg">
           Cancel
         </button>
         <button
@@ -1988,9 +1988,9 @@ function AssignRoleModal({
 
   return (
     <Dialog open onClose={onClose}>
-      <div className="p-4 border-b border-surface-700 flex justify-between items-center">
+      <div className="p-4 border-b border-surface-200 flex justify-between items-center">
         <h3 className="text-lg font-medium text-white">Assign {roleLabel}</h3>
-        <button onClick={onClose} className="p-1 hover:bg-surface-700 rounded">
+        <button onClick={onClose} className="p-1 hover:bg-surface-200 rounded">
           <X className="w-5 h-5 text-surface-600" />
         </button>
       </div>
@@ -2003,7 +2003,7 @@ function AssignRoleModal({
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder="Search by name or email..."
-            className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+            className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
           />
         </div>
 
@@ -2014,7 +2014,7 @@ function AssignRoleModal({
             className={`flex items-center gap-3 p-3 rounded-lg cursor-pointer ${
               userId === ''
                 ? 'bg-brand-500/20 border border-brand-500'
-                : 'bg-surface-700 hover:bg-surface-600'
+                : 'bg-surface-200 hover:bg-surface-600'
             }`}
           >
             <input
@@ -2044,7 +2044,7 @@ function AssignRoleModal({
               className={`flex items-center gap-3 p-3 rounded-lg cursor-pointer ${
                 userId === user.id
                   ? 'bg-brand-500/20 border border-brand-500'
-                  : 'bg-surface-700 hover:bg-surface-600'
+                  : 'bg-surface-200 hover:bg-surface-600'
               }`}
             >
               <input
@@ -2080,14 +2080,14 @@ function AssignRoleModal({
                 value={userId}
                 onChange={(e) => setUserId(e.target.value)}
                 placeholder="Enter user ID..."
-                className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+                className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
               />
             </div>
           )}
         </div>
       </div>
-      <div className="p-4 border-t border-surface-700 flex justify-end gap-3">
-        <button onClick={onClose} className="px-4 py-2 bg-surface-700 text-surface-700 rounded-lg">
+      <div className="p-4 border-t border-surface-200 flex justify-end gap-3">
+        <button onClick={onClose} className="px-4 py-2 bg-surface-200 text-surface-700 rounded-lg">
           Cancel
         </button>
         <button

--- a/frontend/src/components/settings/ApiSettings.tsx
+++ b/frontend/src/components/settings/ApiSettings.tsx
@@ -76,7 +76,7 @@ export default function ApiSettings() {
     <div className="card p-6 space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-lg font-semibold text-surface-100">API Keys</h2>
+          <h2 className="text-lg font-semibold text-surface-900">API Keys</h2>
           <p className="text-surface-600 text-sm mt-1">Manage API keys for programmatic access</p>
         </div>
         <Button onClick={() => setShowCreateModal(true)} variant="primary">
@@ -97,11 +97,11 @@ export default function ApiSettings() {
           {keys.map((key: ApiKey) => (
             <div
               key={key.id}
-              className="flex items-center justify-between p-4 bg-surface-800/50 rounded-lg"
+              className="flex items-center justify-between p-4 bg-white/50 rounded-lg"
             >
               <div>
                 <div className="flex items-center gap-2">
-                  <p className="text-surface-100 font-medium">{key.name}</p>
+                  <p className="text-surface-900 font-medium">{key.name}</p>
                   {!key.isActive && (
                     <span className="px-2 py-0.5 text-xs bg-red-500/20 text-red-600 rounded">
                       Revoked

--- a/frontend/src/components/settings/ModuleSettings.tsx
+++ b/frontend/src/components/settings/ModuleSettings.tsx
@@ -101,7 +101,7 @@ export function ModuleSettings() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-lg font-semibold text-surface-100">Module Configuration</h2>
+          <h2 className="text-lg font-semibold text-surface-900">Module Configuration</h2>
           <p className="text-surface-600 text-sm mt-1">
             Enable or disable modules for this organization. Deployment defaults act as a baseline;
             changes here apply at the organization level.
@@ -113,7 +113,7 @@ export function ModuleSettings() {
       </div>
 
       <div className="card p-4 space-y-4">
-        <h3 className="text-sm font-semibold text-surface-200 mb-2">Presets</h3>
+        <h3 className="text-sm font-semibold text-surface-800 mb-2">Presets</h3>
         <div className="flex flex-wrap gap-2">
           {MODULE_PRESETS.map((preset) => (
             <button
@@ -123,7 +123,7 @@ export function ModuleSettings() {
               className={`px-3 py-1.5 rounded-full text-xs border ${
                 selectedPreset?.id === preset.id
                   ? 'bg-brand-500 text-white border-brand-500'
-                  : 'bg-surface-900 text-surface-700 border-surface-700 hover:bg-surface-800'
+                  : 'bg-white text-surface-700 border-surface-200 hover:bg-white'
               }`}
             >
               {preset.name}
@@ -141,7 +141,7 @@ export function ModuleSettings() {
               className={`card p-4 flex items-start gap-3 cursor-pointer border ${
                 checked
                   ? 'border-brand-500 bg-brand-500/10'
-                  : 'border-surface-800 hover:border-surface-600'
+                  : 'border-surface-200 hover:border-surface-300'
               }`}
             >
               <input
@@ -152,9 +152,9 @@ export function ModuleSettings() {
               />
               <div>
                 <div className="flex items-center gap-2">
-                  <span className="text-sm font-semibold text-surface-100">{mod.name}</span>
+                  <span className="text-sm font-semibold text-surface-900">{mod.name}</span>
                   {!checked && (
-                    <span className="text-[10px] px-2 py-0.5 rounded-full bg-surface-800 text-surface-600">
+                    <span className="text-[10px] px-2 py-0.5 rounded-full bg-white text-surface-600">
                       Disabled
                     </span>
                   )}

--- a/frontend/src/components/trust/AIAnswerAssistant.tsx
+++ b/frontend/src/components/trust/AIAnswerAssistant.tsx
@@ -128,10 +128,10 @@ export function AIAnswerAssistant({
       >
         <div className="flex items-center gap-2">
           <SparklesIcon className="w-5 h-5 text-purple-600" />
-          <span className="font-medium text-surface-100">AI Assistant</span>
+          <span className="font-medium text-surface-900">AI Assistant</span>
           {aiEnabled === false && <span className="text-xs text-surface-500">(Disabled)</span>}
         </div>
-        <button className="p-1 text-surface-600 hover:text-surface-200">
+        <button className="p-1 text-surface-600 hover:text-surface-800">
           {isExpanded ? (
             <ChevronUpIcon className="w-4 h-4" />
           ) : (
@@ -190,8 +190,8 @@ export function AIAnswerAssistant({
               </div>
 
               {/* Suggested Answer */}
-              <div className="bg-surface-800/50 rounded-lg p-3 border border-surface-700">
-                <p className="text-sm text-surface-200 whitespace-pre-wrap">
+              <div className="bg-white/50 rounded-lg p-3 border border-surface-200">
+                <p className="text-sm text-surface-800 whitespace-pre-wrap">
                   {suggestion.suggestedAnswer}
                 </p>
               </div>
@@ -212,7 +212,7 @@ export function AIAnswerAssistant({
                     {suggestion.sources.map((source) => (
                       <span
                         key={source.id}
-                        className="px-2 py-0.5 text-xs bg-surface-700 text-surface-700 rounded"
+                        className="px-2 py-0.5 text-xs bg-surface-200 text-surface-700 rounded"
                       >
                         {source.title}
                       </span>

--- a/frontend/src/components/trust/KnowledgeBaseSearchPanel.tsx
+++ b/frontend/src/components/trust/KnowledgeBaseSearchPanel.tsx
@@ -157,27 +157,27 @@ export function KnowledgeBaseSearchPanel({
   return (
     <div
       className={clsx(
-        'bg-surface-900 border border-surface-700 rounded-xl shadow-xl overflow-hidden',
+        'bg-white border border-surface-200 rounded-xl shadow-xl overflow-hidden',
         className
       )}
     >
       {/* Header */}
-      <div className="bg-surface-800 px-4 py-3 flex items-center justify-between border-b border-surface-700">
+      <div className="bg-white px-4 py-3 flex items-center justify-between border-b border-surface-200">
         <div className="flex items-center gap-2">
           <BookOpenIcon className="w-5 h-5 text-brand-400" />
-          <h3 className="font-semibold text-surface-100">Knowledge Base</h3>
+          <h3 className="font-semibold text-surface-900">Knowledge Base</h3>
         </div>
         {onClose && (
           <button
             onClick={onClose}
-            className="p-1 text-surface-600 hover:text-surface-200 rounded transition-colors"
+            className="p-1 text-surface-600 hover:text-surface-800 rounded transition-colors"
           >
             <XMarkIcon className="w-5 h-5" />
           </button>
         )}
       </div>
       {/* Search Input */}
-      <div className="p-3 border-b border-surface-700">
+      <div className="p-3 border-b border-surface-200">
         <div className="relative">
           <MagnifyingGlassIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-surface-500" />
           <Input
@@ -185,7 +185,7 @@ export function KnowledgeBaseSearchPanel({
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             placeholder="Search knowledge base..."
-            className="w-full pl-9 pr-3 py-2 bg-surface-800 border border-surface-600 rounded-lg text-surface-100 text-sm focus:outline-none focus:border-brand-500 placeholder:text-surface-500"
+            className="w-full pl-9 pr-3 py-2 bg-white border border-surface-300 rounded-lg text-surface-900 text-sm focus:outline-none focus:border-brand-500 placeholder:text-surface-500"
           />
           {loading && (
             <ArrowPathIcon className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-surface-600 animate-spin" />
@@ -213,8 +213,8 @@ export function KnowledgeBaseSearchPanel({
           <div
             key={entry.id}
             className={clsx(
-              'border-b border-surface-700 last:border-b-0 transition-colors',
-              selectedEntry?.id === entry.id ? 'bg-brand-500/10' : 'hover:bg-surface-800'
+              'border-b border-surface-200 last:border-b-0 transition-colors',
+              selectedEntry?.id === entry.id ? 'bg-brand-500/10' : 'hover:bg-white'
             )}
           >
             <button
@@ -224,7 +224,7 @@ export function KnowledgeBaseSearchPanel({
               <div className="flex items-start justify-between gap-2">
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 mb-1">
-                    <span className="text-sm font-medium text-surface-100 truncate">
+                    <span className="text-sm font-medium text-surface-900 truncate">
                       {entry.title}
                     </span>
                     {entry.status === 'approved' && (
@@ -241,7 +241,7 @@ export function KnowledgeBaseSearchPanel({
                   )}
                   <div className="flex items-center gap-2 text-xs text-surface-500">
                     {entry.category && (
-                      <span className="px-1.5 py-0.5 bg-surface-700 rounded">{entry.category}</span>
+                      <span className="px-1.5 py-0.5 bg-surface-200 rounded">{entry.category}</span>
                     )}
                     {entry.usageCount && entry.usageCount > 0 && (
                       <span className="flex items-center gap-1">
@@ -257,8 +257,8 @@ export function KnowledgeBaseSearchPanel({
             {/* Expanded View */}
             {selectedEntry?.id === entry.id && (
               <div className="px-3 pb-3 space-y-3">
-                <div className="bg-surface-800 rounded-lg p-3 border border-surface-600">
-                  <p className="text-sm text-surface-200 whitespace-pre-wrap">
+                <div className="bg-white rounded-lg p-3 border border-surface-300">
+                  <p className="text-sm text-surface-800 whitespace-pre-wrap">
                     {entry.answer || 'No answer content'}
                   </p>
                 </div>
@@ -269,7 +269,7 @@ export function KnowledgeBaseSearchPanel({
                     {entry.tags.map((tag, idx) => (
                       <span
                         key={idx}
-                        className="px-2 py-0.5 text-xs bg-surface-700 text-surface-700 rounded"
+                        className="px-2 py-0.5 text-xs bg-surface-200 text-surface-700 rounded"
                       >
                         {tag}
                       </span>
@@ -288,7 +288,7 @@ export function KnowledgeBaseSearchPanel({
                   </button>
                   <button
                     onClick={() => handleCopyAnswer(entry)}
-                    className="px-3 py-2 bg-surface-700 hover:bg-surface-600 text-surface-200 text-sm rounded-lg transition-colors"
+                    className="px-3 py-2 bg-surface-200 hover:bg-surface-600 text-surface-800 text-sm rounded-lg transition-colors"
                     title="Copy to clipboard"
                   >
                     <DocumentDuplicateIcon className="w-4 h-4" />
@@ -300,7 +300,7 @@ export function KnowledgeBaseSearchPanel({
         ))}
       </div>
       {/* Footer hint */}
-      <div className="px-4 py-2 bg-surface-800 border-t border-surface-700">
+      <div className="px-4 py-2 bg-white border-t border-surface-200">
         <p className="text-xs text-surface-500 text-center">
           Click an entry to preview, then "Use This Answer" to apply
         </p>

--- a/frontend/src/components/trust/TrustAnalystQueueWidget.tsx
+++ b/frontend/src/components/trust/TrustAnalystQueueWidget.tsx
@@ -38,7 +38,7 @@ export function TrustAnalystQueueWidget({ className }: TrustAnalystQueueWidgetPr
 
   if (!organizationId) {
     return (
-      <div className={clsx('bg-surface-900 border border-surface-800 rounded-xl p-6', className)}>
+      <div className={clsx('bg-white border border-surface-200 rounded-xl p-6', className)}>
         <p className="text-surface-600 text-sm">Sign in to view your questionnaire queue.</p>
       </div>
     );
@@ -46,13 +46,13 @@ export function TrustAnalystQueueWidget({ className }: TrustAnalystQueueWidgetPr
 
   if (isLoading) {
     return (
-      <div className={clsx('bg-surface-900 border border-surface-800 rounded-xl p-6', className)}>
+      <div className={clsx('bg-white border border-surface-200 rounded-xl p-6', className)}>
         <div className="animate-pulse space-y-4">
-          <div className="h-6 bg-surface-700 rounded w-48" />
+          <div className="h-6 bg-surface-200 rounded w-48" />
           <div className="space-y-3">
-            <div className="h-16 bg-surface-800 rounded" />
-            <div className="h-16 bg-surface-800 rounded" />
-            <div className="h-16 bg-surface-800 rounded" />
+            <div className="h-16 bg-white rounded" />
+            <div className="h-16 bg-white rounded" />
+            <div className="h-16 bg-white rounded" />
           </div>
         </div>
       </div>
@@ -61,7 +61,7 @@ export function TrustAnalystQueueWidget({ className }: TrustAnalystQueueWidgetPr
 
   if (error) {
     return (
-      <div className={clsx('bg-surface-900 border border-surface-800 rounded-xl p-6', className)}>
+      <div className={clsx('bg-white border border-surface-200 rounded-xl p-6', className)}>
         <p className="text-red-600 text-sm">Failed to load queue</p>
       </div>
     );
@@ -74,19 +74,16 @@ export function TrustAnalystQueueWidget({ className }: TrustAnalystQueueWidgetPr
 
   return (
     <div
-      className={clsx(
-        'bg-surface-900 border border-surface-800 rounded-xl overflow-hidden',
-        className
-      )}
+      className={clsx('bg-white border border-surface-200 rounded-xl overflow-hidden', className)}
     >
       {/* Header */}
-      <div className="px-5 py-4 border-b border-surface-800 flex items-center justify-between">
+      <div className="px-5 py-4 border-b border-surface-200 flex items-center justify-between">
         <div className="flex items-center gap-3">
           <div className="p-2 bg-brand-600/20 rounded-lg">
             <DocumentTextIcon className="w-5 h-5 text-brand-400" />
           </div>
           <div>
-            <h3 className="font-semibold text-surface-100">Trust Queue</h3>
+            <h3 className="font-semibold text-surface-900">Trust Queue</h3>
             <p className="text-xs text-surface-600">Questionnaires requiring attention</p>
           </div>
         </div>
@@ -98,7 +95,7 @@ export function TrustAnalystQueueWidget({ className }: TrustAnalystQueueWidgetPr
       </div>
 
       {/* Summary Stats */}
-      <div className="grid grid-cols-4 gap-px bg-surface-700">
+      <div className="grid grid-cols-4 gap-px bg-surface-200">
         <StatBox
           icon={ExclamationTriangleIcon}
           label="Overdue"
@@ -168,7 +165,7 @@ export function TrustAnalystQueueWidget({ className }: TrustAnalystQueueWidgetPr
       </div>
 
       {/* Footer */}
-      <div className="px-5 py-3 border-t border-surface-800 bg-surface-800/50">
+      <div className="px-5 py-3 border-t border-surface-200 bg-white/50">
         <Link
           to="/questionnaires"
           className="flex items-center justify-center gap-2 text-sm text-brand-400 hover:text-brand-300 transition-colors"
@@ -201,7 +198,7 @@ function StatBox({
   };
 
   return (
-    <div className="bg-surface-900 p-3 text-center">
+    <div className="bg-white p-3 text-center">
       <div
         className={clsx('text-2xl font-bold', value > 0 ? colorClasses[color] : 'text-surface-500')}
       >
@@ -238,11 +235,11 @@ function QueueSection({
     urgent: 'bg-red-500/20 text-red-600',
     high: 'bg-orange-500/20 text-orange-600',
     medium: 'bg-yellow-500/20 text-yellow-600',
-    low: 'bg-surface-700 text-surface-600',
+    low: 'bg-surface-200 text-surface-600',
   };
 
   return (
-    <div className="border-b border-surface-800 last:border-b-0">
+    <div className="border-b border-surface-200 last:border-b-0">
       <div
         className={clsx(
           'px-4 py-2 flex items-center gap-2 text-xs font-medium border-l-2',
@@ -252,17 +249,17 @@ function QueueSection({
         <Icon className="w-3.5 h-3.5" />
         {title} ({items.length})
       </div>
-      <div className="divide-y divide-surface-800">
+      <div className="divide-y divide-surface-200">
         {items.slice(0, 3).map((item) => (
           <Link
             key={item.id}
             to={`/questionnaires/${item.id}`}
-            className="block px-4 py-3 hover:bg-surface-800/50 transition-colors group"
+            className="block px-4 py-3 hover:bg-white/50 transition-colors group"
           >
             <div className="flex items-start justify-between gap-2">
               <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2 mb-1">
-                  <span className="text-sm font-medium text-surface-100 truncate">
+                  <span className="text-sm font-medium text-surface-900 truncate">
                     {item.title}
                   </span>
                   <span
@@ -285,7 +282,7 @@ function QueueSection({
                 </div>
                 {/* Progress Bar */}
                 <div className="mt-2 flex items-center gap-2">
-                  <div className="flex-1 h-1.5 bg-surface-700 rounded-full overflow-hidden">
+                  <div className="flex-1 h-1.5 bg-surface-200 rounded-full overflow-hidden">
                     <div
                       className={clsx(
                         'h-full transition-all',

--- a/frontend/src/components/ui/Badge.tsx
+++ b/frontend/src/components/ui/Badge.tsx
@@ -19,12 +19,17 @@ export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
 }
 
 const variants: Record<BadgeVariant, string> = {
-  neutral: 'bg-surface-100 text-surface-700 border border-surface-300',
-  success: 'bg-emerald-50 text-emerald-800 border border-emerald-200',
-  warning: 'bg-amber-50 text-amber-800 border border-amber-200',
-  danger: 'bg-red-50 text-red-800 border border-red-200',
-  info: 'bg-blue-50 text-blue-800 border border-blue-200',
-  brand: 'bg-brand-50 text-brand-800 border border-brand-200',
+  neutral:
+    'bg-surface-100 text-surface-700 border border-surface-300 dark:bg-surface-800 dark:text-surface-200 dark:border-surface-700',
+  success:
+    'bg-emerald-50 text-emerald-800 border border-emerald-200 dark:bg-emerald-900/40 dark:text-emerald-200 dark:border-emerald-800',
+  warning:
+    'bg-amber-50 text-amber-800 border border-amber-200 dark:bg-amber-900/40 dark:text-amber-200 dark:border-amber-800',
+  danger:
+    'bg-red-50 text-red-800 border border-red-200 dark:bg-red-900/40 dark:text-red-200 dark:border-red-800',
+  info: 'bg-blue-50 text-blue-800 border border-blue-200 dark:bg-blue-900/40 dark:text-blue-200 dark:border-blue-800',
+  brand:
+    'bg-brand-50 text-brand-800 border border-brand-200 dark:bg-brand-900/40 dark:text-brand-200 dark:border-brand-800',
 };
 
 const dotColors: Record<BadgeVariant, string> = {

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -33,20 +33,20 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 // the merged class string. Forcing with ! pins the color.
 const variants: Record<ButtonVariant, string> = {
   primary:
-    'bg-brand-600 !text-white shadow-sm hover:bg-brand-500 active:bg-brand-700 focus-visible:ring-brand-500 disabled:hover:bg-brand-600',
+    'bg-brand-600 !text-white shadow-sm hover:bg-brand-500 active:bg-brand-700 focus-visible:ring-brand-500 disabled:hover:bg-brand-600 dark:bg-brand-500 dark:hover:bg-brand-400 dark:active:bg-brand-600 dark:disabled:hover:bg-brand-500',
   secondary:
-    'bg-surface-200 !text-surface-900 border border-surface-400 hover:bg-surface-300 focus-visible:ring-brand-500',
+    'bg-surface-200 !text-surface-900 border border-surface-400 hover:bg-surface-300 focus-visible:ring-brand-500 dark:bg-surface-800 dark:!text-surface-100 dark:border-surface-700 dark:hover:bg-surface-700',
   outline:
-    'border border-surface-400 bg-white !text-surface-900 hover:bg-surface-100 hover:border-surface-500 focus-visible:ring-brand-500',
+    'border border-surface-400 bg-white !text-surface-900 hover:bg-surface-100 hover:border-surface-500 focus-visible:ring-brand-500 dark:bg-transparent dark:!text-surface-200 dark:border-surface-700 dark:hover:bg-surface-800 dark:hover:border-surface-600',
   ghost:
-    'bg-transparent !text-surface-700 hover:bg-surface-100 hover:!text-surface-900 focus-visible:ring-brand-500',
+    'bg-transparent !text-surface-700 hover:bg-surface-100 hover:!text-surface-900 focus-visible:ring-brand-500 dark:!text-surface-300 dark:hover:bg-surface-800 dark:hover:!text-surface-100',
   danger:
-    'bg-red-600 !text-white shadow-sm hover:bg-red-500 active:bg-red-700 focus-visible:ring-red-500 disabled:hover:bg-red-600',
-  link: 'bg-transparent !text-brand-700 hover:!text-brand-800 underline-offset-4 hover:underline focus-visible:ring-brand-500',
+    'bg-red-600 !text-white shadow-sm hover:bg-red-500 active:bg-red-700 focus-visible:ring-red-500 disabled:hover:bg-red-600 dark:bg-red-500 dark:hover:bg-red-400',
+  link: 'bg-transparent !text-brand-700 hover:!text-brand-800 underline-offset-4 hover:underline focus-visible:ring-brand-500 dark:!text-brand-400 dark:hover:!text-brand-300',
   success:
-    'bg-emerald-600 !text-white shadow-sm hover:bg-emerald-500 active:bg-emerald-700 focus-visible:ring-emerald-500 disabled:hover:bg-emerald-600',
+    'bg-emerald-600 !text-white shadow-sm hover:bg-emerald-500 active:bg-emerald-700 focus-visible:ring-emerald-500 disabled:hover:bg-emerald-600 dark:bg-emerald-500 dark:hover:bg-emerald-400',
   warning:
-    'bg-amber-500 !text-white shadow-sm hover:bg-amber-400 active:bg-amber-600 focus-visible:ring-amber-500 disabled:hover:bg-amber-500',
+    'bg-amber-500 !text-white shadow-sm hover:bg-amber-400 active:bg-amber-600 focus-visible:ring-amber-500 disabled:hover:bg-amber-500 dark:bg-amber-400 dark:!text-surface-950 dark:hover:bg-amber-300',
 };
 
 const sizes: Record<ButtonSize, string> = {
@@ -83,7 +83,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         disabled={disabled || isBusy}
         className={cn(
           'inline-flex items-center justify-center font-medium transition-colors',
-          'focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-surface-50',
+          'focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-surface-50 dark:focus-visible:ring-offset-surface-950',
           'disabled:opacity-50 disabled:cursor-not-allowed',
           variants[variant],
           sizes[size],

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -21,10 +21,12 @@ export const Card = forwardRef<HTMLDivElement, CardProps>(
     <div
       ref={ref}
       className={cn(
-        'rounded-lg bg-white border border-surface-200',
-        elevated && 'shadow-[0_1px_2px_0_rgba(30,25,20,0.06),0_1px_3px_-1px_rgba(30,25,20,0.08)]',
+        'rounded-lg bg-white border border-surface-200 dark:bg-surface-900 dark:border-surface-800',
+        elevated &&
+          'shadow-[0_1px_2px_0_rgba(30,25,20,0.06),0_1px_3px_-1px_rgba(30,25,20,0.08)] dark:shadow-[0_1px_2px_0_rgba(0,0,0,0.4),0_1px_3px_-1px_rgba(0,0,0,0.5)]',
         density && densityPad[density],
-        interactive && 'lift-hover cursor-pointer hover:border-surface-300',
+        interactive &&
+          'lift-hover cursor-pointer hover:border-surface-300 dark:hover:border-surface-700',
         className
       )}
       {...props}
@@ -38,7 +40,7 @@ export const CardHeader = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivEleme
     <div
       ref={ref}
       className={cn(
-        'flex items-center justify-between gap-4 px-4 py-3 border-b border-surface-200',
+        'flex items-center justify-between gap-4 px-4 py-3 border-b border-surface-200 dark:border-surface-800',
         className
       )}
       {...props}
@@ -49,7 +51,11 @@ CardHeader.displayName = 'CardHeader';
 
 export const CardTitle = forwardRef<HTMLHeadingElement, HTMLAttributes<HTMLHeadingElement>>(
   ({ className, ...props }, ref) => (
-    <h3 ref={ref} className={cn('text-h3 text-surface-900', className)} {...props} />
+    <h3
+      ref={ref}
+      className={cn('text-h3 text-surface-900 dark:text-surface-100', className)}
+      {...props}
+    />
   )
 );
 CardTitle.displayName = 'CardTitle';
@@ -58,7 +64,11 @@ export const CardDescription = forwardRef<
   HTMLParagraphElement,
   HTMLAttributes<HTMLParagraphElement>
 >(({ className, ...props }, ref) => (
-  <p ref={ref} className={cn('text-small text-surface-600', className)} {...props} />
+  <p
+    ref={ref}
+    className={cn('text-small text-surface-600 dark:text-surface-400', className)}
+    {...props}
+  />
 ));
 CardDescription.displayName = 'CardDescription';
 
@@ -75,7 +85,7 @@ export const CardFooter = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivEleme
     <div
       ref={ref}
       className={cn(
-        'flex items-center justify-end gap-2 px-4 py-3 border-t border-surface-200 bg-surface-50/60',
+        'flex items-center justify-end gap-2 px-4 py-3 border-t border-surface-200 bg-surface-50/60 dark:border-surface-800 dark:bg-surface-950/60',
         className
       )}
       {...props}

--- a/frontend/src/components/ui/DataTable.tsx
+++ b/frontend/src/components/ui/DataTable.tsx
@@ -79,7 +79,12 @@ export function DataTable<TData>({
 
   if (loading) {
     return (
-      <div className={cn('rounded-lg border border-surface-200 bg-white p-4', className)}>
+      <div
+        className={cn(
+          'rounded-lg border border-surface-200 bg-white p-4 dark:bg-surface-900 dark:border-surface-800',
+          className
+        )}
+      >
         <SkeletonRows rows={loadingRows} />
       </div>
     );
@@ -87,20 +92,33 @@ export function DataTable<TData>({
 
   if (data.length === 0) {
     return (
-      <div className={cn('rounded-lg border border-surface-200 bg-white', className)}>
+      <div
+        className={cn(
+          'rounded-lg border border-surface-200 bg-white dark:bg-surface-900 dark:border-surface-800',
+          className
+        )}
+      >
         {emptyState ?? <EmptyState title="No results" description="Try adjusting your filters." />}
       </div>
     );
   }
 
   return (
-    <div className={cn('rounded-lg border border-surface-200 bg-white overflow-hidden', className)}>
+    <div
+      className={cn(
+        'rounded-lg border border-surface-200 bg-white overflow-hidden dark:bg-surface-900 dark:border-surface-800',
+        className
+      )}
+    >
       {/* Desktop table */}
       <div className={cn('overflow-x-auto', mobileBehavior === 'cards' && 'hidden md:block')}>
         <table className="w-full text-small">
-          <thead className="bg-surface-50/40">
+          <thead className="bg-surface-50/40 dark:bg-surface-950/40">
             {table.getHeaderGroups().map((headerGroup) => (
-              <tr key={headerGroup.id} className="border-b border-surface-200">
+              <tr
+                key={headerGroup.id}
+                className="border-b border-surface-200 dark:border-surface-800"
+              >
                 {headerGroup.headers.map((header) => {
                   const canSort = header.column.getCanSort();
                   const sorted = header.column.getIsSorted();
@@ -108,9 +126,10 @@ export function DataTable<TData>({
                     <th
                       key={header.id}
                       className={cn(
-                        'px-4 text-left text-xs font-medium text-surface-600 uppercase tracking-wider',
+                        'px-4 text-left text-xs font-medium text-surface-600 uppercase tracking-wider dark:text-surface-400',
                         densityHead[density],
-                        canSort && 'cursor-pointer select-none hover:text-surface-800'
+                        canSort &&
+                          'cursor-pointer select-none hover:text-surface-800 dark:hover:text-surface-200'
                       )}
                       onClick={canSort ? header.column.getToggleSortingHandler() : undefined}
                       style={{ width: header.getSize() !== 150 ? header.getSize() : undefined }}
@@ -118,7 +137,7 @@ export function DataTable<TData>({
                       <div className="inline-flex items-center gap-1">
                         {flexRender(header.column.columnDef.header, header.getContext())}
                         {canSort && (
-                          <span className="text-surface-500">
+                          <span className="text-surface-500 dark:text-surface-400">
                             {sorted === 'asc' ? (
                               <ChevronUp className="h-3.5 w-3.5" />
                             ) : sorted === 'desc' ? (
@@ -141,14 +160,18 @@ export function DataTable<TData>({
                 key={row.id}
                 onClick={onRowClick ? () => onRowClick(row.original) : undefined}
                 className={cn(
-                  'border-b border-surface-200/60 last:border-b-0 transition-colors',
-                  onRowClick && 'cursor-pointer hover:bg-surface-100/50'
+                  'border-b border-surface-200/60 last:border-b-0 transition-colors dark:border-surface-800/60',
+                  onRowClick &&
+                    'cursor-pointer hover:bg-surface-100/50 dark:hover:bg-surface-800/40'
                 )}
               >
                 {row.getVisibleCells().map((cell) => (
                   <td
                     key={cell.id}
-                    className={cn('px-4 text-surface-800 align-middle', densityRow[density])}
+                    className={cn(
+                      'px-4 text-surface-800 align-middle dark:text-surface-200',
+                      densityRow[density]
+                    )}
                   >
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </td>
@@ -161,7 +184,7 @@ export function DataTable<TData>({
 
       {/* Mobile card stack */}
       {mobileBehavior === 'cards' && (
-        <div className="md:hidden divide-y divide-surface-200/60">
+        <div className="md:hidden divide-y divide-surface-200/60 dark:divide-surface-800/60">
           {table.getRowModel().rows.map((row) => (
             <MobileRow
               key={row.id}
@@ -200,7 +223,8 @@ function MobileRow<TData>({
       onClick={onClick}
       className={cn(
         'p-4 transition-colors',
-        onClick && 'cursor-pointer hover:bg-surface-100/40 active:bg-surface-100/60'
+        onClick &&
+          'cursor-pointer hover:bg-surface-100/40 active:bg-surface-100/60 dark:hover:bg-surface-800/40 dark:active:bg-surface-800/60'
       )}
     >
       <div className="space-y-2">
@@ -213,11 +237,16 @@ function MobileRow<TData>({
           return (
             <div key={cell.id} className="flex items-start justify-between gap-3">
               {label && (
-                <span className="text-xs font-medium text-surface-500 uppercase tracking-wider shrink-0">
+                <span className="text-xs font-medium text-surface-500 uppercase tracking-wider shrink-0 dark:text-surface-400">
                   {label}
                 </span>
               )}
-              <div className={cn('text-small text-surface-800 min-w-0', label && 'text-right')}>
+              <div
+                className={cn(
+                  'text-small text-surface-800 min-w-0 dark:text-surface-200',
+                  label && 'text-right'
+                )}
+              >
                 {flexRender(cell.column.columnDef.cell, cell.getContext())}
               </div>
             </div>

--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -43,7 +43,7 @@ export function Dialog({
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <div className="fixed inset-0 bg-white/40 backdrop-blur-sm" />
+          <div className="fixed inset-0 bg-white/40 backdrop-blur-sm dark:bg-black/60" />
         </Transition.Child>
 
         <div className="fixed inset-0 overflow-y-auto">
@@ -59,26 +59,26 @@ export function Dialog({
             >
               <HUIDialog.Panel
                 className={cn(
-                  'w-full transform overflow-hidden rounded-lg bg-white border border-surface-200 shadow-2xl transition-all',
+                  'w-full transform overflow-hidden rounded-lg bg-white border border-surface-200 shadow-2xl transition-all dark:bg-surface-900 dark:border-surface-800',
                   sizes[size],
                   className
                 )}
               >
                 {title && (
-                  <div className="flex items-start justify-between gap-4 px-5 py-4 border-b border-surface-200">
+                  <div className="flex items-start justify-between gap-4 px-5 py-4 border-b border-surface-200 dark:border-surface-800">
                     <div className="min-w-0">
-                      <HUIDialog.Title className="text-h2 text-surface-900">
+                      <HUIDialog.Title className="text-h2 text-surface-900 dark:text-surface-100">
                         {title}
                       </HUIDialog.Title>
                       {description && (
-                        <HUIDialog.Description className="mt-1 text-small text-surface-600">
+                        <HUIDialog.Description className="mt-1 text-small text-surface-600 dark:text-surface-400">
                           {description}
                         </HUIDialog.Description>
                       )}
                     </div>
                     <button
                       onClick={onClose}
-                      className="text-surface-500 hover:text-surface-900 transition-colors -mr-1"
+                      className="text-surface-500 hover:text-surface-900 dark:text-surface-400 dark:hover:text-surface-100 transition-colors -mr-1"
                       aria-label="Close"
                     >
                       <X className="h-5 w-5" />
@@ -87,7 +87,7 @@ export function Dialog({
                 )}
                 <div className="px-5 py-4">{children}</div>
                 {footer && (
-                  <div className="flex items-center justify-end gap-2 px-5 py-3 border-t border-surface-200 bg-surface-50/30">
+                  <div className="flex items-center justify-end gap-2 px-5 py-3 border-t border-surface-200 bg-surface-50/30 dark:border-surface-800 dark:bg-surface-950/30">
                     {footer}
                   </div>
                 )}

--- a/frontend/src/components/ui/Drawer.tsx
+++ b/frontend/src/components/ui/Drawer.tsx
@@ -48,7 +48,7 @@ export function Drawer({
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <div className="fixed inset-0 bg-white/30" />
+          <div className="fixed inset-0 bg-white/30 dark:bg-black/50" />
         </Transition.Child>
 
         <div className="fixed inset-0 overflow-hidden">
@@ -63,7 +63,7 @@ export function Drawer({
           >
             <HUIDialog.Panel
               className={cn(
-                'fixed inset-y-0 flex w-full flex-col bg-white border-surface-200 shadow-2xl',
+                'fixed inset-y-0 flex w-full flex-col bg-white border-surface-200 shadow-2xl dark:bg-surface-900 dark:border-surface-800',
                 sideClass,
                 side === 'right' ? 'border-l' : 'border-r',
                 sizes[size],
@@ -71,11 +71,13 @@ export function Drawer({
               )}
             >
               {title && (
-                <div className="flex items-start justify-between gap-4 px-5 py-4 border-b border-surface-200 shrink-0">
+                <div className="flex items-start justify-between gap-4 px-5 py-4 border-b border-surface-200 dark:border-surface-800 shrink-0">
                   <div className="min-w-0">
-                    <HUIDialog.Title className="text-h2 text-surface-900">{title}</HUIDialog.Title>
+                    <HUIDialog.Title className="text-h2 text-surface-900 dark:text-surface-100">
+                      {title}
+                    </HUIDialog.Title>
                     {description && (
-                      <HUIDialog.Description className="mt-1 text-small text-surface-600">
+                      <HUIDialog.Description className="mt-1 text-small text-surface-600 dark:text-surface-400">
                         {description}
                       </HUIDialog.Description>
                     )}
@@ -85,7 +87,7 @@ export function Drawer({
                       e.stopPropagation();
                       onClose();
                     }}
-                    className="text-surface-500 hover:text-surface-900 transition-colors -mr-1"
+                    className="text-surface-500 hover:text-surface-900 dark:text-surface-400 dark:hover:text-surface-100 transition-colors -mr-1"
                     aria-label="Close"
                   >
                     <X className="h-5 w-5" />
@@ -94,7 +96,7 @@ export function Drawer({
               )}
               <div className="flex-1 overflow-y-auto px-5 py-4">{children}</div>
               {footer && (
-                <div className="flex items-center justify-end gap-2 px-5 py-3 border-t border-surface-200 bg-surface-50/30 shrink-0">
+                <div className="flex items-center justify-end gap-2 px-5 py-3 border-t border-surface-200 bg-surface-50/30 dark:border-surface-800 dark:bg-surface-950/30 shrink-0">
                   {footer}
                 </div>
               )}

--- a/frontend/src/components/ui/EmptyState.tsx
+++ b/frontend/src/components/ui/EmptyState.tsx
@@ -40,13 +40,20 @@ export function EmptyState({
     >
       {icon && (
         <div
-          className={cn('mb-3 rounded-full bg-surface-100 p-3 text-surface-500', iconSizes[size])}
+          className={cn(
+            'mb-3 rounded-full bg-surface-100 p-3 text-surface-500 dark:bg-surface-800 dark:text-surface-400',
+            iconSizes[size]
+          )}
         >
           {icon}
         </div>
       )}
-      <h3 className="text-h3 text-surface-900">{title}</h3>
-      {description && <p className="mt-1 max-w-sm text-small text-surface-600">{description}</p>}
+      <h3 className="text-h3 text-surface-900 dark:text-surface-100">{title}</h3>
+      {description && (
+        <p className="mt-1 max-w-sm text-small text-surface-600 dark:text-surface-400">
+          {description}
+        </p>
+      )}
       {action && <div className="mt-4">{action}</div>}
     </div>
   );

--- a/frontend/src/components/ui/FilterBar.tsx
+++ b/frontend/src/components/ui/FilterBar.tsx
@@ -24,12 +24,14 @@ export function FilterBar({ children, active, onClearAll, className }: FilterBar
       <div className="flex flex-wrap items-center gap-2">{children}</div>
       {hasActive && (
         <div className="flex flex-wrap items-center gap-2">
-          <span className="text-xs text-surface-500 uppercase tracking-wider">Active</span>
+          <span className="text-xs text-surface-500 dark:text-surface-400 uppercase tracking-wider">
+            Active
+          </span>
           {active!.map((f) => (
             <button
               key={f.key}
               onClick={f.onClear}
-              className="inline-flex items-center gap-1 rounded-md border border-surface-300 bg-surface-100 px-2 py-1 text-xs text-surface-700 hover:bg-surface-200 hover:text-surface-900 transition-colors"
+              className="inline-flex items-center gap-1 rounded-md border border-surface-300 bg-surface-100 px-2 py-1 text-xs text-surface-700 hover:bg-surface-200 hover:text-surface-900 transition-colors dark:border-surface-700 dark:bg-surface-800 dark:text-surface-200 dark:hover:bg-surface-700 dark:hover:text-surface-100"
             >
               <span>{f.label}</span>
               <X className="h-3 w-3" />

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -20,17 +20,19 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
       return (
         <div className="relative w-full">
           {leftIcon && (
-            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-surface-500 pointer-events-none">
+            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-surface-500 dark:text-surface-400 pointer-events-none">
               {leftIcon}
             </span>
           )}
           <input
             ref={ref}
             className={cn(
-              'w-full rounded-md border bg-white px-3 text-surface-900 placeholder:text-surface-600 transition-colors',
-              'focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-1 focus-visible:ring-offset-surface-50',
+              'w-full rounded-md border bg-white px-3 text-surface-900 placeholder:text-surface-600 transition-colors dark:bg-surface-900 dark:text-surface-100 dark:placeholder:text-surface-500',
+              'focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-1 focus-visible:ring-offset-surface-50 dark:focus-visible:ring-offset-surface-950',
               'disabled:opacity-50 disabled:cursor-not-allowed',
-              invalid ? 'border-red-500/60' : 'border-surface-300 hover:border-surface-400',
+              invalid
+                ? 'border-red-500/60 dark:border-red-500/70'
+                : 'border-surface-300 hover:border-surface-400 dark:border-surface-700 dark:hover:border-surface-600',
               sizes[inputSize],
               leftIcon && 'pl-9',
               rightSlot && 'pr-9',
@@ -39,7 +41,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             {...props}
           />
           {rightSlot && (
-            <span className="absolute right-3 top-1/2 -translate-y-1/2 text-surface-500">
+            <span className="absolute right-3 top-1/2 -translate-y-1/2 text-surface-500 dark:text-surface-400">
               {rightSlot}
             </span>
           )}

--- a/frontend/src/components/ui/Kbd.tsx
+++ b/frontend/src/components/ui/Kbd.tsx
@@ -7,7 +7,7 @@ export function Kbd({ className, children, ...props }: KbdProps) {
   return (
     <kbd
       className={cn(
-        'inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1 rounded border border-surface-300 bg-surface-100 text-[10px] font-mono text-surface-600 leading-none',
+        'inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1 rounded border border-surface-300 bg-surface-100 text-[10px] font-mono text-surface-600 leading-none dark:border-surface-700 dark:bg-surface-800 dark:text-surface-300',
         className
       )}
       {...props}

--- a/frontend/src/components/ui/Label.tsx
+++ b/frontend/src/components/ui/Label.tsx
@@ -9,11 +9,14 @@ export const Label = forwardRef<HTMLLabelElement, LabelProps>(
   ({ className, required, children, ...props }, ref) => (
     <label
       ref={ref}
-      className={cn('block text-small font-medium text-surface-700 mb-1.5', className)}
+      className={cn(
+        'block text-small font-medium text-surface-700 mb-1.5 dark:text-surface-300',
+        className
+      )}
       {...props}
     >
       {children}
-      {required && <span className="text-red-600 ml-1">*</span>}
+      {required && <span className="text-red-600 dark:text-red-400 ml-1">*</span>}
     </label>
   )
 );
@@ -27,7 +30,13 @@ export interface FieldHintProps {
 
 export function FieldHint({ children, error, className }: FieldHintProps) {
   return (
-    <p className={cn('mt-1.5 text-xs', error ? 'text-red-600' : 'text-surface-500', className)}>
+    <p
+      className={cn(
+        'mt-1.5 text-xs',
+        error ? 'text-red-600 dark:text-red-400' : 'text-surface-500 dark:text-surface-400',
+        className
+      )}
+    >
       {children}
     </p>
   );

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -112,17 +112,17 @@ export function Modal({
             >
               <Dialog.Panel
                 className={clsx(
-                  'w-full transform rounded-xl bg-surface-800 shadow-xl transition-all',
-                  'border border-surface-700',
+                  'w-full transform rounded-xl bg-white shadow-xl transition-all',
+                  'border border-surface-200',
                   sizeStyles[size]
                 )}
               >
                 {/* Header */}
                 {(title || showCloseButton) && (
-                  <div className="flex items-start justify-between p-4 border-b border-surface-700">
+                  <div className="flex items-start justify-between p-4 border-b border-surface-200">
                     <div>
                       {title && (
-                        <Dialog.Title as="h2" className="text-lg font-semibold text-surface-100">
+                        <Dialog.Title as="h2" className="text-lg font-semibold text-surface-900">
                           {title}
                         </Dialog.Title>
                       )}
@@ -140,7 +140,7 @@ export function Modal({
                         onClick={onClose}
                         className={clsx(
                           'rounded-lg p-1.5 text-surface-600',
-                          'hover:bg-surface-700 hover:text-surface-200',
+                          'hover:bg-surface-200 hover:text-surface-800',
                           'focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-surface-800',
                           'transition-colors'
                         )}
@@ -171,7 +171,7 @@ export function ModalFooter({ children, className }: { children: ReactNode; clas
   return (
     <div
       className={clsx(
-        'flex items-center justify-end gap-3 pt-4 mt-4 border-t border-surface-700',
+        'flex items-center justify-end gap-3 pt-4 mt-4 border-t border-surface-200',
         className
       )}
     >

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -112,22 +112,25 @@ export function Modal({
             >
               <Dialog.Panel
                 className={clsx(
-                  'w-full transform rounded-xl bg-white shadow-xl transition-all',
-                  'border border-surface-200',
+                  'w-full transform rounded-xl bg-white shadow-xl transition-all dark:bg-surface-900',
+                  'border border-surface-200 dark:border-surface-800',
                   sizeStyles[size]
                 )}
               >
                 {/* Header */}
                 {(title || showCloseButton) && (
-                  <div className="flex items-start justify-between p-4 border-b border-surface-200">
+                  <div className="flex items-start justify-between p-4 border-b border-surface-200 dark:border-surface-800">
                     <div>
                       {title && (
-                        <Dialog.Title as="h2" className="text-lg font-semibold text-surface-900">
+                        <Dialog.Title
+                          as="h2"
+                          className="text-lg font-semibold text-surface-900 dark:text-surface-100"
+                        >
                           {title}
                         </Dialog.Title>
                       )}
                       {description && (
-                        <Dialog.Description className="mt-1 text-sm text-surface-600">
+                        <Dialog.Description className="mt-1 text-sm text-surface-600 dark:text-surface-400">
                           {description}
                         </Dialog.Description>
                       )}
@@ -139,9 +142,9 @@ export function Modal({
                         type="button"
                         onClick={onClose}
                         className={clsx(
-                          'rounded-lg p-1.5 text-surface-600',
-                          'hover:bg-surface-200 hover:text-surface-800',
-                          'focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-surface-800',
+                          'rounded-lg p-1.5 text-surface-600 dark:text-surface-400',
+                          'hover:bg-surface-200 hover:text-surface-800 dark:hover:bg-surface-800 dark:hover:text-surface-200',
+                          'focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 focus:ring-offset-surface-50 dark:focus:ring-offset-surface-950',
                           'transition-colors'
                         )}
                         aria-label="Close modal"
@@ -171,7 +174,7 @@ export function ModalFooter({ children, className }: { children: ReactNode; clas
   return (
     <div
       className={clsx(
-        'flex items-center justify-end gap-3 pt-4 mt-4 border-t border-surface-200',
+        'flex items-center justify-end gap-3 pt-4 mt-4 border-t border-surface-200 dark:border-surface-800',
         className
       )}
     >

--- a/frontend/src/components/ui/PageHeader.tsx
+++ b/frontend/src/components/ui/PageHeader.tsx
@@ -19,11 +19,13 @@ export function PageHeader({ title, description, actions, meta, className }: Pag
     >
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-3 flex-wrap">
-          <h1 className="text-h1 text-surface-900">{title}</h1>
+          <h1 className="text-h1 text-surface-900 dark:text-surface-100">{title}</h1>
           {meta}
         </div>
         {description && (
-          <p className="text-small text-surface-600 mt-1.5 max-w-3xl">{description}</p>
+          <p className="text-small text-surface-600 dark:text-surface-400 mt-1.5 max-w-3xl">
+            {description}
+          </p>
         )}
       </div>
       {actions && <div className="flex items-center gap-2 shrink-0">{actions}</div>}

--- a/frontend/src/components/ui/Select.tsx
+++ b/frontend/src/components/ui/Select.tsx
@@ -57,10 +57,12 @@ export function Select({
   }, [options, query, searchable]);
 
   const triggerBase = cn(
-    'relative w-full rounded-md border bg-white pl-3 pr-9 text-left text-surface-900 transition-colors',
-    'focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-1 focus-visible:ring-offset-surface-50',
+    'relative w-full rounded-md border bg-white pl-3 pr-9 text-left text-surface-900 transition-colors dark:bg-surface-900 dark:text-surface-100',
+    'focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-1 focus-visible:ring-offset-surface-50 dark:focus-visible:ring-offset-surface-950',
     'disabled:opacity-50 disabled:cursor-not-allowed',
-    invalid ? 'border-red-500/60' : 'border-surface-300 hover:border-surface-400',
+    invalid
+      ? 'border-red-500/60 dark:border-red-500/70'
+      : 'border-surface-300 hover:border-surface-400 dark:border-surface-700 dark:hover:border-surface-600',
     sizes[size],
     fullWidth ? 'w-full' : 'w-auto',
     className
@@ -72,20 +74,20 @@ export function Select({
         <div className={cn('relative', !fullWidth && 'inline-block')}>
           <div className={cn(triggerBase, 'flex items-center')}>
             <Combobox.Input
-              className="w-full bg-transparent border-0 p-0 text-body text-surface-900 placeholder:text-surface-600 focus:outline-none focus:ring-0"
+              className="w-full bg-transparent border-0 p-0 text-body text-surface-900 placeholder:text-surface-600 focus:outline-none focus:ring-0 dark:text-surface-100 dark:placeholder:text-surface-500"
               displayValue={(v: string) => options.find((o) => o.value === v)?.label ?? ''}
               onChange={(e) => setQuery(e.target.value)}
               placeholder={placeholder}
             />
             <Combobox.Button className="absolute inset-y-0 right-0 flex items-center pr-2">
-              <ChevronDown className="h-4 w-4 text-surface-500" />
+              <ChevronDown className="h-4 w-4 text-surface-500 dark:text-surface-400" />
             </Combobox.Button>
           </div>
           {clearable && value && (
             <button
               type="button"
               onClick={() => onChange('')}
-              className="absolute inset-y-0 right-7 z-10 flex items-center text-surface-500 hover:text-surface-700"
+              className="absolute inset-y-0 right-7 z-10 flex items-center text-surface-500 hover:text-surface-700 dark:text-surface-400 dark:hover:text-surface-200"
               aria-label="Clear selection"
             >
               <X className="h-3.5 w-3.5" />
@@ -98,9 +100,11 @@ export function Select({
             leaveTo="opacity-0"
             afterLeave={() => setQuery('')}
           >
-            <Combobox.Options className="absolute z-50 mt-1 max-h-72 min-w-full w-max max-w-sm overflow-auto rounded-md border border-surface-300 bg-white py-1 shadow-xl ring-1 ring-black/5 focus:outline-none">
+            <Combobox.Options className="absolute z-50 mt-1 max-h-72 min-w-full w-max max-w-sm overflow-auto rounded-md border border-surface-300 bg-white py-1 shadow-xl ring-1 ring-black/5 focus:outline-none dark:bg-surface-900 dark:border-surface-700 dark:ring-white/5">
               {filteredOptions.length === 0 ? (
-                <div className="px-3 py-2 text-small text-surface-500">No results</div>
+                <div className="px-3 py-2 text-small text-surface-500 dark:text-surface-400">
+                  No results
+                </div>
               ) : (
                 filteredOptions.map((opt) => (
                   <Combobox.Option
@@ -110,8 +114,10 @@ export function Select({
                     className={({ active, selected }) =>
                       cn(
                         'relative cursor-pointer select-none px-3 py-1.5 text-body',
-                        active && 'bg-surface-100',
-                        selected ? 'text-brand-700' : 'text-surface-900',
+                        active && 'bg-surface-100 dark:bg-surface-800',
+                        selected
+                          ? 'text-brand-700 dark:text-brand-300'
+                          : 'text-surface-900 dark:text-surface-100',
                         opt.disabled && 'opacity-50 cursor-not-allowed'
                       )
                     }
@@ -121,12 +127,14 @@ export function Select({
                         <div className="min-w-0 flex-1">
                           <div className="truncate">{opt.label}</div>
                           {opt.description && (
-                            <div className="text-xs text-surface-500 truncate">
+                            <div className="text-xs text-surface-500 dark:text-surface-400 truncate">
                               {opt.description}
                             </div>
                           )}
                         </div>
-                        {selected && <Check className="h-4 w-4 shrink-0 text-brand-700 mt-0.5" />}
+                        {selected && (
+                          <Check className="h-4 w-4 shrink-0 text-brand-700 dark:text-brand-300 mt-0.5" />
+                        )}
                       </div>
                     )}
                   </Combobox.Option>
@@ -143,7 +151,12 @@ export function Select({
     <Listbox value={value} onChange={onChange} disabled={disabled}>
       <div className={cn('relative', !fullWidth && 'inline-block')}>
         <Listbox.Button className={triggerBase}>
-          <span className={cn('block truncate', !selectedOption && 'text-surface-500')}>
+          <span
+            className={cn(
+              'block truncate',
+              !selectedOption && 'text-surface-500 dark:text-surface-400'
+            )}
+          >
             {selectedOption?.label ?? placeholder}
           </span>
           <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
@@ -169,7 +182,7 @@ export function Select({
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <Listbox.Options className="absolute z-50 mt-1 max-h-72 min-w-full w-max max-w-sm overflow-auto rounded-md border border-surface-300 bg-white py-1 shadow-xl ring-1 ring-black/5 focus:outline-none">
+          <Listbox.Options className="absolute z-50 mt-1 max-h-72 min-w-full w-max max-w-sm overflow-auto rounded-md border border-surface-300 bg-white py-1 shadow-xl ring-1 ring-black/5 focus:outline-none dark:bg-surface-900 dark:border-surface-700 dark:ring-white/5">
             {options.map((opt) => (
               <Listbox.Option
                 key={opt.value}
@@ -178,8 +191,10 @@ export function Select({
                 className={({ active, selected }) =>
                   cn(
                     'relative cursor-pointer select-none px-3 py-1.5 text-body',
-                    active && 'bg-surface-100',
-                    selected ? 'text-brand-700' : 'text-surface-900',
+                    active && 'bg-surface-100 dark:bg-surface-800',
+                    selected
+                      ? 'text-brand-700 dark:text-brand-300'
+                      : 'text-surface-900 dark:text-surface-100',
                     opt.disabled && 'opacity-50 cursor-not-allowed'
                   )
                 }
@@ -189,10 +204,14 @@ export function Select({
                     <div className="min-w-0 flex-1">
                       <div className="truncate">{opt.label}</div>
                       {opt.description && (
-                        <div className="text-xs text-surface-500 truncate">{opt.description}</div>
+                        <div className="text-xs text-surface-500 dark:text-surface-400 truncate">
+                          {opt.description}
+                        </div>
                       )}
                     </div>
-                    {selected && <Check className="h-4 w-4 shrink-0 text-brand-700 mt-0.5" />}
+                    {selected && (
+                      <Check className="h-4 w-4 shrink-0 text-brand-700 dark:text-brand-300 mt-0.5" />
+                    )}
                   </div>
                 )}
               </Listbox.Option>

--- a/frontend/src/components/ui/SelectNative.tsx
+++ b/frontend/src/components/ui/SelectNative.tsx
@@ -29,14 +29,18 @@ export const SelectNative = forwardRef<HTMLSelectElement, SelectNativeProps>(
     <select
       ref={ref}
       className={cn(
-        'w-full rounded-md border bg-white px-3 pr-9 text-surface-900 transition-colors appearance-none',
+        'w-full rounded-md border bg-white px-3 pr-9 text-surface-900 transition-colors appearance-none dark:bg-surface-900 dark:text-surface-100',
         'bg-no-repeat bg-right',
-        // Inline SVG chevron for the dropdown arrow
+        // Inline SVG chevron for the dropdown arrow (light mode)
         'bg-[url("data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20viewBox=%270%200%2024%2024%27%20fill=%27none%27%20stroke=%27%235e5d5a%27%20stroke-width=%272%27%3E%3Cpolyline%20points=%276%209%2012%2015%2018%209%27/%3E%3C/svg%3E")]',
+        // Chevron color for dark mode (lighter stroke)
+        'dark:bg-[url("data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20viewBox=%270%200%2024%2024%27%20fill=%27none%27%20stroke=%27%238a8884%27%20stroke-width=%272%27%3E%3Cpolyline%20points=%276%209%2012%2015%2018%209%27/%3E%3C/svg%3E")]',
         '[background-position:right_0.65rem_center] [background-size:1rem]',
-        'focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-1 focus-visible:ring-offset-surface-50',
+        'focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-1 focus-visible:ring-offset-surface-50 dark:focus-visible:ring-offset-surface-950',
         'disabled:opacity-50 disabled:cursor-not-allowed',
-        invalid ? 'border-red-500/60' : 'border-surface-300 hover:border-surface-400',
+        invalid
+          ? 'border-red-500/60 dark:border-red-500/70'
+          : 'border-surface-300 hover:border-surface-400 dark:border-surface-700 dark:hover:border-surface-600',
         sizes[selectSize],
         className
       )}

--- a/frontend/src/components/ui/StatCard.tsx
+++ b/frontend/src/components/ui/StatCard.tsx
@@ -19,35 +19,35 @@ const toneStyles: Record<
   { iconBg: string; spark: { stroke: string; fill: string } }
 > = {
   brand: {
-    iconBg: 'bg-brand-500/10 text-brand-700',
+    iconBg: 'bg-brand-500/10 text-brand-700 dark:bg-brand-500/20 dark:text-brand-300',
     spark: { stroke: 'rgb(16 185 129)', fill: 'rgba(16, 185, 129, 0.15)' },
   },
   accent: {
-    iconBg: 'bg-accent-500/10 text-accent-700',
+    iconBg: 'bg-accent-500/10 text-accent-700 dark:bg-accent-500/20 dark:text-accent-300',
     spark: { stroke: 'rgb(129 140 248)', fill: 'rgba(129, 140, 248, 0.15)' },
   },
   emerald: {
-    iconBg: 'bg-emerald-500/10 text-emerald-600',
+    iconBg: 'bg-emerald-500/10 text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-300',
     spark: { stroke: 'rgb(52 211 153)', fill: 'rgba(52, 211, 153, 0.15)' },
   },
   red: {
-    iconBg: 'bg-red-500/10 text-red-600',
+    iconBg: 'bg-red-500/10 text-red-600 dark:bg-red-500/20 dark:text-red-300',
     spark: { stroke: 'rgb(248 113 113)', fill: 'rgba(248, 113, 113, 0.15)' },
   },
   amber: {
-    iconBg: 'bg-amber-500/10 text-amber-700',
+    iconBg: 'bg-amber-500/10 text-amber-700 dark:bg-amber-500/20 dark:text-amber-300',
     spark: { stroke: 'rgb(251 191 36)', fill: 'rgba(251, 191, 36, 0.15)' },
   },
   blue: {
-    iconBg: 'bg-blue-500/10 text-blue-600',
+    iconBg: 'bg-blue-500/10 text-blue-600 dark:bg-blue-500/20 dark:text-blue-300',
     spark: { stroke: 'rgb(96 165 250)', fill: 'rgba(96, 165, 250, 0.15)' },
   },
   purple: {
-    iconBg: 'bg-purple-500/10 text-purple-600',
+    iconBg: 'bg-purple-500/10 text-purple-600 dark:bg-purple-500/20 dark:text-purple-300',
     spark: { stroke: 'rgb(196 181 253)', fill: 'rgba(196, 181, 253, 0.15)' },
   },
   neutral: {
-    iconBg: 'bg-surface-100 text-surface-700',
+    iconBg: 'bg-surface-100 text-surface-700 dark:bg-surface-800 dark:text-surface-300',
     spark: { stroke: 'rgb(154 160 180)', fill: 'rgba(154, 160, 180, 0.12)' },
   },
 };
@@ -88,7 +88,11 @@ export function StatCard({
   const deltaZero = (delta ?? 0) === 0;
   const deltaGood = deltaZero ? null : deltaPositiveIsGood ? deltaPositive : !deltaPositive;
   const deltaColor =
-    deltaGood === null ? 'text-surface-500' : deltaGood ? 'text-emerald-600' : 'text-red-600';
+    deltaGood === null
+      ? 'text-surface-500 dark:text-surface-400'
+      : deltaGood
+        ? 'text-emerald-600 dark:text-emerald-400'
+        : 'text-red-600 dark:text-red-400';
 
   return (
     <Card
@@ -99,9 +103,15 @@ export function StatCard({
       <CardBody density="comfy">
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0 flex-1">
-            <p className="text-xs text-surface-500 uppercase tracking-wider font-medium">{label}</p>
-            <p className="text-display text-surface-900 mt-1 tabular-nums">{value}</p>
-            {caption && <p className="text-xs text-surface-500 mt-0.5">{caption}</p>}
+            <p className="text-xs text-surface-500 dark:text-surface-400 uppercase tracking-wider font-medium">
+              {label}
+            </p>
+            <p className="text-display text-surface-900 dark:text-surface-100 mt-1 tabular-nums">
+              {value}
+            </p>
+            {caption && (
+              <p className="text-xs text-surface-500 dark:text-surface-400 mt-0.5">{caption}</p>
+            )}
             {delta !== undefined && (
               <div className={cn('flex items-center gap-1 mt-1.5 text-xs font-medium', deltaColor)}>
                 {deltaZero ? (
@@ -112,7 +122,9 @@ export function StatCard({
                   <ArrowDown className="h-3 w-3" />
                 )}
                 <span>{deltaZero ? '0' : `${deltaPositive ? '+' : ''}${delta}`}%</span>
-                <span className="text-surface-500 font-normal">vs last period</span>
+                <span className="text-surface-500 dark:text-surface-400 font-normal">
+                  vs last period
+                </span>
               </div>
             )}
           </div>

--- a/frontend/src/components/ui/Tabs.tsx
+++ b/frontend/src/components/ui/Tabs.tsx
@@ -12,7 +12,12 @@ export interface TabsProps {
 export function Tabs({ tabs, defaultIndex, onChange, className }: TabsProps) {
   return (
     <Tab.Group defaultIndex={defaultIndex} onChange={onChange}>
-      <Tab.List className={cn('flex items-center gap-1 border-b border-surface-200', className)}>
+      <Tab.List
+        className={cn(
+          'flex items-center gap-1 border-b border-surface-200 dark:border-surface-800',
+          className
+        )}
+      >
         {tabs.map((tab, i) => (
           <Tab
             key={i}
@@ -21,8 +26,8 @@ export function Tabs({ tabs, defaultIndex, onChange, className }: TabsProps) {
               cn(
                 'relative px-3 py-2 text-small font-medium transition-colors -mb-px border-b-2 outline-none',
                 selected
-                  ? 'border-brand-500 text-surface-900'
-                  : 'border-transparent text-surface-600 hover:text-surface-900',
+                  ? 'border-brand-500 text-surface-900 dark:text-surface-100'
+                  : 'border-transparent text-surface-600 hover:text-surface-900 dark:text-surface-400 dark:hover:text-surface-100',
                 'focus-visible:ring-2 focus-visible:ring-brand-500 rounded-t-md',
                 tab.disabled && 'opacity-50 cursor-not-allowed'
               )

--- a/frontend/src/components/ui/Textarea.tsx
+++ b/frontend/src/components/ui/Textarea.tsx
@@ -10,10 +10,12 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
     <textarea
       ref={ref}
       className={cn(
-        'w-full rounded-md border bg-white px-3 py-2 text-body text-surface-900 placeholder:text-surface-600 transition-colors',
-        'focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-1 focus-visible:ring-offset-surface-50',
+        'w-full rounded-md border bg-white px-3 py-2 text-body text-surface-900 placeholder:text-surface-600 transition-colors dark:bg-surface-900 dark:text-surface-100 dark:placeholder:text-surface-500',
+        'focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-1 focus-visible:ring-offset-surface-50 dark:focus-visible:ring-offset-surface-950',
         'disabled:opacity-50 disabled:cursor-not-allowed',
-        invalid ? 'border-red-500/60' : 'border-surface-300 hover:border-surface-400',
+        invalid
+          ? 'border-red-500/60 dark:border-red-500/70'
+          : 'border-surface-300 hover:border-surface-400 dark:border-surface-700 dark:hover:border-surface-600',
         'min-h-[80px] resize-y',
         className
       )}

--- a/frontend/src/components/ui/Tooltip.tsx
+++ b/frontend/src/components/ui/Tooltip.tsx
@@ -51,7 +51,7 @@ export function Tooltip({ content, children, side = 'top', delay = 200, classNam
           id={id}
           role="tooltip"
           className={cn(
-            'absolute z-50 pointer-events-none whitespace-nowrap rounded-md bg-surface-100 px-2 py-1 text-xs text-surface-900 shadow-lg border border-surface-300 animate-fade-in',
+            'absolute z-50 pointer-events-none whitespace-nowrap rounded-md bg-surface-900 px-2 py-1 text-xs text-surface-50 shadow-lg border border-surface-800 animate-fade-in dark:bg-surface-100 dark:text-surface-900 dark:border-surface-300',
             sidePos[side],
             className
           )}

--- a/frontend/src/components/vendor/SOC2AnalysisPanel.tsx
+++ b/frontend/src/components/vendor/SOC2AnalysisPanel.tsx
@@ -80,17 +80,17 @@ export function SOC2AnalysisPanel({
 
   if (!analysis) {
     return (
-      <div className="bg-surface-800/50 border border-surface-700 rounded-lg p-6">
+      <div className="bg-white/50 border border-surface-200 rounded-lg p-6">
         <div className="flex items-center gap-3 mb-4">
           <SparklesIcon className="w-6 h-6 text-purple-600" />
           <div>
-            <h3 className="font-semibold text-surface-100">AI-Powered SOC 2 Analysis</h3>
+            <h3 className="font-semibold text-surface-900">AI-Powered SOC 2 Analysis</h3>
             <p className="text-sm text-surface-600">
               Analyze this SOC 2 report to extract exceptions, CUECs, and findings
             </p>
           </div>
         </div>
-        <div className="bg-surface-900/50 rounded-lg p-4 mb-4">
+        <div className="bg-white/50 rounded-lg p-4 mb-4">
           <p className="text-sm text-surface-700 mb-3">AI analysis will extract:</p>
           <ul className="text-sm text-surface-600 space-y-2">
             <li className="flex items-center gap-2">
@@ -136,14 +136,14 @@ export function SOC2AnalysisPanel({
   return (
     <div className="space-y-4">
       {/* Analysis Header */}
-      <div className="bg-surface-800/50 border border-surface-700 rounded-lg p-4">
+      <div className="bg-white/50 border border-surface-200 rounded-lg p-4">
         <div className="flex items-start justify-between">
           <div className="flex items-center gap-3">
             <div className="p-2 bg-purple-500/20 rounded-lg">
               <SparklesIcon className="w-5 h-5 text-purple-600" />
             </div>
             <div>
-              <h3 className="font-semibold text-surface-100">AI Analysis Results</h3>
+              <h3 className="font-semibold text-surface-900">AI Analysis Results</h3>
               <p className="text-xs text-surface-600">
                 Analyzed: {new Date(analysis.analyzedAt).toLocaleDateString()}
               </p>
@@ -166,13 +166,13 @@ export function SOC2AnalysisPanel({
         </div>
 
         {/* Summary */}
-        <div className="mt-4 p-3 bg-surface-900/50 rounded-lg">
+        <div className="mt-4 p-3 bg-white/50 rounded-lg">
           <p className="text-sm text-surface-700">{analysis.summary}</p>
         </div>
 
         {/* Key Stats */}
         <div className="grid grid-cols-4 gap-3 mt-4">
-          <div className="text-center p-2 bg-surface-900/50 rounded-lg">
+          <div className="text-center p-2 bg-white/50 rounded-lg">
             <p
               className={clsx('text-xl font-bold', RISK_SCORE_COLORS[analysis.suggestedRiskScore])}
             >
@@ -181,7 +181,7 @@ export function SOC2AnalysisPanel({
             </p>
             <p className="text-xs text-surface-600">Risk Score</p>
           </div>
-          <div className="text-center p-2 bg-surface-900/50 rounded-lg">
+          <div className="text-center p-2 bg-white/50 rounded-lg">
             <p
               className={clsx(
                 'text-xl font-bold',
@@ -192,11 +192,11 @@ export function SOC2AnalysisPanel({
             </p>
             <p className="text-xs text-surface-600">Exceptions</p>
           </div>
-          <div className="text-center p-2 bg-surface-900/50 rounded-lg">
+          <div className="text-center p-2 bg-white/50 rounded-lg">
             <p className="text-xl font-bold text-yellow-600">{analysis.cuecs.length}</p>
             <p className="text-xs text-surface-600">CUECs</p>
           </div>
-          <div className="text-center p-2 bg-surface-900/50 rounded-lg">
+          <div className="text-center p-2 bg-white/50 rounded-lg">
             <p className="text-xl font-bold text-blue-600">{analysis.controlGaps.length}</p>
             <p className="text-xs text-surface-600">Gaps</p>
           </div>
@@ -208,7 +208,7 @@ export function SOC2AnalysisPanel({
             {analysis.reportPeriod && (
               <div>
                 <p className="text-surface-600 text-xs">Report Period</p>
-                <p className="text-surface-200">
+                <p className="text-surface-800">
                   {analysis.reportPeriod.startDate} to {analysis.reportPeriod.endDate}
                 </p>
               </div>
@@ -216,7 +216,7 @@ export function SOC2AnalysisPanel({
             {analysis.auditor && (
               <div>
                 <p className="text-surface-600 text-xs">Auditor</p>
-                <p className="text-surface-200">{analysis.auditor}</p>
+                <p className="text-surface-800">{analysis.auditor}</p>
               </div>
             )}
             {analysis.opinionType && (
@@ -309,8 +309,8 @@ export function SOC2AnalysisPanel({
         >
           <div className="space-y-2">
             {analysis.subserviceOrganizations.map((org, idx) => (
-              <div key={idx} className="p-3 bg-surface-900/50 rounded-lg">
-                <p className="font-medium text-surface-100">{org.name}</p>
+              <div key={idx} className="p-3 bg-white/50 rounded-lg">
+                <p className="font-medium text-surface-900">{org.name}</p>
                 <p className="text-sm text-surface-600 mt-1">{org.services}</p>
                 <p className="text-xs text-surface-500 mt-1">
                   Method: {org.carveOutOrInclusiveMethod.replace('_', ' ')}
@@ -356,14 +356,14 @@ function CollapsibleSection({
   children,
 }: CollapsibleSectionProps) {
   return (
-    <div className="bg-surface-800/50 border border-surface-700 rounded-lg overflow-hidden">
+    <div className="bg-white/50 border border-surface-200 rounded-lg overflow-hidden">
       <button
         onClick={onToggle}
-        className="w-full flex items-center justify-between p-4 hover:bg-surface-700/50 transition-colors"
+        className="w-full flex items-center justify-between p-4 hover:bg-surface-200/50 transition-colors"
       >
         <div className="flex items-center gap-3">
           <Icon className={clsx('w-5 h-5', iconColor)} />
-          <span className="font-medium text-surface-100">{title}</span>
+          <span className="font-medium text-surface-900">{title}</span>
           <span className="text-sm text-surface-600">({count})</span>
         </div>
         {expanded ? (
@@ -396,9 +396,9 @@ function ExceptionCard({ exception }: { exception: SOC2Exception }) {
           {exception.severity}
         </span>
       </div>
-      <p className="text-sm text-surface-200 mt-2">{exception.description}</p>
+      <p className="text-sm text-surface-800 mt-2">{exception.description}</p>
       {exception.managementResponse && (
-        <div className="mt-2 pt-2 border-t border-surface-600/50">
+        <div className="mt-2 pt-2 border-t border-surface-300/50">
           <p className="text-xs text-surface-600">Management Response:</p>
           <p className="text-xs text-surface-700 mt-1">{exception.managementResponse}</p>
         </div>
@@ -416,9 +416,9 @@ function CUECCard({ cuec }: { cuec: CUEC }) {
   };
 
   return (
-    <div className="p-3 bg-surface-900/50 rounded-lg">
+    <div className="p-3 bg-white/50 rounded-lg">
       <div className="flex items-start justify-between">
-        <p className="text-sm text-surface-200 flex-1">{cuec.description}</p>
+        <p className="text-sm text-surface-800 flex-1">{cuec.description}</p>
         <span
           className={clsx(
             'text-xs px-2 py-0.5 rounded ml-2 whitespace-nowrap',
@@ -442,15 +442,15 @@ function GapCard({ gap }: { gap: ControlGap }) {
   };
 
   return (
-    <div className="p-3 bg-surface-900/50 rounded-lg">
+    <div className="p-3 bg-white/50 rounded-lg">
       <div className="flex items-center justify-between mb-2">
-        <span className="font-medium text-surface-100">{gap.area}</span>
+        <span className="font-medium text-surface-900">{gap.area}</span>
         <span className={clsx('text-xs capitalize', priorityColors[gap.priority])}>
           {gap.priority} priority
         </span>
       </div>
       <p className="text-sm text-surface-700">{gap.description}</p>
-      <div className="mt-2 pt-2 border-t border-surface-700">
+      <div className="mt-2 pt-2 border-t border-surface-200">
         <p className="text-xs text-surface-600">Recommendation:</p>
         <p className="text-xs text-surface-700 mt-1">{gap.recommendation}</p>
       </div>

--- a/frontend/src/components/vendor/VendorReviewsDueWidget.tsx
+++ b/frontend/src/components/vendor/VendorReviewsDueWidget.tsx
@@ -41,11 +41,11 @@ export function VendorReviewsDueWidget({ className }: VendorReviewsDueWidgetProp
     return (
       <div className={clsx('card p-6', className)}>
         <div className="animate-pulse space-y-4">
-          <div className="h-6 bg-surface-700 rounded w-1/3"></div>
+          <div className="h-6 bg-surface-200 rounded w-1/3"></div>
           <div className="space-y-3">
-            <div className="h-12 bg-surface-700 rounded"></div>
-            <div className="h-12 bg-surface-700 rounded"></div>
-            <div className="h-12 bg-surface-700 rounded"></div>
+            <div className="h-12 bg-surface-200 rounded"></div>
+            <div className="h-12 bg-surface-200 rounded"></div>
+            <div className="h-12 bg-surface-200 rounded"></div>
           </div>
         </div>
       </div>
@@ -79,7 +79,7 @@ export function VendorReviewsDueWidget({ className }: VendorReviewsDueWidgetProp
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2">
           <CalendarDaysIcon className="w-5 h-5 text-brand-400" />
-          <h2 className="text-lg font-semibold text-surface-100">Vendor Reviews Due</h2>
+          <h2 className="text-lg font-semibold text-surface-900">Vendor Reviews Due</h2>
         </div>
         <Link
           to="/vendors"
@@ -94,7 +94,7 @@ export function VendorReviewsDueWidget({ className }: VendorReviewsDueWidgetProp
         <div
           className={clsx(
             'p-3 rounded-lg text-center',
-            summary.overdueCount > 0 ? 'bg-red-500/10 border border-red-500/30' : 'bg-surface-800'
+            summary.overdueCount > 0 ? 'bg-red-500/10 border border-red-500/30' : 'bg-white'
           )}
         >
           <p
@@ -112,7 +112,7 @@ export function VendorReviewsDueWidget({ className }: VendorReviewsDueWidgetProp
             'p-3 rounded-lg text-center',
             summary.dueThisWeekCount > 0
               ? 'bg-orange-500/10 border border-orange-500/30'
-              : 'bg-surface-800'
+              : 'bg-white'
           )}
         >
           <p
@@ -130,7 +130,7 @@ export function VendorReviewsDueWidget({ className }: VendorReviewsDueWidgetProp
             'p-3 rounded-lg text-center',
             summary.dueThisMonthCount > 0
               ? 'bg-yellow-500/10 border border-yellow-500/30'
-              : 'bg-surface-800'
+              : 'bg-white'
           )}
         >
           <p
@@ -188,7 +188,7 @@ export function VendorReviewsDueWidget({ className }: VendorReviewsDueWidgetProp
 
       {/* Footer */}
       {summary.upcomingCount > 0 && (
-        <div className="mt-4 pt-3 border-t border-surface-700 text-center">
+        <div className="mt-4 pt-3 border-t border-surface-200 text-center">
           <p className="text-xs text-surface-600">
             {summary.upcomingCount} reviews scheduled in the next 90 days
           </p>
@@ -222,19 +222,19 @@ function ReviewItem({ vendor, status, statusText }: ReviewItemProps) {
   return (
     <Link
       to={`/vendors/${vendor.id}`}
-      className="flex items-center justify-between p-3 bg-surface-800/50 hover:bg-surface-700 rounded-lg transition-colors group"
+      className="flex items-center justify-between p-3 bg-white/50 hover:bg-surface-200 rounded-lg transition-colors group"
     >
       <div className="flex items-center gap-3 min-w-0">
         <Icon className={clsx('w-4 h-4 flex-shrink-0', statusColors[status])} />
         <div className="min-w-0">
-          <p className="text-sm font-medium text-surface-100 truncate group-hover:text-brand-400 transition-colors">
+          <p className="text-sm font-medium text-surface-900 truncate group-hover:text-brand-400 transition-colors">
             {vendor.name}
           </p>
           <div className="flex items-center gap-2 mt-0.5">
             <span
               className={clsx(
                 'text-xs px-1.5 py-0.5 rounded',
-                TIER_COLORS[vendor.tier] || 'bg-surface-700 text-surface-600'
+                TIER_COLORS[vendor.tier] || 'bg-surface-200 text-surface-600'
               )}
             >
               {TIER_LABELS[vendor.tier] || vendor.tier}

--- a/frontend/src/components/vendor/VendorRiskAssessmentPanel.tsx
+++ b/frontend/src/components/vendor/VendorRiskAssessmentPanel.tsx
@@ -77,7 +77,7 @@ function ScoreBar({
   return (
     <div className="flex items-center gap-3">
       <span className="text-sm text-surface-600 w-24">{label}</span>
-      <div className="flex-1 h-2 bg-surface-800 rounded-full overflow-hidden">
+      <div className="flex-1 h-2 bg-white rounded-full overflow-hidden">
         <div className={clsx('h-full transition-all', color)} style={{ width: `${percentage}%` }} />
       </div>
       <span className="text-sm font-medium text-surface-700 w-12 text-right">
@@ -174,10 +174,10 @@ export function VendorRiskAssessmentPanel({
 
   if (loading) {
     return (
-      <div className="bg-surface-900 border border-surface-800 rounded-lg p-6">
+      <div className="bg-white border border-surface-200 rounded-lg p-6">
         <div className="flex items-center gap-3 mb-4">
           <ShieldExclamationIcon className="w-5 h-5 text-brand-400" />
-          <h3 className="text-lg font-medium text-surface-100">Risk Assessment</h3>
+          <h3 className="text-lg font-medium text-surface-900">Risk Assessment</h3>
         </div>
         <div className="flex items-center justify-center py-8">
           <ArrowPathIcon className="w-6 h-6 text-surface-600 animate-spin" />
@@ -189,10 +189,10 @@ export function VendorRiskAssessmentPanel({
 
   if (error) {
     return (
-      <div className="bg-surface-900 border border-surface-800 rounded-lg p-6">
+      <div className="bg-white border border-surface-200 rounded-lg p-6">
         <div className="flex items-center gap-3 mb-4">
           <ShieldExclamationIcon className="w-5 h-5 text-brand-400" />
-          <h3 className="text-lg font-medium text-surface-100">Risk Assessment</h3>
+          <h3 className="text-lg font-medium text-surface-900">Risk Assessment</h3>
         </div>
         <div className="text-center py-6">
           <ExclamationTriangleIcon className="w-10 h-10 mx-auto mb-2 text-red-600" />
@@ -207,11 +207,11 @@ export function VendorRiskAssessmentPanel({
 
   if (!latestAssessment) {
     return (
-      <div className="bg-surface-900 border border-surface-800 rounded-lg p-6">
+      <div className="bg-white border border-surface-200 rounded-lg p-6">
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center gap-3">
             <ShieldExclamationIcon className="w-5 h-5 text-brand-400" />
-            <h3 className="text-lg font-medium text-surface-100">Risk Assessment</h3>
+            <h3 className="text-lg font-medium text-surface-900">Risk Assessment</h3>
           </div>
         </div>
         <div className="text-center py-8">
@@ -232,12 +232,12 @@ export function VendorRiskAssessmentPanel({
   }
 
   return (
-    <div className="bg-surface-900 border border-surface-800 rounded-lg p-6">
+    <div className="bg-white border border-surface-200 rounded-lg p-6">
       {/* Header */}
       <div className="flex items-center justify-between mb-6">
         <div className="flex items-center gap-3">
           <ShieldExclamationIcon className="w-5 h-5 text-brand-400" />
-          <h3 className="text-lg font-medium text-surface-100">Risk Assessment</h3>
+          <h3 className="text-lg font-medium text-surface-900">Risk Assessment</h3>
         </div>
         <Button variant="outline" size="sm" onClick={onStartAssessment}>
           New Assessment
@@ -260,12 +260,12 @@ export function VendorRiskAssessmentPanel({
         <div className="flex items-start justify-between">
           <div>
             <div className="flex items-center gap-3 mb-2">
-              <span className="text-3xl font-bold text-surface-100">
+              <span className="text-3xl font-bold text-surface-900">
                 {latestAssessment.totalScore}
               </span>
               <RiskBadge level={latestAssessment.riskLevel} />
             </div>
-            <h4 className="font-medium text-surface-200 mb-1">{latestAssessment.title}</h4>
+            <h4 className="font-medium text-surface-800 mb-1">{latestAssessment.title}</h4>
             {latestAssessment.description && (
               <p className="text-sm text-surface-600 mb-2">{latestAssessment.description}</p>
             )}
@@ -319,11 +319,11 @@ export function VendorRiskAssessmentPanel({
       </div>
 
       {/* Recommended Action */}
-      <div className="p-3 bg-surface-800/50 rounded-lg mb-6">
+      <div className="p-3 bg-white/50 rounded-lg mb-6">
         <div className="flex items-start gap-2">
           <CheckCircleIcon className="w-5 h-5 text-brand-400 mt-0.5 flex-shrink-0" />
           <div>
-            <h5 className="text-sm font-medium text-surface-200">Recommended Action</h5>
+            <h5 className="text-sm font-medium text-surface-800">Recommended Action</h5>
             <p className="text-sm text-surface-600">{latestAssessment.recommendedAction}</p>
           </div>
         </div>
@@ -331,9 +331,9 @@ export function VendorRiskAssessmentPanel({
 
       {/* Details Grid */}
       <div className="grid grid-cols-2 gap-4 mb-6">
-        <div className="p-3 bg-surface-800/30 rounded-lg">
+        <div className="p-3 bg-white/30 rounded-lg">
           <h5 className="text-xs text-surface-500 uppercase tracking-wide mb-1">Likelihood</h5>
-          <p className="text-lg font-semibold text-surface-200">
+          <p className="text-lg font-semibold text-surface-800">
             {latestAssessment.likelihood.level}
           </p>
           <p className="text-xs text-surface-600">
@@ -342,16 +342,16 @@ export function VendorRiskAssessmentPanel({
             {latestAssessment.likelihood.controlStrength}
           </p>
         </div>
-        <div className="p-3 bg-surface-800/30 rounded-lg">
+        <div className="p-3 bg-white/30 rounded-lg">
           <h5 className="text-xs text-surface-500 uppercase tracking-wide mb-1">Impact</h5>
-          <p className="text-lg font-semibold text-surface-200">{latestAssessment.impact.level}</p>
+          <p className="text-lg font-semibold text-surface-800">{latestAssessment.impact.level}</p>
           <p className="text-xs text-surface-600">Total: {latestAssessment.impact.total} points</p>
         </div>
       </div>
 
       {/* Assessment History */}
       {history.length > 1 && (
-        <div className="border-t border-surface-800 pt-4">
+        <div className="border-t border-surface-200 pt-4">
           <button
             onClick={() => setShowHistory(!showHistory)}
             className="flex items-center justify-between w-full text-left"
@@ -371,7 +371,7 @@ export function VendorRiskAssessmentPanel({
               {history.slice(1).map((assessment) => (
                 <div
                   key={assessment.id}
-                  className="flex items-center justify-between p-3 bg-surface-800/30 rounded-lg"
+                  className="flex items-center justify-between p-3 bg-white/30 rounded-lg"
                 >
                   <div>
                     <p className="text-sm font-medium text-surface-700">{assessment.title}</p>

--- a/frontend/src/components/vendor/VendorRiskAssessmentWizard.tsx
+++ b/frontend/src/components/vendor/VendorRiskAssessmentWizard.tsx
@@ -193,7 +193,7 @@ function RadioOption({
         'w-full text-left p-3 rounded-lg border transition-colors',
         selected
           ? 'border-brand-500 bg-brand-500/10'
-          : 'border-surface-700 hover:border-surface-600 bg-surface-800/50'
+          : 'border-surface-200 hover:border-surface-300 bg-white/50'
       )}
     >
       <div className="flex items-start gap-3">
@@ -204,7 +204,7 @@ function RadioOption({
           )}
         />
         <div>
-          <p className={clsx('font-medium', selected ? 'text-surface-100' : 'text-surface-700')}>
+          <p className={clsx('font-medium', selected ? 'text-surface-900' : 'text-surface-700')}>
             {label}
             <span className="ml-2 text-xs text-surface-500">({value} pts)</span>
           </p>
@@ -228,7 +228,7 @@ function ScoreIndicator({
   return (
     <div className="flex items-center gap-2">
       <span className="text-sm text-surface-600 w-20">{label}</span>
-      <div className="flex-1 h-2 bg-surface-800 rounded-full overflow-hidden">
+      <div className="flex-1 h-2 bg-white rounded-full overflow-hidden">
         <div
           className={clsx(
             'h-full transition-all',
@@ -401,7 +401,7 @@ export function VendorRiskAssessmentWizard({
                 type="text"
                 value={state.title}
                 onChange={(e) => setState({ ...state, title: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               />
             </div>
             <div>
@@ -410,7 +410,7 @@ export function VendorRiskAssessmentWizard({
                 value={state.description}
                 onChange={(e) => setState({ ...state, description: e.target.value })}
                 rows={3}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
                 placeholder="Describe the risk scenario in 1-2 sentences..."
               />
             </div>
@@ -422,7 +422,7 @@ export function VendorRiskAssessmentWizard({
                 type="text"
                 value={state.assessor}
                 onChange={(e) => setState({ ...state, assessor: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               />
             </div>
           </div>
@@ -432,7 +432,7 @@ export function VendorRiskAssessmentWizard({
         return (
           <div className="space-y-6">
             <div>
-              <h4 className="font-medium text-surface-200 mb-3">
+              <h4 className="font-medium text-surface-800 mb-3">
                 What type of data does this vendor process?
               </h4>
               <div className="space-y-2">
@@ -449,7 +449,7 @@ export function VendorRiskAssessmentWizard({
               </div>
             </div>
             <div>
-              <h4 className="font-medium text-surface-200 mb-3">
+              <h4 className="font-medium text-surface-800 mb-3">
                 What is the vendor's role in your infrastructure?
               </h4>
               <div className="space-y-2">
@@ -472,7 +472,7 @@ export function VendorRiskAssessmentWizard({
         return (
           <div className="space-y-6">
             <div>
-              <h4 className="font-medium text-surface-200 mb-3">
+              <h4 className="font-medium text-surface-800 mb-3">
                 Who is the most likely threat actor?
               </h4>
               <div className="space-y-2">
@@ -489,7 +489,7 @@ export function VendorRiskAssessmentWizard({
               </div>
             </div>
             <div>
-              <h4 className="font-medium text-surface-200 mb-3">
+              <h4 className="font-medium text-surface-800 mb-3">
                 What is the primary threat objective?
               </h4>
               <div className="space-y-2">
@@ -512,7 +512,7 @@ export function VendorRiskAssessmentWizard({
         return (
           <div className="space-y-6">
             <div>
-              <h4 className="font-medium text-surface-200 mb-3">Threat Event Frequency</h4>
+              <h4 className="font-medium text-surface-800 mb-3">Threat Event Frequency</h4>
               <div className="space-y-2">
                 {LIKELIHOOD_FREQUENCY_OPTIONS.map((opt) => (
                   <RadioOption
@@ -527,7 +527,7 @@ export function VendorRiskAssessmentWizard({
               </div>
             </div>
             <div>
-              <h4 className="font-medium text-surface-200 mb-3">Threat Actor Capability</h4>
+              <h4 className="font-medium text-surface-800 mb-3">Threat Actor Capability</h4>
               <div className="space-y-2">
                 {LIKELIHOOD_CAPABILITY_OPTIONS.map((opt) => (
                   <RadioOption
@@ -542,7 +542,7 @@ export function VendorRiskAssessmentWizard({
               </div>
             </div>
             <div>
-              <h4 className="font-medium text-surface-200 mb-3">Control Strength</h4>
+              <h4 className="font-medium text-surface-800 mb-3">Control Strength</h4>
               <div className="space-y-2">
                 {LIKELIHOOD_CONTROL_OPTIONS.map((opt) => (
                   <RadioOption
@@ -564,7 +564,7 @@ export function VendorRiskAssessmentWizard({
           <div className="space-y-4">
             {Object.entries(IMPACT_OPTIONS).map(([key, options]) => (
               <div key={key}>
-                <h4 className="font-medium text-surface-200 mb-2 capitalize">{key} Impact</h4>
+                <h4 className="font-medium text-surface-800 mb-2 capitalize">{key} Impact</h4>
                 <SelectNative
                   value={
                     state[
@@ -579,7 +579,7 @@ export function VendorRiskAssessmentWizard({
                       ),
                     })
                   }
-                  className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                  className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
                 >
                   {options.map((opt) => (
                     <option key={opt.value} value={opt.value}>
@@ -631,8 +631,8 @@ export function VendorRiskAssessmentWizard({
               <ScoreIndicator score={impactScore} maxScore={25} label="Impact" />
             </div>
 
-            <div className="p-4 bg-surface-800/50 rounded-lg">
-              <h4 className="font-medium text-surface-200 mb-2">Recommended Action</h4>
+            <div className="p-4 bg-white/50 rounded-lg">
+              <h4 className="font-medium text-surface-800 mb-2">Recommended Action</h4>
               <p className="text-surface-600">
                 {riskLevel === 'Critical'
                   ? 'Immediate action required - escalate to leadership'
@@ -657,18 +657,18 @@ export function VendorRiskAssessmentWizard({
     <Dialog open onClose={onClose} size="xl">
       <div className="flex flex-col max-h-[80vh]">
         {/* Header */}
-        <div className="flex items-center justify-between p-4 border-b border-surface-800">
+        <div className="flex items-center justify-between p-4 border-b border-surface-200">
           <div className="flex items-center gap-3">
             <ShieldExclamationIcon className="w-6 h-6 text-brand-400" />
             <div>
-              <h2 className="text-lg font-semibold text-surface-100">Vendor Risk Assessment</h2>
+              <h2 className="text-lg font-semibold text-surface-900">Vendor Risk Assessment</h2>
               <p className="text-sm text-surface-600">{vendorName}</p>
             </div>
           </div>
         </div>
 
         {/* Progress */}
-        <div className="px-4 py-3 border-b border-surface-800 bg-surface-800/30">
+        <div className="px-4 py-3 border-b border-surface-200 bg-white/30">
           <div className="flex items-center gap-2">
             {steps.map((_, i) => (
               <div key={i} className="flex items-center">
@@ -679,14 +679,14 @@ export function VendorRiskAssessmentWizard({
                       ? 'bg-brand-500 text-white'
                       : i === step
                         ? 'bg-brand-500/20 text-brand-400 border border-brand-500'
-                        : 'bg-surface-800 text-surface-500'
+                        : 'bg-white text-surface-500'
                   )}
                 >
                   {i < step ? <CheckCircleIcon className="w-5 h-5" /> : i + 1}
                 </div>
                 {i < steps.length - 1 && (
                   <div
-                    className={clsx('w-8 h-0.5 mx-1', i < step ? 'bg-brand-500' : 'bg-surface-700')}
+                    className={clsx('w-8 h-0.5 mx-1', i < step ? 'bg-brand-500' : 'bg-surface-200')}
                   />
                 )}
               </div>
@@ -699,7 +699,7 @@ export function VendorRiskAssessmentWizard({
         <div className="flex-1 overflow-y-auto p-6">{renderStep()}</div>
 
         {/* Footer */}
-        <div className="flex items-center justify-between p-4 border-t border-surface-800">
+        <div className="flex items-center justify-between p-4 border-t border-surface-200">
           <Button
             variant="ghost"
             onClick={() => setStep(step - 1)}

--- a/frontend/src/components/vendor/VendorSecurityScanPanel.tsx
+++ b/frontend/src/components/vendor/VendorSecurityScanPanel.tsx
@@ -203,7 +203,7 @@ function ScoreGauge({ score, size = 'lg' }: { score: number; size?: 'sm' | 'lg' 
     return (
       <div className="flex items-center gap-2">
         <div className={clsx('text-lg font-bold', getColor(score))}>{score}</div>
-        <div className="w-16 h-2 bg-surface-800 rounded-full overflow-hidden">
+        <div className="w-16 h-2 bg-white rounded-full overflow-hidden">
           <div
             className={clsx(
               'h-full',
@@ -301,7 +301,7 @@ function StatusBadgeWithLink({
         href={url}
         target="_blank"
         rel="noopener noreferrer"
-        className="hover:bg-surface-800 rounded px-1 -mx-1 transition-colors group"
+        className="hover:bg-white rounded px-1 -mx-1 transition-colors group"
         title={`Open ${label}`}
       >
         {content}
@@ -377,19 +377,19 @@ function SubdomainCrawlModal({
   return (
     <Dialog open onClose={onClose}>
       {/* Header */}
-      <div className="flex items-center justify-between p-4 border-b border-surface-700">
+      <div className="flex items-center justify-between p-4 border-b border-surface-200">
         <div className="flex items-center gap-3">
           <div className="p-2 bg-brand-500/20 rounded-lg">
             <LinkIcon className="w-5 h-5 text-brand-400" />
           </div>
           <div>
-            <h3 className="font-semibold text-surface-100">{subdomain.fullDomain}</h3>
+            <h3 className="font-semibold text-surface-900">{subdomain.fullDomain}</h3>
             <p className="text-sm text-surface-600">Discovered pages and links</p>
           </div>
         </div>
         <button
           onClick={onClose}
-          className="p-2 text-surface-600 hover:text-surface-200 hover:bg-surface-800 rounded-lg transition-colors"
+          className="p-2 text-surface-600 hover:text-surface-800 hover:bg-white rounded-lg transition-colors"
         >
           <XMarkIcon className="w-5 h-5" />
         </button>
@@ -415,15 +415,15 @@ function SubdomainCrawlModal({
         {crawlResult && (
           <>
             {/* Stats Bar */}
-            <div className="flex items-center gap-6 p-4 bg-surface-800/50 border-b border-surface-700">
+            <div className="flex items-center gap-6 p-4 bg-white/50 border-b border-surface-200">
               <div>
-                <div className="text-2xl font-bold text-surface-100">
+                <div className="text-2xl font-bold text-surface-900">
                   {crawlResult.pages.length}
                 </div>
                 <div className="text-xs text-surface-600">Pages Found</div>
               </div>
               <div>
-                <div className="text-2xl font-bold text-surface-100">
+                <div className="text-2xl font-bold text-surface-900">
                   {crawlResult.externalLinks.length}
                 </div>
                 <div className="text-xs text-surface-600">External Links</div>
@@ -434,14 +434,14 @@ function SubdomainCrawlModal({
             </div>
 
             {/* Tabs */}
-            <div className="flex border-b border-surface-700">
+            <div className="flex border-b border-surface-200">
               <button
                 onClick={() => setActiveTab('pages')}
                 className={clsx(
                   'px-4 py-2 text-sm font-medium border-b-2 transition-colors',
                   activeTab === 'pages'
                     ? 'border-brand-400 text-brand-400'
-                    : 'border-transparent text-surface-600 hover:text-surface-200'
+                    : 'border-transparent text-surface-600 hover:text-surface-800'
                 )}
               >
                 Internal Pages ({crawlResult.pages.length})
@@ -452,7 +452,7 @@ function SubdomainCrawlModal({
                   'px-4 py-2 text-sm font-medium border-b-2 transition-colors',
                   activeTab === 'external'
                     ? 'border-brand-400 text-brand-400'
-                    : 'border-transparent text-surface-600 hover:text-surface-200'
+                    : 'border-transparent text-surface-600 hover:text-surface-800'
                 )}
               >
                 External Links ({crawlResult.externalLinks.length})
@@ -462,8 +462,8 @@ function SubdomainCrawlModal({
             {/* Table */}
             <div className="overflow-auto max-h-[calc(85vh-280px)]">
               <table className="w-full text-sm">
-                <thead className="sticky top-0 bg-surface-800 z-10">
-                  <tr className="border-b border-surface-700">
+                <thead className="sticky top-0 bg-white z-10">
+                  <tr className="border-b border-surface-200">
                     <th className="px-4 py-2 text-left text-xs font-medium text-surface-600 uppercase">
                       Page
                     </th>
@@ -476,16 +476,16 @@ function SubdomainCrawlModal({
                     <th className="px-4 py-2 text-left text-xs font-medium text-surface-600 uppercase w-12"></th>
                   </tr>
                 </thead>
-                <tbody className="divide-y divide-surface-800">
+                <tbody className="divide-y divide-surface-200">
                   {(activeTab === 'pages' ? crawlResult.pages : crawlResult.externalLinks).map(
                     (page, idx) => (
-                      <tr key={idx} className="hover:bg-surface-800/50">
+                      <tr key={idx} className="hover:bg-white/50">
                         <td className="px-4 py-3">
                           <div className="flex items-start gap-2">
                             <DocumentTextIcon className="w-4 h-4 text-surface-500 mt-0.5 flex-shrink-0" />
                             <div className="min-w-0">
                               <div
-                                className="font-medium text-surface-200 truncate max-w-md"
+                                className="font-medium text-surface-800 truncate max-w-md"
                                 title={page.title || page.url}
                               >
                                 {page.title || new URL(page.url).pathname || '/'}
@@ -515,7 +515,7 @@ function SubdomainCrawlModal({
                                     ? 'bg-blue-500/20 text-blue-600'
                                     : page.statusCode >= 400
                                       ? 'bg-red-500/20 text-red-600'
-                                      : 'bg-surface-700 text-surface-600'
+                                      : 'bg-surface-200 text-surface-600'
                               )}
                             >
                               {page.statusCode}
@@ -557,7 +557,7 @@ function SubdomainCrawlModal({
       </div>
 
       {/* Footer */}
-      <div className="p-4 border-t border-surface-700 flex justify-between items-center">
+      <div className="p-4 border-t border-surface-200 flex justify-between items-center">
         <a
           href={`${subdomain.hasSSL ? 'https' : 'http'}://${subdomain.fullDomain}`}
           target="_blank"
@@ -622,7 +622,7 @@ function SubdomainSection({
       );
     }
     return (
-      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-surface-700 text-surface-600">
+      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-surface-200 text-surface-600">
         <ServerIcon className="w-3 h-3" />
         DNS Only
       </span>
@@ -633,7 +633,7 @@ function SubdomainSection({
     SENSITIVE_SUBDOMAINS.some((s) => sub.subdomain.toLowerCase().includes(s));
 
   return (
-    <div className="p-4 border-b border-surface-800">
+    <div className="p-4 border-b border-surface-200">
       {/* Modal */}
       {selectedSubdomain && (
         <SubdomainCrawlModal
@@ -647,8 +647,8 @@ function SubdomainSection({
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2">
           <ServerIcon className="w-5 h-5 text-surface-600" />
-          <h4 className="text-sm font-medium text-surface-200">Discovered Subdomains</h4>
-          <span className="px-2 py-0.5 text-xs bg-surface-700 text-surface-700 rounded-full">
+          <h4 className="text-sm font-medium text-surface-800">Discovered Subdomains</h4>
+          <span className="px-2 py-0.5 text-xs bg-surface-200 text-surface-700 rounded-full">
             {subdomains.discovered.length} found
           </span>
           <Tooltip
@@ -672,10 +672,10 @@ function SubdomainSection({
             'px-3 py-2 rounded-lg text-left transition-colors',
             filter === 'all'
               ? 'bg-brand-500/20 border border-brand-500/50'
-              : 'bg-surface-800 border border-surface-700 hover:border-surface-600'
+              : 'bg-white border border-surface-200 hover:border-surface-300'
           )}
         >
-          <div className="text-lg font-semibold text-surface-100">
+          <div className="text-lg font-semibold text-surface-900">
             {subdomains.discovered.length}
           </div>
           <div className="text-xs text-surface-600">Total</div>
@@ -686,13 +686,13 @@ function SubdomainSection({
             'px-3 py-2 rounded-lg text-left transition-colors',
             filter === 'sensitive'
               ? 'bg-red-500/20 border border-red-500/50'
-              : 'bg-surface-800 border border-surface-700 hover:border-surface-600'
+              : 'bg-white border border-surface-200 hover:border-surface-300'
           )}
         >
           <div
             className={clsx(
               'text-lg font-semibold',
-              sensitiveSubdomains.length > 0 ? 'text-red-600' : 'text-surface-100'
+              sensitiveSubdomains.length > 0 ? 'text-red-600' : 'text-surface-900'
             )}
           >
             {sensitiveSubdomains.length}
@@ -705,7 +705,7 @@ function SubdomainSection({
             'px-3 py-2 rounded-lg text-left transition-colors',
             filter === 'ssl'
               ? 'bg-green-500/20 border border-green-500/50'
-              : 'bg-surface-800 border border-surface-700 hover:border-surface-600'
+              : 'bg-white border border-surface-200 hover:border-surface-300'
           )}
         >
           <div className="text-lg font-semibold text-green-600">{sslSubdomains.length}</div>
@@ -717,13 +717,13 @@ function SubdomainSection({
             'px-3 py-2 rounded-lg text-left transition-colors',
             filter === 'nossl'
               ? 'bg-yellow-500/20 border border-yellow-500/50'
-              : 'bg-surface-800 border border-surface-700 hover:border-surface-600'
+              : 'bg-white border border-surface-200 hover:border-surface-300'
           )}
         >
           <div
             className={clsx(
               'text-lg font-semibold',
-              noSslSubdomains.length > 0 ? 'text-yellow-600' : 'text-surface-100'
+              noSslSubdomains.length > 0 ? 'text-yellow-600' : 'text-surface-900'
             )}
           >
             {noSslSubdomains.length}
@@ -733,10 +733,10 @@ function SubdomainSection({
       </div>
 
       {/* Table */}
-      <div className="bg-surface-800/50 rounded-lg border border-surface-700 overflow-hidden">
+      <div className="bg-white/50 rounded-lg border border-surface-200 overflow-hidden">
         <table className="w-full text-sm">
           <thead>
-            <tr className="border-b border-surface-700 bg-surface-800">
+            <tr className="border-b border-surface-200 bg-white">
               <th className="px-4 py-2 text-left text-xs font-medium text-surface-600 uppercase tracking-wider">
                 Subdomain
               </th>
@@ -754,12 +754,12 @@ function SubdomainSection({
               </th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-surface-700">
+          <tbody className="divide-y divide-surface-200">
             {displaySubdomains.map((sub) => (
               <tr
                 key={sub.fullDomain}
                 className={clsx(
-                  'hover:bg-surface-700/50 transition-colors',
+                  'hover:bg-surface-200/50 transition-colors',
                   isSensitive(sub) && 'bg-red-500/5'
                 )}
               >
@@ -770,7 +770,7 @@ function SubdomainSection({
                         Sensitive
                       </span>
                     )}
-                    <span className="text-surface-200 font-medium">{sub.subdomain}</span>
+                    <span className="text-surface-800 font-medium">{sub.subdomain}</span>
                     <span className="text-surface-500">.{subdomains.domain}</span>
                   </div>
                 </td>
@@ -818,7 +818,7 @@ function SubdomainSection({
                       href={`${sub.hasSSL ? 'https' : 'http'}://${sub.fullDomain}`}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="p-1 text-surface-600 hover:text-surface-200 transition-colors"
+                      className="p-1 text-surface-600 hover:text-surface-800 transition-colors"
                       title="Open in new tab"
                     >
                       <ArrowTopRightOnSquareIcon className="w-4 h-4" />
@@ -874,7 +874,7 @@ function FindingCard({
       case 'Low':
         return 'border-blue-500/50 bg-blue-500/5';
       default:
-        return 'border-surface-700 bg-surface-800/50';
+        return 'border-surface-200 bg-white/50';
     }
   };
 
@@ -889,7 +889,7 @@ function FindingCard({
       case 'Low':
         return 'bg-blue-500/20 text-blue-600';
       default:
-        return 'bg-surface-700 text-surface-600';
+        return 'bg-surface-200 text-surface-600';
     }
   };
 
@@ -905,7 +905,7 @@ function FindingCard({
           >
             {finding.level}
           </span>
-          <span className="font-medium text-surface-200">{finding.title}</span>
+          <span className="font-medium text-surface-800">{finding.title}</span>
         </div>
         {expanded ? (
           <ChevronUpIcon className="w-4 h-4 text-surface-500" />
@@ -1025,10 +1025,10 @@ export function VendorSecurityScanPanel({
 
   if (scanning) {
     return (
-      <div className="bg-surface-900 border border-surface-800 rounded-lg p-8">
+      <div className="bg-white border border-surface-200 rounded-lg p-8">
         <div className="flex flex-col items-center justify-center">
           <ArrowPathIcon className="w-12 h-12 text-brand-400 animate-spin mb-4" />
-          <h3 className="text-lg font-medium text-surface-100 mb-2">Scanning {vendorName}...</h3>
+          <h3 className="text-lg font-medium text-surface-900 mb-2">Scanning {vendorName}...</h3>
           <p className="text-surface-600 text-center max-w-md">
             Analyzing SSL/TLS, security headers, DNS configuration, and compliance indicators. This
             may take 30 seconds to 2 minutes depending on the target website.
@@ -1040,11 +1040,11 @@ export function VendorSecurityScanPanel({
 
   if (!result) {
     return (
-      <div className="bg-surface-900 border border-surface-800 rounded-lg p-6">
+      <div className="bg-white border border-surface-200 rounded-lg p-6">
         <div className="flex items-center gap-4 mb-4">
           <GlobeAltIcon className="w-8 h-8 text-brand-400" />
           <div>
-            <h3 className="text-lg font-medium text-surface-100">Security Scan</h3>
+            <h3 className="text-lg font-medium text-surface-900">Security Scan</h3>
             <p className="text-sm text-surface-600">
               Automatically scan vendor website for security posture, compliance indicators, and
               risks.
@@ -1079,13 +1079,13 @@ export function VendorSecurityScanPanel({
   }
 
   return (
-    <div className="bg-surface-900 border border-surface-800 rounded-lg">
+    <div className="bg-white border border-surface-200 rounded-lg">
       {/* Header */}
-      <div className="flex items-center justify-between p-4 border-b border-surface-800">
+      <div className="flex items-center justify-between p-4 border-b border-surface-200">
         <div className="flex items-center gap-3">
           <ShieldCheckIcon className="w-6 h-6 text-brand-400" />
           <div>
-            <h3 className="font-medium text-surface-100">Security Scan Results</h3>
+            <h3 className="font-medium text-surface-900">Security Scan Results</h3>
             <p className="text-sm text-surface-500">
               Scanned {new Date(result.scannedAt).toLocaleDateString()} at{' '}
               {new Date(result.scannedAt).toLocaleTimeString()}
@@ -1103,7 +1103,7 @@ export function VendorSecurityScanPanel({
       </div>
 
       {/* Overall Score */}
-      <div className="p-6 border-b border-surface-800">
+      <div className="p-6 border-b border-surface-200">
         <div className="flex items-center gap-8">
           <ScoreGauge score={result.overallScore} />
           <div className="flex-1">
@@ -1127,7 +1127,7 @@ export function VendorSecurityScanPanel({
       </div>
 
       {/* Category Scores */}
-      <div className="p-4 border-b border-surface-800">
+      <div className="p-4 border-b border-surface-200">
         <h4 className="text-sm font-medium text-surface-700 mb-3">Category Scores</h4>
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
           <div className="flex items-center gap-3">
@@ -1174,7 +1174,7 @@ export function VendorSecurityScanPanel({
       </div>
 
       {/* Quick Stats */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 p-4 border-b border-surface-800">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 p-4 border-b border-surface-200">
         <div>
           <h5 className="text-xs font-medium text-surface-500 mb-2">SSL/TLS</h5>
           <div className="flex items-center gap-1">
@@ -1243,7 +1243,7 @@ export function VendorSecurityScanPanel({
         result.compliance.hasISO27001 ||
         result.compliance.hasSecurityWhitepaper ||
         result.compliance.certifications.length > 2) && (
-        <div className="px-4 pb-4 border-b border-surface-800">
+        <div className="px-4 pb-4 border-b border-surface-200">
           <h5 className="text-xs font-medium text-surface-500 mb-2">Additional Compliance</h5>
           <div className="flex flex-wrap gap-3">
             {result.compliance.hasBugBounty && (
@@ -1317,7 +1317,7 @@ export function VendorSecurityScanPanel({
 
       {/* Recommendations */}
       {result.recommendations.length > 0 && (
-        <div className="p-4 bg-surface-800/30 border-t border-surface-800">
+        <div className="p-4 bg-white/30 border-t border-surface-200">
           <h4 className="text-sm font-medium text-surface-700 mb-2">Top Recommendations</h4>
           <ul className="space-y-1">
             {result.recommendations.slice(0, 5).map((rec, i) => (

--- a/frontend/src/components/widgets/MappingCoverageWidget.tsx
+++ b/frontend/src/components/widgets/MappingCoverageWidget.tsx
@@ -48,7 +48,7 @@ export function MappingCoverageWidget({ frameworkId, className }: MappingCoverag
       >
         <div className="flex items-center gap-2 mb-4">
           <LinkIcon className="w-5 h-5 text-brand-400" />
-          <h2 className="text-lg font-semibold text-surface-100">Mapping Coverage</h2>
+          <h2 className="text-lg font-semibold text-surface-900">Mapping Coverage</h2>
         </div>
         <div className="flex items-center justify-center py-8">
           <ArrowPathIcon className="w-6 h-6 text-surface-500 animate-spin" aria-hidden="true" />
@@ -63,7 +63,7 @@ export function MappingCoverageWidget({ frameworkId, className }: MappingCoverag
       <div role="region" aria-label={regionLabel} className={clsx('card p-6', className)}>
         <div className="flex items-center gap-2 mb-4">
           <LinkIcon className="w-5 h-5 text-brand-400" />
-          <h2 className="text-lg font-semibold text-surface-100">Mapping Coverage</h2>
+          <h2 className="text-lg font-semibold text-surface-900">Mapping Coverage</h2>
         </div>
         <div
           role="alert"
@@ -102,7 +102,7 @@ export function MappingCoverageWidget({ frameworkId, className }: MappingCoverag
     <div role="region" aria-label={regionLabel} className={clsx('card p-6', className)}>
       <div className="flex items-center gap-2 mb-4">
         <LinkIcon className="w-5 h-5 text-brand-400" />
-        <h2 className="text-lg font-semibold text-surface-100">Mapping Coverage</h2>
+        <h2 className="text-lg font-semibold text-surface-900">Mapping Coverage</h2>
       </div>
 
       {isZeroState ? (

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -1,0 +1,108 @@
+/**
+ * ThemeContext — gates the design system's light/dark surfaces.
+ *
+ * Three modes:
+ *   - 'light'  : always force light (adds `light` class to <html>)
+ *   - 'dark'   : always force dark (adds `dark` class to <html>)
+ *   - 'system' : follows `prefers-color-scheme`, listening for changes
+ *
+ * Persisted to localStorage under the key `theme`. Default is 'system'.
+ *
+ * Tailwind's darkMode is set to `'class'` in tailwind.config.js, so the
+ * presence of the `dark` class on <html> is what flips every `dark:`
+ * variant across the app. Light mode is the absence of that class.
+ *
+ * Note: we set the class on <html> (not <body>) so that media-level
+ * styling like `color-scheme: dark` (scrollbars, form controls) can pick
+ * it up from the `html.dark { color-scheme: dark; }` rule in index.css.
+ */
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  ReactNode,
+} from 'react';
+
+export type Theme = 'light' | 'dark' | 'system';
+export type ResolvedTheme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Theme;
+  /** The currently-applied theme: 'light' or 'dark'. Tracks system when theme === 'system'. */
+  resolvedTheme: ResolvedTheme;
+  setTheme: (theme: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+const STORAGE_KEY = 'theme';
+
+function getSystemPreference(): ResolvedTheme {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return 'light';
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function readStoredTheme(): Theme {
+  if (typeof localStorage === 'undefined') return 'system';
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored === 'light' || stored === 'dark' || stored === 'system') return stored;
+  return 'system';
+}
+
+function applyClass(resolved: ResolvedTheme) {
+  if (typeof document === 'undefined') return;
+  const root = document.documentElement;
+  root.classList.remove('light', 'dark');
+  root.classList.add(resolved);
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(() => readStoredTheme());
+  const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>(() =>
+    readStoredTheme() === 'system' ? getSystemPreference() : (readStoredTheme() as ResolvedTheme)
+  );
+
+  // Apply the resolved class to <html> whenever it changes.
+  useEffect(() => {
+    applyClass(resolvedTheme);
+  }, [resolvedTheme]);
+
+  // Listen for OS preference changes when in 'system' mode.
+  useEffect(() => {
+    if (theme !== 'system' || typeof window === 'undefined' || !window.matchMedia) return;
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = (e: MediaQueryListEvent) => setResolvedTheme(e.matches ? 'dark' : 'light');
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, [theme]);
+
+  // Recompute resolvedTheme when user changes the mode.
+  useEffect(() => {
+    setResolvedTheme(theme === 'system' ? getSystemPreference() : theme);
+  }, [theme]);
+
+  const setTheme = useCallback((next: Theme) => {
+    setThemeState(next);
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(STORAGE_KEY, next);
+    }
+  }, []);
+
+  const value = useMemo(
+    () => ({ theme, resolvedTheme, setTheme }),
+    [theme, resolvedTheme, setTheme]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return ctx;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,6 +3,7 @@
 @tailwind utilities;
 
 @layer base {
+  /* Light mode (default). Each token has a `.dark` counterpart below. */
   :root {
     --background: 252 252 251;
     --foreground: 31 29 27;
@@ -24,68 +25,97 @@
     --ring-offset: 252 252 251;
   }
 
+  /* Dark mode. Activated by adding the `dark` class to <html>. */
+  .dark {
+    --background: 20 19 15;
+    --foreground: 245 244 241;
+    --card: 31 30 28;
+    --card-foreground: 245 244 241;
+    --primary: 16 185 129;
+    --primary-foreground: 6 78 59;
+    --secondary: 47 46 44;
+    --secondary-foreground: 245 244 241;
+    --muted: 47 46 44;
+    --muted-foreground: 138 136 132;
+    --accent: 217 119 87;
+    --accent-foreground: 20 19 15;
+    --destructive: 248 113 113;
+    --destructive-foreground: 20 19 15;
+    --border: 47 46 44;
+    --input: 47 46 44;
+    --ring: 16 185 129;
+    --ring-offset: 20 19 15;
+  }
+
   * {
-    @apply border-surface-200;
+    @apply border-surface-200 dark:border-surface-800;
   }
 
   html {
     color-scheme: light;
   }
+  html.dark {
+    color-scheme: dark;
+  }
 
   body {
-    @apply bg-surface-50 text-surface-900 antialiased;
+    @apply bg-surface-50 text-surface-900 dark:bg-surface-950 dark:text-surface-100 antialiased;
     font-feature-settings: "cv11", "ss01", "ss03";
   }
 
   *:focus-visible {
-    @apply outline-none ring-2 ring-brand-500 ring-offset-2 ring-offset-surface-50;
+    @apply outline-none ring-2 ring-brand-500 ring-offset-2 ring-offset-surface-50 dark:ring-offset-surface-950;
   }
 
   ::selection {
     background-color: rgb(217 119 87 / 0.25);
     color: rgb(31 29 27);
   }
+  .dark ::selection {
+    background-color: rgb(217 119 87 / 0.35);
+    color: rgb(245 244 241);
+  }
 }
 
 @layer components {
   /* Legacy utilities — kept as escape hatches. New code uses primitives. */
   .btn {
-    @apply inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface-50 disabled:opacity-50 disabled:pointer-events-none;
+    @apply inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface-50 dark:focus-visible:ring-offset-surface-950 disabled:opacity-50 disabled:pointer-events-none;
   }
 
   .btn-primary {
-    @apply btn bg-brand-600 text-white hover:bg-brand-700 shadow-sm;
+    @apply btn bg-brand-600 text-white hover:bg-brand-700 dark:bg-brand-500 dark:hover:bg-brand-400 shadow-sm;
   }
 
   .btn-secondary {
-    @apply btn bg-white text-surface-800 border border-surface-200 hover:bg-surface-100 shadow-sm;
+    @apply btn bg-white text-surface-800 border border-surface-200 hover:bg-surface-100 dark:bg-surface-800 dark:text-surface-100 dark:border-surface-700 dark:hover:bg-surface-700 shadow-sm;
   }
 
   .btn-outline {
-    @apply btn border border-surface-300 bg-white text-surface-700 hover:bg-surface-100 hover:border-surface-400;
+    @apply btn border border-surface-300 bg-white text-surface-700 hover:bg-surface-100 hover:border-surface-400 dark:bg-transparent dark:text-surface-200 dark:border-surface-700 dark:hover:bg-surface-800 dark:hover:border-surface-600;
   }
 
   .btn-ghost {
-    @apply btn bg-transparent text-surface-700 hover:bg-surface-100;
+    @apply btn bg-transparent text-surface-700 hover:bg-surface-100 dark:text-surface-300 dark:hover:bg-surface-800 dark:hover:text-surface-100;
   }
 
   .btn-danger {
-    @apply btn bg-red-600 text-white hover:bg-red-700 shadow-sm;
+    @apply btn bg-red-600 text-white hover:bg-red-700 dark:bg-red-500 dark:hover:bg-red-400 shadow-sm;
   }
 
   .card {
-    @apply bg-white border border-surface-200 rounded-lg;
+    @apply bg-white border border-surface-200 rounded-lg dark:bg-surface-900 dark:border-surface-800;
     box-shadow:
       0 1px 2px 0 rgba(30, 25, 20, 0.06),
       0 1px 3px -1px rgba(30, 25, 20, 0.08);
   }
 
   .input {
-    @apply w-full rounded-md border border-surface-300 bg-white px-3 py-2 text-sm text-surface-900 placeholder:text-surface-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-1 focus-visible:ring-offset-surface-50 focus:border-transparent disabled:opacity-50;
+    @apply w-full rounded-md border border-surface-300 bg-white px-3 py-2 text-sm text-surface-900 placeholder:text-surface-400 dark:bg-surface-900 dark:text-surface-100 dark:border-surface-700 dark:placeholder:text-surface-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-1 focus-visible:ring-offset-surface-50 dark:focus-visible:ring-offset-surface-950 focus:border-transparent disabled:opacity-50;
   }
 
   .label {
-    @apply text-sm font-medium text-surface-700;
+    @apply text-sm font-medium text-surface-700 dark:text-surface-300;
   }
 
   .badge {
@@ -94,23 +124,23 @@
 
   /* Legacy badge classes. New code: use <Badge variant="..."> from @/components/ui. */
   .badge-success {
-    @apply badge bg-emerald-50 text-emerald-800 border border-emerald-200;
+    @apply badge bg-emerald-50 text-emerald-800 border border-emerald-200 dark:bg-emerald-900/40 dark:text-emerald-200 dark:border-emerald-800;
   }
 
   .badge-warning {
-    @apply badge bg-amber-50 text-amber-800 border border-amber-200;
+    @apply badge bg-amber-50 text-amber-800 border border-amber-200 dark:bg-amber-900/40 dark:text-amber-200 dark:border-amber-800;
   }
 
   .badge-danger {
-    @apply badge bg-red-50 text-red-800 border border-red-200;
+    @apply badge bg-red-50 text-red-800 border border-red-200 dark:bg-red-900/40 dark:text-red-200 dark:border-red-800;
   }
 
   .badge-info {
-    @apply badge bg-blue-50 text-blue-800 border border-blue-200;
+    @apply badge bg-blue-50 text-blue-800 border border-blue-200 dark:bg-blue-900/40 dark:text-blue-200 dark:border-blue-800;
   }
 
   .badge-neutral {
-    @apply badge bg-surface-100 text-surface-700 border border-surface-300;
+    @apply badge bg-surface-100 text-surface-700 border border-surface-300 dark:bg-surface-800 dark:text-surface-300 dark:border-surface-700;
   }
 
   .stat-card {
@@ -118,15 +148,15 @@
   }
 
   .stat-value {
-    @apply text-3xl font-bold text-surface-900;
+    @apply text-3xl font-bold text-surface-900 dark:text-surface-100;
   }
 
   .stat-label {
-    @apply text-sm text-surface-600 mt-1;
+    @apply text-sm text-surface-600 dark:text-surface-400 mt-1;
   }
 
   .progress-bar {
-    @apply h-2 bg-surface-100 rounded-full overflow-hidden;
+    @apply h-2 bg-surface-100 dark:bg-surface-800 rounded-full overflow-hidden;
   }
 
   .progress-fill {
@@ -135,13 +165,23 @@
 }
 
 @layer utilities {
-  /* Skeleton shimmer — warm light */
+  /* Skeleton shimmer — warm light + dark variants */
   .skeleton-shimmer {
     background: linear-gradient(
       90deg,
       rgb(220 214 199 / 1) 0%,
       rgb(196 189 170 / 1) 50%,
       rgb(220 214 199 / 1) 100%
+    );
+    background-size: 200% 100%;
+    animation: shimmer 1.6s ease-in-out infinite;
+  }
+  .dark .skeleton-shimmer {
+    background: linear-gradient(
+      90deg,
+      rgb(47 46 44 / 1) 0%,
+      rgb(69 68 65 / 1) 50%,
+      rgb(47 46 44 / 1) 100%
     );
     background-size: 200% 100%;
     animation: shimmer 1.6s ease-in-out infinite;
@@ -159,6 +199,12 @@
       0 1px 2px 0 rgba(30, 25, 20, 0.06),
       0 1px 3px -1px rgba(30, 25, 20, 0.08);
   }
+  .dark .surface-elevated {
+    background: rgb(31 30 28);
+    box-shadow:
+      0 1px 2px 0 rgba(0, 0, 0, 0.4),
+      0 1px 3px -1px rgba(0, 0, 0, 0.5);
+  }
 
   /* Hover-lift */
   .lift-hover {
@@ -169,6 +215,11 @@
     box-shadow:
       0 6px 16px -4px rgba(30, 25, 20, 0.12),
       0 0 0 1px rgba(30, 25, 20, 0.08);
+  }
+  .dark .lift-hover:hover {
+    box-shadow:
+      0 6px 16px -4px rgba(0, 0, 0, 0.5),
+      0 0 0 1px rgba(255, 255, 255, 0.08);
   }
 }
 
@@ -182,7 +233,7 @@
 }
 
 ::-webkit-scrollbar-thumb {
-  @apply bg-surface-300/80 rounded-full hover:bg-surface-400;
+  @apply bg-surface-300/80 rounded-full hover:bg-surface-400 dark:bg-surface-700/80 dark:hover:bg-surface-600;
 }
 
 .table-container {
@@ -194,25 +245,25 @@ table {
 }
 
 thead {
-  @apply border-b border-surface-200;
+  @apply border-b border-surface-200 dark:border-surface-800;
 }
 
 th {
-  @apply px-4 py-3 text-left text-xs font-medium text-surface-500 uppercase tracking-wider;
+  @apply px-4 py-3 text-left text-xs font-medium text-surface-500 dark:text-surface-400 uppercase tracking-wider;
 }
 
 td {
-  @apply px-4 py-4 text-surface-700;
+  @apply px-4 py-4 text-surface-700 dark:text-surface-200;
 }
 
 tbody tr {
-  @apply border-b border-surface-200/60 hover:bg-surface-100/60 transition-colors;
+  @apply border-b border-surface-200/60 hover:bg-surface-100/60 dark:border-surface-800/60 dark:hover:bg-surface-800/40 transition-colors;
 }
 
 [cmdk-root] { @apply w-full; }
-[cmdk-input] { @apply w-full bg-transparent text-surface-900 placeholder:text-surface-400 outline-none border-0; }
+[cmdk-input] { @apply w-full bg-transparent text-surface-900 placeholder:text-surface-400 dark:text-surface-100 dark:placeholder:text-surface-500 outline-none border-0; }
 [cmdk-list] { @apply max-h-96 overflow-y-auto overscroll-contain; }
-[cmdk-item] { @apply flex items-center gap-3 px-3 py-2 rounded-md text-sm text-surface-700 cursor-pointer transition-colors; }
-[cmdk-item][data-selected="true"] { @apply bg-surface-100 text-surface-900; }
-[cmdk-group-heading] { @apply px-3 py-1.5 text-xs font-medium text-surface-500 uppercase tracking-wider; }
-[cmdk-empty] { @apply px-3 py-6 text-center text-sm text-surface-500; }
+[cmdk-item] { @apply flex items-center gap-3 px-3 py-2 rounded-md text-sm text-surface-700 dark:text-surface-200 cursor-pointer transition-colors; }
+[cmdk-item][data-selected="true"] { @apply bg-surface-100 text-surface-900 dark:bg-surface-800 dark:text-surface-100; }
+[cmdk-group-heading] { @apply px-3 py-1.5 text-xs font-medium text-surface-500 dark:text-surface-400 uppercase tracking-wider; }
+[cmdk-empty] { @apply px-3 py-6 text-center text-sm text-surface-500 dark:text-surface-400; }

--- a/frontend/src/lib/categoryStyle.ts
+++ b/frontend/src/lib/categoryStyle.ts
@@ -3,18 +3,65 @@
 // as a chip — gives the page visual variety without overloading status colors.
 // All combinations are tested for AA contrast on the off-white page background.
 
+// Each entry pairs a light-mode set (bg-X-50/text-X-800/border-X-200) with
+// a dark-mode counterpart (bg-X-900/40, text-X-200, border-X-800). Both
+// directions are tested for AA contrast.
 const PALETTE = [
-  { bg: 'bg-indigo-50', text: 'text-indigo-800', border: 'border-indigo-200' },
-  { bg: 'bg-sky-50', text: 'text-sky-800', border: 'border-sky-200' },
-  { bg: 'bg-teal-50', text: 'text-teal-800', border: 'border-teal-200' },
-  { bg: 'bg-emerald-50', text: 'text-emerald-800', border: 'border-emerald-200' },
-  { bg: 'bg-lime-50', text: 'text-lime-800', border: 'border-lime-300' },
-  { bg: 'bg-amber-50', text: 'text-amber-800', border: 'border-amber-200' },
-  { bg: 'bg-orange-50', text: 'text-orange-800', border: 'border-orange-200' },
-  { bg: 'bg-rose-50', text: 'text-rose-800', border: 'border-rose-200' },
-  { bg: 'bg-fuchsia-50', text: 'text-fuchsia-800', border: 'border-fuchsia-200' },
-  { bg: 'bg-violet-50', text: 'text-violet-800', border: 'border-violet-200' },
-  { bg: 'bg-cyan-50', text: 'text-cyan-800', border: 'border-cyan-200' },
+  {
+    bg: 'bg-indigo-50 dark:bg-indigo-900/40',
+    text: 'text-indigo-800 dark:text-indigo-200',
+    border: 'border-indigo-200 dark:border-indigo-800',
+  },
+  {
+    bg: 'bg-sky-50 dark:bg-sky-900/40',
+    text: 'text-sky-800 dark:text-sky-200',
+    border: 'border-sky-200 dark:border-sky-800',
+  },
+  {
+    bg: 'bg-teal-50 dark:bg-teal-900/40',
+    text: 'text-teal-800 dark:text-teal-200',
+    border: 'border-teal-200 dark:border-teal-800',
+  },
+  {
+    bg: 'bg-emerald-50 dark:bg-emerald-900/40',
+    text: 'text-emerald-800 dark:text-emerald-200',
+    border: 'border-emerald-200 dark:border-emerald-800',
+  },
+  {
+    bg: 'bg-lime-50 dark:bg-lime-900/40',
+    text: 'text-lime-800 dark:text-lime-200',
+    border: 'border-lime-300 dark:border-lime-800',
+  },
+  {
+    bg: 'bg-amber-50 dark:bg-amber-900/40',
+    text: 'text-amber-800 dark:text-amber-200',
+    border: 'border-amber-200 dark:border-amber-800',
+  },
+  {
+    bg: 'bg-orange-50 dark:bg-orange-900/40',
+    text: 'text-orange-800 dark:text-orange-200',
+    border: 'border-orange-200 dark:border-orange-800',
+  },
+  {
+    bg: 'bg-rose-50 dark:bg-rose-900/40',
+    text: 'text-rose-800 dark:text-rose-200',
+    border: 'border-rose-200 dark:border-rose-800',
+  },
+  {
+    bg: 'bg-fuchsia-50 dark:bg-fuchsia-900/40',
+    text: 'text-fuchsia-800 dark:text-fuchsia-200',
+    border: 'border-fuchsia-200 dark:border-fuchsia-800',
+  },
+  {
+    bg: 'bg-violet-50 dark:bg-violet-900/40',
+    text: 'text-violet-800 dark:text-violet-200',
+    border: 'border-violet-200 dark:border-violet-800',
+  },
+  {
+    bg: 'bg-cyan-50 dark:bg-cyan-900/40',
+    text: 'text-cyan-800 dark:text-cyan-200',
+    border: 'border-cyan-200 dark:border-cyan-800',
+  },
 ];
 
 // Explicit assignments for known categories / framework types so the most

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -192,7 +192,7 @@ export const BCDR_PLAN_STATUSES = {
   in_review: { value: 'in_review', label: 'In Review', color: 'bg-yellow-500/20 text-yellow-400' },
   approved: { value: 'approved', label: 'Approved', color: 'bg-blue-500/20 text-blue-400' },
   published: { value: 'published', label: 'Published', color: 'bg-green-500/20 text-green-400' },
-  archived: { value: 'archived', label: 'Archived', color: 'bg-surface-700 text-surface-400' },
+  archived: { value: 'archived', label: 'Archived', color: 'bg-surface-200 text-surface-400' },
 } as const;
 
 export const BCDR_PLAN_STATUS_OPTIONS = Object.values(BCDR_PLAN_STATUSES);

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Toaster } from 'react-hot-toast';
 import App from './App';
 import { AuthProvider } from './contexts/AuthContext';
+import { ThemeProvider } from './contexts/ThemeContext';
 import { BrandingProvider } from './contexts/BrandingContext';
 import { WorkspaceProvider } from './contexts/WorkspaceContext';
 import { ModuleProvider } from './contexts/ModuleContext';
@@ -110,34 +111,37 @@ const queryClient = new QueryClient({
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <ErrorBoundary>
-      <BrandingProvider>
-        <BrowserRouter
-          future={{
-            v7_startTransition: true,
-            v7_relativeSplatPath: true,
-          }}
-        >
-          <QueryClientProvider client={queryClient}>
-            <AuthProvider>
-              <ModuleProvider>
-                <WorkspaceProvider>
-                  {/* Global UI components */}
-                  <NetworkStatus />
-                  <SessionWarning warningThreshold={2 * 60 * 1000} />
-                  <App />
-                  <Toaster
-                    position="top-right"
-                    toastOptions={{
-                      className: 'bg-white text-surface-900 border border-surface-200 shadow-lift',
-                      duration: 4000,
-                    }}
-                  />
-                </WorkspaceProvider>
-              </ModuleProvider>
-            </AuthProvider>
-          </QueryClientProvider>
-        </BrowserRouter>
-      </BrandingProvider>
+      <ThemeProvider>
+        <BrandingProvider>
+          <BrowserRouter
+            future={{
+              v7_startTransition: true,
+              v7_relativeSplatPath: true,
+            }}
+          >
+            <QueryClientProvider client={queryClient}>
+              <AuthProvider>
+                <ModuleProvider>
+                  <WorkspaceProvider>
+                    {/* Global UI components */}
+                    <NetworkStatus />
+                    <SessionWarning warningThreshold={2 * 60 * 1000} />
+                    <App />
+                    <Toaster
+                      position="top-right"
+                      toastOptions={{
+                        className:
+                          'bg-white text-surface-900 border border-surface-200 dark:bg-surface-900 dark:text-surface-100 dark:border-surface-800 shadow-lift',
+                        duration: 4000,
+                      }}
+                    />
+                  </WorkspaceProvider>
+                </ModuleProvider>
+              </AuthProvider>
+            </QueryClientProvider>
+          </BrowserRouter>
+        </BrandingProvider>
+      </ThemeProvider>
     </ErrorBoundary>
   </React.StrictMode>
 );

--- a/frontend/src/pages/AIRiskAssistant.tsx
+++ b/frontend/src/pages/AIRiskAssistant.tsx
@@ -44,7 +44,7 @@ export default function AIRiskAssistant() {
         <h1 className="text-2xl font-semibold text-white">AI Risk Assistant</h1>
         <p className="text-surface-600">
           The AI module is not enabled for this environment. Ask an administrator to set
-          <code className="mx-1 text-xs bg-surface-900 px-2 py-1 rounded">
+          <code className="mx-1 text-xs bg-white px-2 py-1 rounded">
             VITE_ENABLE_AI_MODULE=true
           </code>
           and provide AI provider API keys.
@@ -93,25 +93,25 @@ export default function AIRiskAssistant() {
             {data.suggestedCategory && (
               <div>
                 <p className="text-surface-500">Category</p>
-                <p className="text-surface-100 font-medium">{data.suggestedCategory}</p>
+                <p className="text-surface-900 font-medium">{data.suggestedCategory}</p>
               </div>
             )}
             {data.suggestedLikelihood && (
               <div>
                 <p className="text-surface-500">Likelihood</p>
-                <p className="text-surface-100 font-medium">{data.suggestedLikelihood}</p>
+                <p className="text-surface-900 font-medium">{data.suggestedLikelihood}</p>
               </div>
             )}
             {data.suggestedImpact && (
               <div>
                 <p className="text-surface-500">Impact</p>
-                <p className="text-surface-100 font-medium">{data.suggestedImpact}</p>
+                <p className="text-surface-900 font-medium">{data.suggestedImpact}</p>
               </div>
             )}
             {data.suggestedTreatmentPlan && (
               <div className="md:col-span-2">
                 <p className="text-surface-500">Treatment Plan</p>
-                <p className="text-surface-100 whitespace-pre-wrap">
+                <p className="text-surface-900 whitespace-pre-wrap">
                   {data.suggestedTreatmentPlan}
                 </p>
               </div>

--- a/frontend/src/pages/AccountSettings.tsx
+++ b/frontend/src/pages/AccountSettings.tsx
@@ -30,7 +30,7 @@ export default function AccountSettings() {
     <div className="space-y-6 animate-fade-in">
       {/* Header */}
       <div>
-        <h1 className="text-2xl font-bold text-surface-100">Account Settings</h1>
+        <h1 className="text-2xl font-bold text-surface-900">Account Settings</h1>
         <p className="text-surface-600 mt-1">Manage your personal preferences</p>
       </div>
 
@@ -46,7 +46,7 @@ export default function AccountSettings() {
                   'w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors',
                   activeTab === tab.id
                     ? 'bg-brand-600/20 text-brand-400'
-                    : 'text-surface-600 hover:bg-surface-800 hover:text-surface-100'
+                    : 'text-surface-600 hover:bg-white hover:text-surface-900'
                 )}
               >
                 <tab.icon className="w-5 h-5" />
@@ -71,9 +71,9 @@ export default function AccountSettings() {
 function ProfileSettings({ user }: { user: any }) {
   return (
     <div className="card p-6 space-y-6">
-      <h2 className="text-lg font-semibold text-surface-100">Profile</h2>
+      <h2 className="text-lg font-semibold text-surface-900">Profile</h2>
       <div className="flex items-center gap-4">
-        <div className="w-16 h-16 rounded-full bg-surface-700 flex items-center justify-center">
+        <div className="w-16 h-16 rounded-full bg-surface-200 flex items-center justify-center">
           <span className="text-2xl font-medium text-surface-700">
             {user?.name?.charAt(0)?.toUpperCase() || 'U'}
           </span>
@@ -113,7 +113,7 @@ function ProfileSettings({ user }: { user: any }) {
           />
         </div>
       </div>
-      <div className="flex justify-end pt-4 border-t border-surface-800">
+      <div className="flex justify-end pt-4 border-t border-surface-200">
         <Button variant="primary">Save Changes</Button>
       </div>
     </div>
@@ -153,7 +153,7 @@ function NotificationPreferences() {
       {/* Risk Task Notifications - New Section */}
       <div className="card p-6 space-y-6">
         <div>
-          <h2 className="text-lg font-semibold text-surface-100">
+          <h2 className="text-lg font-semibold text-surface-900">
             Risk Workflow Task Notifications
           </h2>
           <p className="text-surface-600 text-sm mt-1">
@@ -166,9 +166,9 @@ function NotificationPreferences() {
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             {/* Email */}
-            <label className="flex flex-col p-4 bg-surface-800/50 rounded-lg cursor-pointer hover:bg-surface-800 border-2 transition-colors border-transparent has-[:checked]:border-brand-500">
+            <label className="flex flex-col p-4 bg-white/50 rounded-lg cursor-pointer hover:bg-white border-2 transition-colors border-transparent has-[:checked]:border-brand-500">
               <div className="flex items-center justify-between mb-2">
-                <span className="text-surface-100 font-medium flex items-center gap-2">
+                <span className="text-surface-900 font-medium flex items-center gap-2">
                   <svg
                     className="w-5 h-5 text-surface-600"
                     fill="none"
@@ -188,16 +188,16 @@ function NotificationPreferences() {
                   type="checkbox"
                   checked={riskTaskPrefs.email}
                   onChange={() => toggleRiskTaskPref('email')}
-                  className="w-5 h-5 rounded border-surface-600 text-brand-500 focus:ring-brand-500"
+                  className="w-5 h-5 rounded border-surface-300 text-brand-500 focus:ring-brand-500"
                 />
               </div>
               <p className="text-surface-500 text-sm">Receive task notifications via email</p>
             </label>
 
             {/* In-App */}
-            <label className="flex flex-col p-4 bg-surface-800/50 rounded-lg cursor-pointer hover:bg-surface-800 border-2 transition-colors border-transparent has-[:checked]:border-brand-500">
+            <label className="flex flex-col p-4 bg-white/50 rounded-lg cursor-pointer hover:bg-white border-2 transition-colors border-transparent has-[:checked]:border-brand-500">
               <div className="flex items-center justify-between mb-2">
-                <span className="text-surface-100 font-medium flex items-center gap-2">
+                <span className="text-surface-900 font-medium flex items-center gap-2">
                   <BellIcon className="w-5 h-5 text-surface-600" />
                   In-App
                 </span>
@@ -205,16 +205,16 @@ function NotificationPreferences() {
                   type="checkbox"
                   checked={riskTaskPrefs.inApp}
                   onChange={() => toggleRiskTaskPref('inApp')}
-                  className="w-5 h-5 rounded border-surface-600 text-brand-500 focus:ring-brand-500"
+                  className="w-5 h-5 rounded border-surface-300 text-brand-500 focus:ring-brand-500"
                 />
               </div>
               <p className="text-surface-500 text-sm">Show notifications in the app</p>
             </label>
 
             {/* Slack */}
-            <label className="flex flex-col p-4 bg-surface-800/50 rounded-lg cursor-pointer hover:bg-surface-800 border-2 transition-colors border-transparent has-[:checked]:border-brand-500">
+            <label className="flex flex-col p-4 bg-white/50 rounded-lg cursor-pointer hover:bg-white border-2 transition-colors border-transparent has-[:checked]:border-brand-500">
               <div className="flex items-center justify-between mb-2">
-                <span className="text-surface-100 font-medium flex items-center gap-2">
+                <span className="text-surface-900 font-medium flex items-center gap-2">
                   <svg className="w-5 h-5 text-surface-600" viewBox="0 0 24 24" fill="currentColor">
                     <path d="M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52zM6.313 15.165a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313zM8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834zM8.834 6.313a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.834a2.528 2.528 0 0 1 2.522-2.521h6.312zM18.956 8.834a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.834a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.834zM17.688 8.834a2.528 2.528 0 0 1-2.523 2.521 2.527 2.527 0 0 1-2.52-2.521V2.522A2.527 2.527 0 0 1 15.165 0a2.528 2.528 0 0 1 2.523 2.522v6.312zM15.165 18.956a2.528 2.528 0 0 1 2.523 2.522A2.528 2.528 0 0 1 15.165 24a2.527 2.527 0 0 1-2.52-2.522v-2.522h2.52zM15.165 17.688a2.527 2.527 0 0 1-2.52-2.523 2.526 2.526 0 0 1 2.52-2.52h6.313A2.527 2.527 0 0 1 24 15.165a2.528 2.528 0 0 1-2.522 2.523h-6.313z" />
                   </svg>
@@ -224,7 +224,7 @@ function NotificationPreferences() {
                   type="checkbox"
                   checked={riskTaskPrefs.slack}
                   onChange={() => toggleRiskTaskPref('slack')}
-                  className="w-5 h-5 rounded border-surface-600 text-brand-500 focus:ring-brand-500"
+                  className="w-5 h-5 rounded border-surface-300 text-brand-500 focus:ring-brand-500"
                 />
               </div>
               <p className="text-surface-500 text-sm">Get notifications in Slack DMs</p>
@@ -233,7 +233,7 @@ function NotificationPreferences() {
 
           {/* Slack User ID - only shown when Slack is enabled */}
           {riskTaskPrefs.slack && (
-            <div className="p-4 bg-surface-800/30 rounded-lg border border-surface-700">
+            <div className="p-4 bg-white/30 rounded-lg border border-surface-200">
               <label className="label">Slack User ID</label>
               <Input
                 type="text"
@@ -268,7 +268,7 @@ function NotificationPreferences() {
                   'flex-1 min-w-[200px] p-3 rounded-lg cursor-pointer border-2 transition-colors',
                   riskTaskPrefs.digestMode === option.value
                     ? 'border-brand-500 bg-brand-500/10'
-                    : 'border-surface-700 bg-surface-800/50 hover:border-surface-600'
+                    : 'border-surface-200 bg-white/50 hover:border-surface-300'
                 )}
               >
                 <div className="flex items-center gap-2">
@@ -282,7 +282,7 @@ function NotificationPreferences() {
                     }
                     className="w-4 h-4 text-brand-500 focus:ring-brand-500"
                   />
-                  <span className="text-surface-100 font-medium">{option.label}</span>
+                  <span className="text-surface-900 font-medium">{option.label}</span>
                 </div>
                 <p className="text-surface-500 text-sm mt-1 ml-6">{option.desc}</p>
               </label>
@@ -290,13 +290,13 @@ function NotificationPreferences() {
           </div>
         </div>
 
-        <div className="flex justify-end pt-4 border-t border-surface-800">
+        <div className="flex justify-end pt-4 border-t border-surface-200">
           <Button variant="primary">Save Task Preferences</Button>
         </div>
       </div>
       {/* General Notifications */}
       <div className="card p-6 space-y-6">
-        <h2 className="text-lg font-semibold text-surface-100">General Notifications</h2>
+        <h2 className="text-lg font-semibold text-surface-900">General Notifications</h2>
         <p className="text-surface-600 text-sm">
           Choose how you want to be notified about other activity.
         </p>
@@ -305,22 +305,22 @@ function NotificationPreferences() {
           <h3 className="text-sm font-medium text-surface-700">Email Notifications</h3>
 
           <div className="space-y-3">
-            <label className="flex items-center justify-between p-3 bg-surface-800/50 rounded-lg cursor-pointer hover:bg-surface-800">
+            <label className="flex items-center justify-between p-3 bg-white/50 rounded-lg cursor-pointer hover:bg-white">
               <div>
-                <span className="text-surface-100 font-medium">Email Notifications</span>
+                <span className="text-surface-900 font-medium">Email Notifications</span>
                 <p className="text-surface-500 text-sm">Receive notifications via email</p>
               </div>
               <input
                 type="checkbox"
                 checked={preferences.emailNotifications}
                 onChange={() => togglePreference('emailNotifications')}
-                className="w-5 h-5 rounded border-surface-600 text-brand-500 focus:ring-brand-500"
+                className="w-5 h-5 rounded border-surface-300 text-brand-500 focus:ring-brand-500"
               />
             </label>
 
-            <label className="flex items-center justify-between p-3 bg-surface-800/50 rounded-lg cursor-pointer hover:bg-surface-800">
+            <label className="flex items-center justify-between p-3 bg-white/50 rounded-lg cursor-pointer hover:bg-white">
               <div>
-                <span className="text-surface-100 font-medium">Compliance Alerts</span>
+                <span className="text-surface-900 font-medium">Compliance Alerts</span>
                 <p className="text-surface-500 text-sm">
                   Get notified about compliance drift and issues
                 </p>
@@ -329,13 +329,13 @@ function NotificationPreferences() {
                 type="checkbox"
                 checked={preferences.complianceAlerts}
                 onChange={() => togglePreference('complianceAlerts')}
-                className="w-5 h-5 rounded border-surface-600 text-brand-500 focus:ring-brand-500"
+                className="w-5 h-5 rounded border-surface-300 text-brand-500 focus:ring-brand-500"
               />
             </label>
 
-            <label className="flex items-center justify-between p-3 bg-surface-800/50 rounded-lg cursor-pointer hover:bg-surface-800">
+            <label className="flex items-center justify-between p-3 bg-white/50 rounded-lg cursor-pointer hover:bg-white">
               <div>
-                <span className="text-surface-100 font-medium">Evidence Reminders</span>
+                <span className="text-surface-900 font-medium">Evidence Reminders</span>
                 <p className="text-surface-500 text-sm">
                   Reminders for expiring or missing evidence
                 </p>
@@ -344,13 +344,13 @@ function NotificationPreferences() {
                 type="checkbox"
                 checked={preferences.evidenceReminders}
                 onChange={() => togglePreference('evidenceReminders')}
-                className="w-5 h-5 rounded border-surface-600 text-brand-500 focus:ring-brand-500"
+                className="w-5 h-5 rounded border-surface-300 text-brand-500 focus:ring-brand-500"
               />
             </label>
 
-            <label className="flex items-center justify-between p-3 bg-surface-800/50 rounded-lg cursor-pointer hover:bg-surface-800">
+            <label className="flex items-center justify-between p-3 bg-white/50 rounded-lg cursor-pointer hover:bg-white">
               <div>
-                <span className="text-surface-100 font-medium">Risk Alerts</span>
+                <span className="text-surface-900 font-medium">Risk Alerts</span>
                 <p className="text-surface-500 text-sm">
                   Notifications about new or escalated risks
                 </p>
@@ -359,41 +359,41 @@ function NotificationPreferences() {
                 type="checkbox"
                 checked={preferences.riskAlerts}
                 onChange={() => togglePreference('riskAlerts')}
-                className="w-5 h-5 rounded border-surface-600 text-brand-500 focus:ring-brand-500"
+                className="w-5 h-5 rounded border-surface-300 text-brand-500 focus:ring-brand-500"
               />
             </label>
 
-            <label className="flex items-center justify-between p-3 bg-surface-800/50 rounded-lg cursor-pointer hover:bg-surface-800">
+            <label className="flex items-center justify-between p-3 bg-white/50 rounded-lg cursor-pointer hover:bg-white">
               <div>
-                <span className="text-surface-100 font-medium">Weekly Digest</span>
+                <span className="text-surface-900 font-medium">Weekly Digest</span>
                 <p className="text-surface-500 text-sm">Summary of activity sent weekly</p>
               </div>
               <input
                 type="checkbox"
                 checked={preferences.weeklyDigest}
                 onChange={() => togglePreference('weeklyDigest')}
-                className="w-5 h-5 rounded border-surface-600 text-brand-500 focus:ring-brand-500"
+                className="w-5 h-5 rounded border-surface-300 text-brand-500 focus:ring-brand-500"
               />
             </label>
           </div>
 
           <h3 className="text-sm font-medium text-surface-700 pt-4">In-App Notifications</h3>
 
-          <label className="flex items-center justify-between p-3 bg-surface-800/50 rounded-lg cursor-pointer hover:bg-surface-800">
+          <label className="flex items-center justify-between p-3 bg-white/50 rounded-lg cursor-pointer hover:bg-white">
             <div>
-              <span className="text-surface-100 font-medium">In-App Notifications</span>
+              <span className="text-surface-900 font-medium">In-App Notifications</span>
               <p className="text-surface-500 text-sm">Show notifications in the app</p>
             </div>
             <input
               type="checkbox"
               checked={preferences.inAppNotifications}
               onChange={() => togglePreference('inAppNotifications')}
-              className="w-5 h-5 rounded border-surface-600 text-brand-500 focus:ring-brand-500"
+              className="w-5 h-5 rounded border-surface-300 text-brand-500 focus:ring-brand-500"
             />
           </label>
         </div>
 
-        <div className="flex justify-end pt-4 border-t border-surface-800">
+        <div className="flex justify-end pt-4 border-t border-surface-200">
           <Button variant="primary">Save Preferences</Button>
         </div>
       </div>
@@ -429,7 +429,7 @@ function SecuritySettings() {
   return (
     <div className="space-y-6">
       <div className="card p-6 space-y-6">
-        <h2 className="text-lg font-semibold text-surface-100">Password</h2>
+        <h2 className="text-lg font-semibold text-surface-900">Password</h2>
 
         <div className="space-y-4">
           <div>
@@ -446,19 +446,19 @@ function SecuritySettings() {
           </div>
         </div>
 
-        <div className="flex justify-end pt-4 border-t border-surface-800">
+        <div className="flex justify-end pt-4 border-t border-surface-200">
           <Button variant="primary">Update Password</Button>
         </div>
       </div>
       <div className="card p-6 space-y-6">
         <div className="flex items-center justify-between">
           <div>
-            <h2 className="text-lg font-semibold text-surface-100">Two-Factor Authentication</h2>
+            <h2 className="text-lg font-semibold text-surface-900">Two-Factor Authentication</h2>
             <p className="text-surface-600 text-sm mt-1">
               Add an extra layer of security to your account
             </p>
           </div>
-          <span className="px-3 py-1 text-sm rounded-full bg-surface-700 text-surface-700">
+          <span className="px-3 py-1 text-sm rounded-full bg-surface-200 text-surface-700">
             Not enabled
           </span>
         </div>
@@ -469,15 +469,15 @@ function SecuritySettings() {
         </Button>
       </div>
       <div className="card p-6 space-y-6">
-        <h2 className="text-lg font-semibold text-surface-100">Active Sessions</h2>
+        <h2 className="text-lg font-semibold text-surface-900">Active Sessions</h2>
         <p className="text-surface-600 text-sm">Manage your active sessions across devices</p>
 
         <div className="space-y-3">
-          <div className="flex items-center justify-between p-3 bg-surface-800/50 rounded-lg">
+          <div className="flex items-center justify-between p-3 bg-white/50 rounded-lg">
             <div className="flex items-center gap-3">
               <ComputerDesktopIcon className="w-8 h-8 text-surface-600" />
               <div>
-                <p className="text-surface-100 font-medium">MacOS - Chrome</p>
+                <p className="text-surface-900 font-medium">MacOS - Chrome</p>
                 <p className="text-surface-500 text-sm">Current session • Last active now</p>
               </div>
             </div>

--- a/frontend/src/pages/AccountSettings.tsx
+++ b/frontend/src/pages/AccountSettings.tsx
@@ -1,18 +1,18 @@
 import { useState } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
+import { useTheme, Theme } from '@/contexts/ThemeContext';
 import {
   UserIcon,
   BellIcon,
   ShieldCheckIcon,
   PaintBrushIcon,
   ComputerDesktopIcon,
+  SunIcon,
+  MoonIcon,
 } from '@heroicons/react/24/outline';
 import clsx from 'clsx';
-
 import { Input } from '@/components/ui/Input';
-
 import { SelectNative } from '@/components/ui/SelectNative';
-
 import { Button } from '@/components/ui/Button';
 
 const TABS = [
@@ -402,24 +402,90 @@ function NotificationPreferences() {
 }
 
 function AppearanceSettings() {
+  const { theme, setTheme } = useTheme();
+
+  const themeOptions: {
+    id: Theme;
+    label: string;
+    description: string;
+    icon: typeof SunIcon;
+  }[] = [
+    { id: 'light', label: 'Light', description: 'Cream background with dark text', icon: SunIcon },
+    {
+      id: 'dark',
+      label: 'Dark',
+      description: 'Warm ink background with bright text',
+      icon: MoonIcon,
+    },
+    {
+      id: 'system',
+      label: 'System',
+      description: 'Follow your OS preference',
+      icon: ComputerDesktopIcon,
+    },
+  ];
+
   return (
     <div className="card p-6 space-y-6">
       <div>
-        <h2 className="text-lg font-semibold text-surface-900">Appearance</h2>
-        <p className="text-surface-600 text-sm mt-1">
+        <h2 className="text-lg font-semibold text-surface-900 dark:text-surface-100">Appearance</h2>
+        <p className="text-surface-600 dark:text-surface-400 text-sm mt-1">
           Customize how GigaChad GRC looks on your device
         </p>
       </div>
-      <div className="space-y-4">
-        <div>
-          <label className="label">Date Format</label>
-          <SelectNative className="input mt-1 max-w-xs">
-            <option value="YYYY-MM-DD">YYYY-MM-DD (2025-01-15)</option>
-            <option value="MM/DD/YYYY">MM/DD/YYYY (01/15/2025)</option>
-            <option value="DD/MM/YYYY">DD/MM/YYYY (15/01/2025)</option>
-            <option value="MMM DD, YYYY">MMM DD, YYYY (Jan 15, 2025)</option>
-          </SelectNative>
+
+      <div className="space-y-3">
+        <label className="label">Theme</label>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+          {themeOptions.map((option) => {
+            const selected = theme === option.id;
+            return (
+              <button
+                key={option.id}
+                onClick={() => setTheme(option.id)}
+                aria-pressed={selected}
+                className={clsx(
+                  'p-4 rounded-lg border-2 text-left transition-all',
+                  selected
+                    ? 'border-brand-500 bg-brand-50 dark:bg-brand-500/15'
+                    : 'border-surface-200 hover:border-surface-300 bg-white dark:bg-surface-900 dark:border-surface-800 dark:hover:border-surface-700'
+                )}
+              >
+                <option.icon
+                  className={clsx(
+                    'w-7 h-7 mb-2',
+                    selected
+                      ? 'text-brand-700 dark:text-brand-300'
+                      : 'text-surface-600 dark:text-surface-400'
+                  )}
+                />
+                <div
+                  className={clsx(
+                    'font-medium',
+                    selected
+                      ? 'text-brand-800 dark:text-brand-200'
+                      : 'text-surface-900 dark:text-surface-100'
+                  )}
+                >
+                  {option.label}
+                </div>
+                <div className="text-surface-600 dark:text-surface-400 text-xs mt-0.5">
+                  {option.description}
+                </div>
+              </button>
+            );
+          })}
         </div>
+      </div>
+
+      <div>
+        <label className="label">Date Format</label>
+        <SelectNative className="input mt-1 max-w-xs">
+          <option value="YYYY-MM-DD">YYYY-MM-DD (2025-01-15)</option>
+          <option value="MM/DD/YYYY">MM/DD/YYYY (01/15/2025)</option>
+          <option value="DD/MM/YYYY">DD/MM/YYYY (15/01/2025)</option>
+          <option value="MMM DD, YYYY">MMM DD, YYYY (Jan 15, 2025)</option>
+        </SelectNative>
       </div>
     </div>
   );

--- a/frontend/src/pages/AnswerTemplates.tsx
+++ b/frontend/src/pages/AnswerTemplates.tsx
@@ -120,7 +120,7 @@ export default function AnswerTemplates() {
 
   const getCategoryStyle = (category?: string) => {
     const cat = CATEGORIES.find((c) => c.value === category);
-    return cat?.color || 'bg-surface-700 text-surface-700';
+    return cat?.color || 'bg-surface-200 text-surface-700';
   };
 
   if (!organizationId) {
@@ -138,7 +138,7 @@ export default function AnswerTemplates() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold text-surface-100">Answer Templates</h1>
+          <h1 className="text-3xl font-bold text-surface-900">Answer Templates</h1>
           <p className="mt-1 text-surface-600">
             Create and manage reusable answer templates for questionnaires
           </p>
@@ -162,14 +162,14 @@ export default function AnswerTemplates() {
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             placeholder="Search templates..."
-            className="w-full pl-10 pr-4 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+            className="w-full pl-10 pr-4 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
           />
         </div>
 
         <SelectNative
           value={categoryFilter}
           onChange={(e) => setCategoryFilter(e.target.value)}
-          className="px-4 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+          className="px-4 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
         >
           <option value="">All Categories</option>
           {CATEGORIES.map((cat) => (
@@ -184,7 +184,7 @@ export default function AnswerTemplates() {
             type="checkbox"
             checked={showArchived}
             onChange={(e) => setShowArchived(e.target.checked)}
-            className="rounded border-surface-600 text-brand-500"
+            className="rounded border-surface-300 text-brand-500"
           />
           Show Archived
         </label>
@@ -195,11 +195,11 @@ export default function AnswerTemplates() {
           Array.from({ length: 6 }).map((_, i) => (
             <div
               key={i}
-              className="bg-surface-900 border border-surface-800 rounded-xl p-5 animate-pulse"
+              className="bg-white border border-surface-200 rounded-xl p-5 animate-pulse"
             >
-              <div className="h-5 bg-surface-700 rounded w-3/4 mb-3" />
-              <div className="h-16 bg-surface-800 rounded mb-3" />
-              <div className="h-4 bg-surface-700 rounded w-1/2" />
+              <div className="h-5 bg-surface-200 rounded w-3/4 mb-3" />
+              <div className="h-16 bg-white rounded mb-3" />
+              <div className="h-4 bg-surface-200 rounded w-1/2" />
             </div>
           ))
         ) : templates?.length === 0 ? (
@@ -215,15 +215,15 @@ export default function AnswerTemplates() {
             <div
               key={template.id}
               className={clsx(
-                'bg-surface-900 border rounded-xl p-5 cursor-pointer transition-all hover:border-surface-600',
+                'bg-white border rounded-xl p-5 cursor-pointer transition-all hover:border-surface-300',
                 selectedTemplate?.id === template.id
                   ? 'border-brand-500 ring-2 ring-brand-500/20'
-                  : 'border-surface-800'
+                  : 'border-surface-200'
               )}
               onClick={() => setSelectedTemplate(template)}
             >
               <div className="flex items-start justify-between mb-3">
-                <h3 className="font-semibold text-surface-100 truncate flex-1">{template.title}</h3>
+                <h3 className="font-semibold text-surface-900 truncate flex-1">{template.title}</h3>
                 <span
                   className={clsx(
                     'px-2 py-0.5 text-xs rounded-full ml-2',
@@ -264,12 +264,12 @@ export default function AnswerTemplates() {
       </div>
       {/* Template Detail Panel */}
       {selectedTemplate && (
-        <div className="fixed inset-y-0 right-0 w-full max-w-lg bg-surface-900 border-l border-surface-700 shadow-xl z-40 overflow-y-auto">
-          <div className="sticky top-0 bg-surface-900 border-b border-surface-700 px-6 py-4 flex items-center justify-between">
-            <h2 className="text-lg font-semibold text-surface-100">Template Details</h2>
+        <div className="fixed inset-y-0 right-0 w-full max-w-lg bg-white border-l border-surface-200 shadow-xl z-40 overflow-y-auto">
+          <div className="sticky top-0 bg-white border-b border-surface-200 px-6 py-4 flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-surface-900">Template Details</h2>
             <button
               onClick={() => setSelectedTemplate(null)}
-              className="p-2 text-surface-600 hover:text-surface-200 rounded-lg hover:bg-surface-800"
+              className="p-2 text-surface-600 hover:text-surface-800 rounded-lg hover:bg-white"
             >
               <XMarkIcon className="w-5 h-5" />
             </button>
@@ -278,7 +278,7 @@ export default function AnswerTemplates() {
           <div className="p-6 space-y-6">
             <div>
               <div className="flex items-center justify-between mb-2">
-                <h3 className="text-xl font-semibold text-surface-100">{selectedTemplate.title}</h3>
+                <h3 className="text-xl font-semibold text-surface-900">{selectedTemplate.title}</h3>
                 <span
                   className={clsx(
                     'px-2 py-1 text-xs rounded-full',
@@ -292,7 +292,7 @@ export default function AnswerTemplates() {
 
             <div>
               <label className="block text-sm font-medium text-surface-600 mb-2">Content</label>
-              <div className="bg-surface-800 rounded-lg p-4 text-sm text-surface-200 whitespace-pre-wrap font-mono">
+              <div className="bg-white rounded-lg p-4 text-sm text-surface-800 whitespace-pre-wrap font-mono">
                 {selectedTemplate.content}
               </div>
             </div>
@@ -322,7 +322,7 @@ export default function AnswerTemplates() {
                   {selectedTemplate.tags.map((tag, i) => (
                     <span
                       key={i}
-                      className="px-2 py-1 bg-surface-700 text-surface-700 text-xs rounded"
+                      className="px-2 py-1 bg-surface-200 text-surface-700 text-xs rounded"
                     >
                       {tag}
                     </span>
@@ -334,11 +334,11 @@ export default function AnswerTemplates() {
             <div className="grid grid-cols-2 gap-4 text-sm">
               <div>
                 <label className="text-surface-500">Usage Count</label>
-                <p className="text-surface-200">{selectedTemplate.usageCount}</p>
+                <p className="text-surface-800">{selectedTemplate.usageCount}</p>
               </div>
               <div>
                 <label className="text-surface-500">Last Used</label>
-                <p className="text-surface-200">
+                <p className="text-surface-800">
                   {selectedTemplate.lastUsedAt
                     ? new Date(selectedTemplate.lastUsedAt).toLocaleDateString()
                     : 'Never'}
@@ -346,7 +346,7 @@ export default function AnswerTemplates() {
               </div>
             </div>
 
-            <div className="flex gap-2 pt-4 border-t border-surface-700">
+            <div className="flex gap-2 pt-4 border-t border-surface-200">
               <Button
                 variant="outline"
                 onClick={() => {
@@ -455,13 +455,13 @@ function TemplateModal({
 
   return (
     <Dialog open onClose={onClose}>
-      <div className="sticky top-0 bg-surface-900 border-b border-surface-700 px-6 py-4 flex items-center justify-between">
-        <h2 className="text-lg font-semibold text-surface-100">
+      <div className="sticky top-0 bg-white border-b border-surface-200 px-6 py-4 flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-surface-900">
           {template ? 'Edit Template' : 'Create Template'}
         </h2>
         <button
           onClick={onClose}
-          className="p-2 text-surface-600 hover:text-surface-200 rounded-lg hover:bg-surface-800"
+          className="p-2 text-surface-600 hover:text-surface-800 rounded-lg hover:bg-white"
         >
           <XMarkIcon className="w-5 h-5" />
         </button>
@@ -477,7 +477,7 @@ function TemplateModal({
             required
             value={formData.title}
             onChange={(e) => setFormData((prev) => ({ ...prev, title: e.target.value }))}
-            className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+            className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
             placeholder="e.g., SOC 2 Compliance Response"
           />
         </div>
@@ -487,7 +487,7 @@ function TemplateModal({
           <SelectNative
             value={formData.category}
             onChange={(e) => setFormData((prev) => ({ ...prev, category: e.target.value }))}
-            className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+            className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
           >
             <option value="">Select category...</option>
             {CATEGORIES.map((cat) => (
@@ -511,7 +511,7 @@ function TemplateModal({
             value={formData.content}
             onChange={(e) => setFormData((prev) => ({ ...prev, content: e.target.value }))}
             rows={8}
-            className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500 font-mono text-sm"
+            className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 font-mono text-sm"
             placeholder="Enter template content...
 
 Example:
@@ -543,12 +543,12 @@ Example:
             type="text"
             value={formData.tags}
             onChange={(e) => setFormData((prev) => ({ ...prev, tags: e.target.value }))}
-            className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+            className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
             placeholder="encryption, data-protection, audit (comma-separated)"
           />
         </div>
 
-        <div className="flex justify-end gap-3 pt-4 border-t border-surface-700">
+        <div className="flex justify-end gap-3 pt-4 border-t border-surface-200">
           <Button variant="secondary" type="button" onClick={onClose}>
             Cancel
           </Button>

--- a/frontend/src/pages/AssessmentDetail.tsx
+++ b/frontend/src/pages/AssessmentDetail.tsx
@@ -60,17 +60,17 @@ function AssessmentForm({ assessment, onSave, onCancel }: AssessmentFormProps) {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
-      <div className="bg-surface-900 border border-surface-800 rounded-lg p-6 space-y-6">
+      <div className="bg-white border border-surface-200 rounded-lg p-6 space-y-6">
         {/* Basic Information */}
         <div>
-          <h3 className="text-lg font-medium text-surface-100 mb-4">Basic Information</h3>
+          <h3 className="text-lg font-medium text-surface-900 mb-4">Basic Information</h3>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
               <label className="block text-sm font-medium text-surface-600 mb-1">Vendor *</label>
               <SelectNative
                 value={formData.vendorId}
                 onChange={(e) => setFormData({ ...formData, vendorId: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
                 required
               >
                 <option value="">Select a vendor...</option>
@@ -88,7 +88,7 @@ function AssessmentForm({ assessment, onSave, onCancel }: AssessmentFormProps) {
               <SelectNative
                 value={formData.assessmentType}
                 onChange={(e) => setFormData({ ...formData, assessmentType: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
                 required
               >
                 <option value="initial_onboarding">Initial Onboarding</option>
@@ -103,7 +103,7 @@ function AssessmentForm({ assessment, onSave, onCancel }: AssessmentFormProps) {
               <SelectNative
                 value={formData.status}
                 onChange={(e) => setFormData({ ...formData, status: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
                 required
               >
                 <option value="pending">Pending</option>
@@ -119,7 +119,7 @@ function AssessmentForm({ assessment, onSave, onCancel }: AssessmentFormProps) {
               <SelectNative
                 value={formData.inherentRiskScore || ''}
                 onChange={(e) => setFormData({ ...formData, inherentRiskScore: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               >
                 <option value="">Select risk level...</option>
                 <option value="very_low">Very Low</option>
@@ -134,7 +134,7 @@ function AssessmentForm({ assessment, onSave, onCancel }: AssessmentFormProps) {
 
         {/* Dates */}
         <div>
-          <h3 className="text-lg font-medium text-surface-100 mb-4">Schedule</h3>
+          <h3 className="text-lg font-medium text-surface-900 mb-4">Schedule</h3>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
               <label className="block text-sm font-medium text-surface-600 mb-1">Due Date</label>
@@ -142,7 +142,7 @@ function AssessmentForm({ assessment, onSave, onCancel }: AssessmentFormProps) {
                 type="date"
                 value={formData.dueDate || ''}
                 onChange={(e) => setFormData({ ...formData, dueDate: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               />
             </div>
             <div>
@@ -153,7 +153,7 @@ function AssessmentForm({ assessment, onSave, onCancel }: AssessmentFormProps) {
                 type="date"
                 value={formData.completedAt || ''}
                 onChange={(e) => setFormData({ ...formData, completedAt: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               />
             </div>
           </div>
@@ -161,7 +161,7 @@ function AssessmentForm({ assessment, onSave, onCancel }: AssessmentFormProps) {
 
         {/* Risk Assessment */}
         <div>
-          <h3 className="text-lg font-medium text-surface-100 mb-4">Risk Assessment</h3>
+          <h3 className="text-lg font-medium text-surface-900 mb-4">Risk Assessment</h3>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
               <label className="block text-sm font-medium text-surface-600 mb-1">
@@ -175,7 +175,7 @@ function AssessmentForm({ assessment, onSave, onCancel }: AssessmentFormProps) {
                 onChange={(e) =>
                   setFormData({ ...formData, overallScore: parseInt(e.target.value) || undefined })
                 }
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               />
             </div>
             <div>
@@ -185,7 +185,7 @@ function AssessmentForm({ assessment, onSave, onCancel }: AssessmentFormProps) {
               <SelectNative
                 value={formData.residualRiskScore || ''}
                 onChange={(e) => setFormData({ ...formData, residualRiskScore: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               >
                 <option value="">Select risk level...</option>
                 <option value="very_low">Very Low</option>
@@ -202,7 +202,7 @@ function AssessmentForm({ assessment, onSave, onCancel }: AssessmentFormProps) {
               <SelectNative
                 value={formData.securityRisk || ''}
                 onChange={(e) => setFormData({ ...formData, securityRisk: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               >
                 <option value="">Select risk level...</option>
                 <option value="very_low">Very Low</option>
@@ -219,7 +219,7 @@ function AssessmentForm({ assessment, onSave, onCancel }: AssessmentFormProps) {
               <SelectNative
                 value={formData.complianceRisk || ''}
                 onChange={(e) => setFormData({ ...formData, complianceRisk: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               >
                 <option value="">Select risk level...</option>
                 <option value="very_low">Very Low</option>
@@ -236,7 +236,7 @@ function AssessmentForm({ assessment, onSave, onCancel }: AssessmentFormProps) {
               <SelectNative
                 value={formData.operationalRisk || ''}
                 onChange={(e) => setFormData({ ...formData, operationalRisk: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               >
                 <option value="">Select risk level...</option>
                 <option value="very_low">Very Low</option>
@@ -253,7 +253,7 @@ function AssessmentForm({ assessment, onSave, onCancel }: AssessmentFormProps) {
               <SelectNative
                 value={formData.financialRisk || ''}
                 onChange={(e) => setFormData({ ...formData, financialRisk: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               >
                 <option value="">Select risk level...</option>
                 <option value="very_low">Very Low</option>
@@ -268,14 +268,14 @@ function AssessmentForm({ assessment, onSave, onCancel }: AssessmentFormProps) {
 
         {/* Outcome */}
         <div>
-          <h3 className="text-lg font-medium text-surface-100 mb-4">Assessment Outcome</h3>
+          <h3 className="text-lg font-medium text-surface-900 mb-4">Assessment Outcome</h3>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
               <label className="block text-sm font-medium text-surface-600 mb-1">Outcome</label>
               <SelectNative
                 value={formData.outcome || ''}
                 onChange={(e) => setFormData({ ...formData, outcome: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               >
                 <option value="">Select outcome...</option>
                 <option value="approved">Approved</option>
@@ -292,7 +292,7 @@ function AssessmentForm({ assessment, onSave, onCancel }: AssessmentFormProps) {
                 type="text"
                 value={formData.outcomeNotes || ''}
                 onChange={(e) => setFormData({ ...formData, outcomeNotes: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
                 placeholder="Additional notes about the outcome..."
               />
             </div>
@@ -306,7 +306,7 @@ function AssessmentForm({ assessment, onSave, onCancel }: AssessmentFormProps) {
             value={typeof formData.findings === 'string' ? formData.findings : ''}
             onChange={(e) => setFormData({ ...formData, findings: e.target.value })}
             rows={4}
-            className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+            className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
             placeholder="Document any findings, issues, or concerns discovered during the assessment..."
           />
         </div>
@@ -318,7 +318,7 @@ function AssessmentForm({ assessment, onSave, onCancel }: AssessmentFormProps) {
             value={formData.recommendations || ''}
             onChange={(e) => setFormData({ ...formData, recommendations: e.target.value })}
             rows={4}
-            className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+            className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
             placeholder="Provide recommendations for improvement or remediation..."
           />
         </div>
@@ -328,7 +328,7 @@ function AssessmentForm({ assessment, onSave, onCancel }: AssessmentFormProps) {
         <button
           type="button"
           onClick={onCancel}
-          className="px-4 py-2 text-surface-700 hover:text-surface-100 transition-colors"
+          className="px-4 py-2 text-surface-700 hover:text-surface-900 transition-colors"
         >
           Cancel
         </button>
@@ -354,11 +354,11 @@ function AssessmentView({
 }) {
   return (
     <div className="space-y-6">
-      <div className="bg-surface-900 border border-surface-800 rounded-lg p-6 space-y-6">
+      <div className="bg-white border border-surface-200 rounded-lg p-6 space-y-6">
         {/* Header */}
         <div className="flex items-start justify-between">
           <div>
-            <h2 className="text-2xl font-bold text-surface-100 capitalize">
+            <h2 className="text-2xl font-bold text-surface-900 capitalize">
               {assessment.assessmentType.replace('_', ' ')}
             </h2>
             <p className="mt-1 text-surface-600">{assessment.vendor?.name}</p>
@@ -366,13 +366,13 @@ function AssessmentView({
           <div className="flex items-center gap-2">
             <button
               onClick={onEdit}
-              className="p-2 text-surface-600 hover:text-surface-100 hover:bg-surface-800 rounded-lg transition-colors"
+              className="p-2 text-surface-600 hover:text-surface-900 hover:bg-white rounded-lg transition-colors"
             >
               <PencilIcon className="w-5 h-5" />
             </button>
             <button
               onClick={onDelete}
-              className="p-2 text-red-600 hover:text-red-700 hover:bg-surface-800 rounded-lg transition-colors"
+              className="p-2 text-red-600 hover:text-red-700 hover:bg-white rounded-lg transition-colors"
             >
               <TrashIcon className="w-5 h-5" />
             </button>
@@ -381,15 +381,15 @@ function AssessmentView({
 
         {/* Basic Information */}
         <div>
-          <h3 className="text-lg font-medium text-surface-100 mb-4">Basic Information</h3>
+          <h3 className="text-lg font-medium text-surface-900 mb-4">Basic Information</h3>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div>
               <dt className="text-sm font-medium text-surface-600 mb-1">Vendor</dt>
-              <dd className="text-sm text-surface-100">{assessment.vendor?.name}</dd>
+              <dd className="text-sm text-surface-900">{assessment.vendor?.name}</dd>
             </div>
             <div>
               <dt className="text-sm font-medium text-surface-600 mb-1">Type</dt>
-              <dd className="text-sm text-surface-100 capitalize">
+              <dd className="text-sm text-surface-900 capitalize">
                 {assessment.assessmentType.replace('_', ' ')}
               </dd>
             </div>
@@ -404,7 +404,7 @@ function AssessmentView({
                         ? 'bg-blue-500/20 text-blue-600'
                         : assessment.status === 'pending'
                           ? 'bg-yellow-500/20 text-yellow-600'
-                          : 'bg-surface-700 text-surface-600'
+                          : 'bg-surface-200 text-surface-600'
                   }`}
                 >
                   {assessment.status.replace('_', ' ')}
@@ -414,7 +414,7 @@ function AssessmentView({
             {assessment.inherentRiskScore && (
               <div>
                 <dt className="text-sm font-medium text-surface-600 mb-1">Inherent Risk</dt>
-                <dd className="text-sm text-surface-100 capitalize">
+                <dd className="text-sm text-surface-900 capitalize">
                   {assessment.inherentRiskScore.replace('_', ' ')}
                 </dd>
               </div>
@@ -424,12 +424,12 @@ function AssessmentView({
 
         {/* Schedule */}
         <div>
-          <h3 className="text-lg font-medium text-surface-100 mb-4">Schedule</h3>
+          <h3 className="text-lg font-medium text-surface-900 mb-4">Schedule</h3>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             {assessment.dueDate && (
               <div>
                 <dt className="text-sm font-medium text-surface-600 mb-1">Due Date</dt>
-                <dd className="text-sm text-surface-100">
+                <dd className="text-sm text-surface-900">
                   {new Date(assessment.dueDate).toLocaleDateString()}
                 </dd>
               </div>
@@ -437,7 +437,7 @@ function AssessmentView({
             {assessment.completedAt && (
               <div>
                 <dt className="text-sm font-medium text-surface-600 mb-1">Completed</dt>
-                <dd className="text-sm text-surface-100">
+                <dd className="text-sm text-surface-900">
                   {new Date(assessment.completedAt).toLocaleDateString()}
                 </dd>
               </div>
@@ -452,16 +452,16 @@ function AssessmentView({
           assessment.operationalRisk ||
           assessment.residualRiskScore) && (
           <div>
-            <h3 className="text-lg font-medium text-surface-100 mb-4">Risk Assessment</h3>
+            <h3 className="text-lg font-medium text-surface-900 mb-4">Risk Assessment</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               {assessment.overallScore !== null && assessment.overallScore !== undefined && (
                 <div>
                   <dt className="text-sm font-medium text-surface-600 mb-2">Overall Score</dt>
                   <dd className="flex items-center gap-3">
-                    <span className="text-2xl font-bold text-surface-100">
+                    <span className="text-2xl font-bold text-surface-900">
                       {assessment.overallScore}
                     </span>
-                    <div className="flex-1 h-3 bg-surface-700 rounded-full overflow-hidden">
+                    <div className="flex-1 h-3 bg-surface-200 rounded-full overflow-hidden">
                       <div
                         className={`h-full ${
                           assessment.overallScore >= 80
@@ -583,7 +583,7 @@ function AssessmentView({
         {/* Outcome */}
         {(assessment.outcome || assessment.outcomeNotes) && (
           <div>
-            <h3 className="text-lg font-medium text-surface-100 mb-4">Outcome</h3>
+            <h3 className="text-lg font-medium text-surface-900 mb-4">Outcome</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               {assessment.outcome && (
                 <div>
@@ -606,7 +606,7 @@ function AssessmentView({
               {assessment.outcomeNotes && (
                 <div>
                   <dt className="text-sm font-medium text-surface-600 mb-1">Notes</dt>
-                  <dd className="text-sm text-surface-100">{assessment.outcomeNotes}</dd>
+                  <dd className="text-sm text-surface-900">{assessment.outcomeNotes}</dd>
                 </div>
               )}
             </div>
@@ -616,7 +616,7 @@ function AssessmentView({
         {/* Findings */}
         {assessment.findings && (
           <div>
-            <h3 className="text-lg font-medium text-surface-100 mb-4">Findings</h3>
+            <h3 className="text-lg font-medium text-surface-900 mb-4">Findings</h3>
             <div className="text-sm text-surface-700 whitespace-pre-wrap">
               {typeof assessment.findings === 'string'
                 ? assessment.findings
@@ -628,7 +628,7 @@ function AssessmentView({
         {/* Recommendations */}
         {assessment.recommendations && (
           <div>
-            <h3 className="text-lg font-medium text-surface-100 mb-4">Recommendations</h3>
+            <h3 className="text-lg font-medium text-surface-900 mb-4">Recommendations</h3>
             <div className="text-sm text-surface-700 whitespace-pre-wrap">
               {assessment.recommendations}
             </div>
@@ -743,12 +743,12 @@ export default function AssessmentDetail() {
       <div className="flex items-center gap-4">
         <button
           onClick={() => navigate('/assessments')}
-          className="p-2 text-surface-600 hover:text-surface-100 hover:bg-surface-800 rounded-lg transition-colors"
+          className="p-2 text-surface-600 hover:text-surface-900 hover:bg-white rounded-lg transition-colors"
         >
           <ArrowLeftIcon className="w-5 h-5" />
         </button>
         <div>
-          <h1 className="text-3xl font-bold text-surface-100">
+          <h1 className="text-3xl font-bold text-surface-900">
             {id === 'new' ? 'New Assessment' : 'Assessment Details'}
           </h1>
           {assessment && (

--- a/frontend/src/pages/Assessments.tsx
+++ b/frontend/src/pages/Assessments.tsx
@@ -33,7 +33,7 @@ export default function Assessments() {
       <div className="space-y-6">
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-3xl font-bold text-surface-100">Vendor Assessments</h1>
+            <h1 className="text-3xl font-bold text-surface-900">Vendor Assessments</h1>
             <p className="mt-1 text-surface-600">Track and manage vendor risk assessments</p>
           </div>
         </div>
@@ -47,7 +47,7 @@ export default function Assessments() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold text-surface-100">Vendor Assessments</h1>
+          <h1 className="text-3xl font-bold text-surface-900">Vendor Assessments</h1>
           <p className="mt-1 text-surface-600">Track and manage vendor risk assessments</p>
         </div>
         <Button
@@ -60,7 +60,7 @@ export default function Assessments() {
 
       {/* Assessments List */}
       {assessments.length === 0 ? (
-        <div className="bg-surface-900 border border-surface-800 rounded-lg p-12 text-center">
+        <div className="bg-white border border-surface-200 rounded-lg p-12 text-center">
           <DocumentCheckIcon className="w-12 h-12 text-surface-600 mx-auto mb-4" />
           <h3 className="text-lg font-medium text-surface-700 mb-2">No assessments yet</h3>
           <p className="text-surface-500 mb-6">
@@ -74,9 +74,9 @@ export default function Assessments() {
           </Button>
         </div>
       ) : (
-        <div className="bg-surface-900 border border-surface-800 rounded-lg overflow-hidden">
+        <div className="bg-white border border-surface-200 rounded-lg overflow-hidden">
           <table className="w-full">
-            <thead className="bg-surface-800 border-b border-surface-700">
+            <thead className="bg-white border-b border-surface-200">
               <tr>
                 <th className="px-6 py-3 text-left text-xs font-medium text-surface-600 uppercase tracking-wider">
                   Vendor
@@ -95,14 +95,14 @@ export default function Assessments() {
                 </th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-surface-800">
+            <tbody className="divide-y divide-surface-200">
               {assessments.map((assessment) => (
                 <tr
                   key={assessment.id}
                   onClick={() => navigate(`/assessments/${assessment.id}`)}
-                  className="hover:bg-surface-800 cursor-pointer transition-colors"
+                  className="hover:bg-white cursor-pointer transition-colors"
                 >
-                  <td className="px-6 py-4 text-sm font-medium text-surface-100">
+                  <td className="px-6 py-4 text-sm font-medium text-surface-900">
                     {assessment.vendor?.name}
                   </td>
                   <td className="px-6 py-4 text-sm text-surface-700 capitalize">
@@ -117,7 +117,7 @@ export default function Assessments() {
                             ? 'bg-blue-500/20 text-blue-600'
                             : assessment.status === 'pending'
                               ? 'bg-yellow-500/20 text-yellow-600'
-                              : 'bg-surface-700 text-surface-600'
+                              : 'bg-surface-200 text-surface-600'
                       }`}
                     >
                       {assessment.status.replace('_', ' ')}
@@ -126,10 +126,10 @@ export default function Assessments() {
                   <td className="px-6 py-4">
                     {assessment.overallScore !== null && assessment.overallScore !== undefined ? (
                       <div className="flex items-center gap-2">
-                        <span className="text-sm font-medium text-surface-100">
+                        <span className="text-sm font-medium text-surface-900">
                           {assessment.overallScore}
                         </span>
-                        <div className="w-16 h-2 bg-surface-700 rounded-full overflow-hidden">
+                        <div className="w-16 h-2 bg-surface-200 rounded-full overflow-hidden">
                           <div
                             className={`h-full ${
                               assessment.overallScore >= 80

--- a/frontend/src/pages/AssetDetail.tsx
+++ b/frontend/src/pages/AssetDetail.tsx
@@ -208,7 +208,7 @@ export default function AssetDetail() {
         <div className="flex items-center gap-4">
           <button
             onClick={() => navigate('/assets')}
-            className="p-2 hover:bg-surface-700 rounded-lg text-surface-600"
+            className="p-2 hover:bg-surface-200 rounded-lg text-surface-600"
           >
             <ArrowLeft className="w-5 h-5" />
           </button>
@@ -254,11 +254,11 @@ export default function AssetDetail() {
       {/* Asset Details */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Main Info */}
-        <div className="lg:col-span-2 bg-surface-800 rounded-xl border border-surface-700 p-6 space-y-6">
+        <div className="lg:col-span-2 bg-white rounded-xl border border-surface-200 p-6 space-y-6">
           {asset.description && (
             <div>
               <h3 className="text-sm font-medium text-surface-600 mb-2">Description</h3>
-              <p className="text-surface-200">{asset.description}</p>
+              <p className="text-surface-800">{asset.description}</p>
             </div>
           )}
 
@@ -311,9 +311,9 @@ export default function AssetDetail() {
 
           {/* Metadata */}
           {asset.metadata && Object.keys(asset.metadata).length > 0 && (
-            <div className="border-t border-surface-700 pt-6">
+            <div className="border-t border-surface-200 pt-6">
               <h3 className="text-sm font-medium text-surface-600 mb-3">Additional Metadata</h3>
-              <div className="bg-surface-700/50 rounded-lg p-4">
+              <div className="bg-surface-200/50 rounded-lg p-4">
                 <pre className="text-sm text-surface-700 overflow-x-auto">
                   {JSON.stringify(asset.metadata, null, 2)}
                 </pre>
@@ -325,7 +325,7 @@ export default function AssetDetail() {
         {/* Sidebar */}
         <div className="space-y-4">
           {/* Quick Stats */}
-          <div className="bg-surface-800 rounded-xl border border-surface-700 p-6">
+          <div className="bg-white rounded-xl border border-surface-200 p-6">
             <h3 className="text-lg font-medium text-white mb-4">Risk Summary</h3>
             <div className="space-y-3">
               <div className="flex justify-between items-center">
@@ -345,18 +345,18 @@ export default function AssetDetail() {
           </div>
 
           {/* Timestamps */}
-          <div className="bg-surface-800 rounded-xl border border-surface-700 p-6">
+          <div className="bg-white rounded-xl border border-surface-200 p-6">
             <h3 className="text-lg font-medium text-white mb-4">Timeline</h3>
             <div className="space-y-3 text-sm">
               <div className="flex justify-between">
                 <span className="text-surface-600">Created</span>
-                <span className="text-surface-200">
+                <span className="text-surface-800">
                   {new Date(asset.createdAt).toLocaleDateString()}
                 </span>
               </div>
               <div className="flex justify-between">
                 <span className="text-surface-600">Updated</span>
-                <span className="text-surface-200">
+                <span className="text-surface-800">
                   {new Date(asset.updatedAt).toLocaleDateString()}
                 </span>
               </div>
@@ -366,14 +366,14 @@ export default function AssetDetail() {
       </div>
       {/* Associated Risks */}
       {asset.risks && asset.risks.length > 0 && (
-        <div className="bg-surface-800 rounded-xl border border-surface-700 p-6">
+        <div className="bg-white rounded-xl border border-surface-200 p-6">
           <h3 className="text-lg font-medium text-white mb-4">Associated Risks</h3>
           <div className="space-y-2">
             {asset.risks.map((risk) => (
               <div
                 key={risk.id}
                 onClick={() => navigate(`/risks/${risk.id}`)}
-                className="flex items-center justify-between p-4 bg-surface-700 rounded-lg cursor-pointer hover:bg-surface-600 transition-colors"
+                className="flex items-center justify-between p-4 bg-surface-200 rounded-lg cursor-pointer hover:bg-surface-600 transition-colors"
               >
                 <div className="flex items-center gap-4">
                   <span className="text-brand-400 font-mono text-sm">{risk.riskId}</span>
@@ -404,7 +404,7 @@ export default function AssetDetail() {
         </div>
       )}
       {/* BC/DR Information */}
-      <div className="bg-surface-800 rounded-xl border border-surface-700 p-6">
+      <div className="bg-white rounded-xl border border-surface-200 p-6">
         <div className="flex items-center justify-between mb-4">
           <h3 className="text-lg font-medium text-white flex items-center gap-2">
             <ShieldAlert className="w-5 h-5 text-brand-400" />
@@ -472,19 +472,19 @@ export default function AssetDetail() {
           </div>
         </div>
         {(asset as any).recoveryNotes && (
-          <div className="mt-4 pt-4 border-t border-surface-700">
+          <div className="mt-4 pt-4 border-t border-surface-200">
             <h4 className="text-sm font-medium text-surface-600 mb-2">Recovery Notes</h4>
-            <p className="text-surface-200 text-sm">{(asset as any).recoveryNotes}</p>
+            <p className="text-surface-800 text-sm">{(asset as any).recoveryNotes}</p>
           </div>
         )}
       </div>
       {/* Edit Modal */}
       <Dialog open={showEditModal} onClose={() => setShowEditModal(false)}>
-        <div className="p-6 border-b border-surface-700 flex items-center justify-between">
+        <div className="p-6 border-b border-surface-200 flex items-center justify-between">
           <h2 className="text-xl font-semibold text-white">Edit Asset</h2>
           <button
             onClick={() => setShowEditModal(false)}
-            className="p-2 hover:bg-surface-700 rounded-lg text-surface-600"
+            className="p-2 hover:bg-surface-200 rounded-lg text-surface-600"
           >
             <X className="w-5 h-5" />
           </button>
@@ -504,7 +504,7 @@ export default function AssetDetail() {
               value={editForm.name}
               onChange={(e) => setEditForm((prev) => ({ ...prev, name: e.target.value }))}
               required
-              className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+              className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
             />
           </div>
 
@@ -514,7 +514,7 @@ export default function AssetDetail() {
               <SelectNative
                 value={editForm.type}
                 onChange={(e) => setEditForm((prev) => ({ ...prev, type: e.target.value }))}
-                className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+                className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
               >
                 {ASSET_TYPES.map((type) => (
                   <option key={type.value} value={type.value}>
@@ -528,7 +528,7 @@ export default function AssetDetail() {
               <SelectNative
                 value={editForm.status}
                 onChange={(e) => setEditForm((prev) => ({ ...prev, status: e.target.value }))}
-                className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+                className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
               >
                 {STATUSES.map((status) => (
                   <option key={status.value} value={status.value}>
@@ -545,7 +545,7 @@ export default function AssetDetail() {
               <SelectNative
                 value={editForm.criticality}
                 onChange={(e) => setEditForm((prev) => ({ ...prev, criticality: e.target.value }))}
-                className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+                className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
               >
                 {CRITICALITY_LEVELS.map((level) => (
                   <option key={level.value} value={level.value}>
@@ -560,7 +560,7 @@ export default function AssetDetail() {
                 type="text"
                 value={editForm.category}
                 onChange={(e) => setEditForm((prev) => ({ ...prev, category: e.target.value }))}
-                className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+                className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
                 placeholder="e.g., Web Server"
               />
             </div>
@@ -573,7 +573,7 @@ export default function AssetDetail() {
                 type="text"
                 value={editForm.owner}
                 onChange={(e) => setEditForm((prev) => ({ ...prev, owner: e.target.value }))}
-                className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+                className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
               />
             </div>
             <div>
@@ -582,7 +582,7 @@ export default function AssetDetail() {
                 type="text"
                 value={editForm.department}
                 onChange={(e) => setEditForm((prev) => ({ ...prev, department: e.target.value }))}
-                className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+                className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
               />
             </div>
           </div>
@@ -593,7 +593,7 @@ export default function AssetDetail() {
               type="text"
               value={editForm.location}
               onChange={(e) => setEditForm((prev) => ({ ...prev, location: e.target.value }))}
-              className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+              className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
               placeholder="e.g., AWS us-east-1, Office HQ"
             />
           </div>
@@ -604,14 +604,14 @@ export default function AssetDetail() {
               value={editForm.description}
               onChange={(e) => setEditForm((prev) => ({ ...prev, description: e.target.value }))}
               rows={3}
-              className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+              className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
               placeholder="Describe this asset..."
             />
           </div>
 
           {/* BC/DR Fields */}
-          <div className="border-t border-surface-700 pt-4 mt-4">
-            <h4 className="text-sm font-medium text-surface-200 mb-4 flex items-center gap-2">
+          <div className="border-t border-surface-200 pt-4 mt-4">
+            <h4 className="text-sm font-medium text-surface-800 mb-4 flex items-center gap-2">
               <ShieldAlert className="w-4 h-4 text-brand-400" />
               Business Continuity / Disaster Recovery
             </h4>
@@ -631,7 +631,7 @@ export default function AssetDetail() {
                       rtoHours: e.target.value ? parseInt(e.target.value) : undefined,
                     }))
                   }
-                  className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+                  className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
                   placeholder="e.g., 4"
                 />
                 <p className="text-xs text-surface-500 mt-1">Recovery Time Objective</p>
@@ -650,7 +650,7 @@ export default function AssetDetail() {
                       rpoHours: e.target.value ? parseInt(e.target.value) : undefined,
                     }))
                   }
-                  className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+                  className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
                   placeholder="e.g., 1"
                 />
                 <p className="text-xs text-surface-500 mt-1">Recovery Point Objective</p>
@@ -667,7 +667,7 @@ export default function AssetDetail() {
                   onChange={(e) =>
                     setEditForm((prev) => ({ ...prev, bcdrCriticality: e.target.value }))
                   }
-                  className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+                  className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
                 >
                   <option value="">Not set</option>
                   <option value="tier_1_critical">Tier 1 - Critical</option>
@@ -688,17 +688,17 @@ export default function AssetDetail() {
                   setEditForm((prev) => ({ ...prev, recoveryNotes: e.target.value }))
                 }
                 rows={2}
-                className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+                className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
                 placeholder="Notes about recovery procedures for this asset..."
               />
             </div>
           </div>
 
-          <div className="flex justify-end gap-3 pt-4 border-t border-surface-700">
+          <div className="flex justify-end gap-3 pt-4 border-t border-surface-200">
             <button
               type="button"
               onClick={() => setShowEditModal(false)}
-              className="px-4 py-2 bg-surface-700 text-surface-700 rounded-lg hover:bg-surface-600"
+              className="px-4 py-2 bg-surface-200 text-surface-700 rounded-lg hover:bg-surface-600"
             >
               Cancel
             </button>
@@ -721,7 +721,7 @@ export default function AssetDetail() {
         <div className="flex justify-end gap-2">
           <button
             onClick={() => setShowDeleteConfirm(false)}
-            className="px-4 py-2 bg-surface-700 text-surface-700 rounded-lg hover:bg-surface-600"
+            className="px-4 py-2 bg-surface-200 text-surface-700 rounded-lg hover:bg-surface-600"
           >
             Cancel
           </button>

--- a/frontend/src/pages/Assets.tsx
+++ b/frontend/src/pages/Assets.tsx
@@ -206,7 +206,7 @@ export default function Assets() {
       {/* Stats Cards */}
       {stats && (
         <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-          <div className="bg-surface-800 rounded-xl border border-surface-700 p-4">
+          <div className="bg-white rounded-xl border border-surface-200 p-4">
             <div className="flex items-center gap-3">
               <div className="p-2 bg-brand-500/20 rounded-lg">
                 <Server className="w-5 h-5 text-brand-400" />
@@ -217,7 +217,7 @@ export default function Assets() {
               </div>
             </div>
           </div>
-          <div className="bg-surface-800 rounded-xl border border-surface-700 p-4">
+          <div className="bg-white rounded-xl border border-surface-200 p-4">
             <div className="flex items-center gap-3">
               <div className="p-2 bg-emerald-500/20 rounded-lg">
                 <CheckCircle className="w-5 h-5 text-emerald-600" />
@@ -230,7 +230,7 @@ export default function Assets() {
               </div>
             </div>
           </div>
-          <div className="bg-surface-800 rounded-xl border border-surface-700 p-4">
+          <div className="bg-white rounded-xl border border-surface-200 p-4">
             <div className="flex items-center gap-3">
               <div className="p-2 bg-red-500/20 rounded-lg">
                 <AlertTriangle className="w-5 h-5 text-red-600" />
@@ -243,7 +243,7 @@ export default function Assets() {
               </div>
             </div>
           </div>
-          <div className="bg-surface-800 rounded-xl border border-surface-700 p-4">
+          <div className="bg-white rounded-xl border border-surface-200 p-4">
             <div className="flex items-center gap-3">
               <div className="p-2 bg-amber-500/20 rounded-lg">
                 <RefreshCw className="w-5 h-5 text-amber-600" />
@@ -257,7 +257,7 @@ export default function Assets() {
         </div>
       )}
       {/* Search and Filters */}
-      <div className="bg-surface-800 rounded-xl border border-surface-700 p-4">
+      <div className="bg-white rounded-xl border border-surface-200 p-4">
         <div className="flex flex-col lg:flex-row gap-4">
           {/* Search */}
           <div className="flex-1 relative">
@@ -267,7 +267,7 @@ export default function Assets() {
               placeholder="Search assets..."
               value={filters.search}
               onChange={(e) => updateFilter('search', e.target.value)}
-              className="w-full pl-10 pr-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white placeholder-surface-400 focus:outline-none focus:ring-2 focus:ring-brand-500"
+              className="w-full pl-10 pr-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white placeholder-surface-500 focus:outline-none focus:ring-2 focus:ring-brand-500"
             />
           </div>
 
@@ -276,7 +276,7 @@ export default function Assets() {
             <SelectNative
               value={filters.source}
               onChange={(e) => updateFilter('source', e.target.value)}
-              className="px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+              className="px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
             >
               <option value="">All Sources</option>
               {sources?.map((source: string) => (
@@ -289,7 +289,7 @@ export default function Assets() {
             <SelectNative
               value={filters.type}
               onChange={(e) => updateFilter('type', e.target.value)}
-              className="px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+              className="px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
             >
               <option value="">All Types</option>
               {ASSET_TYPES.map((type) => (
@@ -302,7 +302,7 @@ export default function Assets() {
             <SelectNative
               value={filters.criticality}
               onChange={(e) => updateFilter('criticality', e.target.value)}
-              className="px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+              className="px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
             >
               <option value="">All Criticality</option>
               {CRITICALITY_LEVELS.map((level) => (
@@ -315,7 +315,7 @@ export default function Assets() {
             <SelectNative
               value={filters.status}
               onChange={(e) => updateFilter('status', e.target.value)}
-              className="px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+              className="px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
             >
               <option value="">All Statuses</option>
               {STATUSES.map((status) => (
@@ -328,7 +328,7 @@ export default function Assets() {
         </div>
       </div>
       {/* Assets Table */}
-      <div className="bg-surface-800 rounded-xl border border-surface-700 overflow-hidden">
+      <div className="bg-white rounded-xl border border-surface-200 overflow-hidden">
         {isLoading ? (
           <SkeletonTable rows={10} columns={7} className="border-none" />
         ) : data?.assets.length === 0 ? (
@@ -342,7 +342,7 @@ export default function Assets() {
         ) : (
           <table className="w-full">
             <thead>
-              <tr className="border-b border-surface-700">
+              <tr className="border-b border-surface-200">
                 <th className="text-left px-4 py-3 text-sm font-medium text-surface-600">Asset</th>
                 <th className="text-left px-4 py-3 text-sm font-medium text-surface-600">Type</th>
                 <th className="text-left px-4 py-3 text-sm font-medium text-surface-600">Source</th>
@@ -363,7 +363,7 @@ export default function Assets() {
                 <tr
                   key={asset.id}
                   onClick={() => navigate(`/assets/${asset.id}`)}
-                  className="border-b border-surface-700 hover:bg-surface-700/50 cursor-pointer transition-colors"
+                  className="border-b border-surface-200 hover:bg-surface-200/50 cursor-pointer transition-colors"
                 >
                   <td className="px-4 py-3">
                     <div className="flex items-center gap-3">
@@ -421,7 +421,7 @@ export default function Assets() {
 
         {/* Pagination */}
         {data && data.total > 25 && (
-          <div className="px-4 py-3 border-t border-surface-700 flex items-center justify-between">
+          <div className="px-4 py-3 border-t border-surface-200 flex items-center justify-between">
             <p className="text-sm text-surface-600">
               Showing {(filters.page - 1) * 25 + 1} to {Math.min(filters.page * 25, data.total)} of{' '}
               {data.total} assets
@@ -430,14 +430,14 @@ export default function Assets() {
               <button
                 onClick={() => updateFilter('page', String(filters.page - 1))}
                 disabled={filters.page === 1}
-                className="px-3 py-1 bg-surface-700 rounded text-surface-700 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-surface-600"
+                className="px-3 py-1 bg-surface-200 rounded text-surface-700 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-surface-600"
               >
                 Previous
               </button>
               <button
                 onClick={() => updateFilter('page', String(filters.page + 1))}
                 disabled={filters.page * 25 >= data.total}
-                className="px-3 py-1 bg-surface-700 rounded text-surface-700 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-surface-600"
+                className="px-3 py-1 bg-surface-200 rounded text-surface-700 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-surface-600"
               >
                 Next
               </button>
@@ -485,9 +485,9 @@ function CreateAssetModal({
 }) {
   return (
     <Dialog open onClose={onClose}>
-      <div className="p-4 border-b border-surface-700 flex justify-between items-center">
+      <div className="p-4 border-b border-surface-200 flex justify-between items-center">
         <h3 className="text-lg font-medium text-white">Add Manual Asset</h3>
-        <button onClick={onClose} className="p-1 hover:bg-surface-700 rounded">
+        <button onClick={onClose} className="p-1 hover:bg-surface-200 rounded">
           <X className="w-5 h-5 text-surface-600" />
         </button>
       </div>
@@ -505,7 +505,7 @@ function CreateAssetModal({
             value={asset.name}
             onChange={(e) => onChange({ ...asset, name: e.target.value })}
             required
-            className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+            className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
             placeholder="e.g., Production Server 1"
           />
         </div>
@@ -515,7 +515,7 @@ function CreateAssetModal({
             <SelectNative
               value={asset.type}
               onChange={(e) => onChange({ ...asset, type: e.target.value })}
-              className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+              className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
             >
               {ASSET_TYPES.map((type) => (
                 <option key={type.value} value={type.value}>
@@ -529,7 +529,7 @@ function CreateAssetModal({
             <SelectNative
               value={asset.criticality}
               onChange={(e) => onChange({ ...asset, criticality: e.target.value })}
-              className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+              className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
             >
               {CRITICALITY_LEVELS.map((level) => (
                 <option key={level.value} value={level.value}>
@@ -545,7 +545,7 @@ function CreateAssetModal({
             type="text"
             value={asset.category}
             onChange={(e) => onChange({ ...asset, category: e.target.value })}
-            className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+            className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
             placeholder="e.g., Web Server, Database"
           />
         </div>
@@ -556,7 +556,7 @@ function CreateAssetModal({
               type="text"
               value={asset.owner}
               onChange={(e) => onChange({ ...asset, owner: e.target.value })}
-              className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+              className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
             />
           </div>
           <div>
@@ -565,7 +565,7 @@ function CreateAssetModal({
               type="text"
               value={asset.department}
               onChange={(e) => onChange({ ...asset, department: e.target.value })}
-              className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+              className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
             />
           </div>
         </div>
@@ -575,7 +575,7 @@ function CreateAssetModal({
             type="text"
             value={asset.location}
             onChange={(e) => onChange({ ...asset, location: e.target.value })}
-            className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+            className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
             placeholder="e.g., AWS us-east-1, Office HQ"
           />
         </div>
@@ -621,9 +621,9 @@ function SyncAssetModal({ onClose, onSuccess }: { onClose: () => void; onSuccess
 
   return (
     <Dialog open onClose={onClose}>
-      <div className="p-4 border-b border-surface-700 flex justify-between items-center">
+      <div className="p-4 border-b border-surface-200 flex justify-between items-center">
         <h3 className="text-lg font-medium text-white">Sync Assets from Integration</h3>
-        <button onClick={onClose} className="p-1 hover:bg-surface-700 rounded">
+        <button onClick={onClose} className="p-1 hover:bg-surface-200 rounded">
           <X className="w-5 h-5 text-surface-600" />
         </button>
       </div>
@@ -677,7 +677,7 @@ function SyncAssetModal({ onClose, onSuccess }: { onClose: () => void; onSuccess
                       className={`flex items-center gap-3 p-3 rounded-lg cursor-pointer ${
                         selectedIntegration === integration.id
                           ? 'bg-brand-500/20 border border-brand-500'
-                          : 'bg-surface-700 border border-surface-600 hover:bg-surface-600'
+                          : 'bg-surface-200 border border-surface-300 hover:bg-surface-600'
                       }`}
                     >
                       <input
@@ -700,7 +700,7 @@ function SyncAssetModal({ onClose, onSuccess }: { onClose: () => void; onSuccess
             <div className="flex justify-end gap-3 pt-2">
               <button
                 onClick={onClose}
-                className="px-4 py-2 bg-surface-700 text-surface-700 rounded-lg"
+                className="px-4 py-2 bg-surface-200 text-surface-700 rounded-lg"
               >
                 Cancel
               </button>

--- a/frontend/src/pages/AuditAnalytics.tsx
+++ b/frontend/src/pages/AuditAnalytics.tsx
@@ -55,7 +55,7 @@ function StatCard({
   color?: string;
 }) {
   return (
-    <div className="bg-surface-800 rounded-lg p-6 border border-surface-700">
+    <div className="bg-white rounded-lg p-6 border border-surface-200">
       <div className="flex items-center justify-between">
         <div>
           <p className="text-surface-600 text-sm">{title}</p>
@@ -63,7 +63,7 @@ function StatCard({
           {trend && <p className="text-sm text-surface-500 mt-1">{trend}</p>}
         </div>
         <div
-          className={`p-3 rounded-lg ${color ? 'bg-opacity-10' : 'bg-surface-700'}`}
+          className={`p-3 rounded-lg ${color ? 'bg-opacity-10' : 'bg-surface-200'}`}
           style={{ backgroundColor: color ? `${color}20` : undefined }}
         >
           <Icon className="h-6 w-6" style={{ color: color || '#9ca3af' }} />
@@ -139,7 +139,7 @@ export default function AuditAnalytics() {
       {/* Charts Row */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Findings by Severity */}
-        <div className="bg-surface-800 rounded-lg p-6 border border-surface-700">
+        <div className="bg-white rounded-lg p-6 border border-surface-200">
           <h3 className="text-lg font-semibold text-white mb-4">Findings by Severity</h3>
           <div className="h-64">
             <LazyRechartsWrapper height={256}>
@@ -179,7 +179,7 @@ export default function AuditAnalytics() {
         </div>
 
         {/* Findings Trend */}
-        <div className="bg-surface-800 rounded-lg p-6 border border-surface-700">
+        <div className="bg-white rounded-lg p-6 border border-surface-200">
           <h3 className="text-lg font-semibold text-white mb-4">Findings Trend</h3>
           <div className="h-64">
             <LazyRechartsWrapper height={256}>
@@ -211,7 +211,7 @@ export default function AuditAnalytics() {
       {/* Additional Metrics */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Avg Remediation Time */}
-        <div className="bg-surface-800 rounded-lg p-6 border border-surface-700">
+        <div className="bg-white rounded-lg p-6 border border-surface-200">
           <div className="flex items-center gap-3 mb-4">
             <ClockIcon className="h-6 w-6 text-brand-400" />
             <h3 className="text-lg font-semibold text-white">Avg Remediation Time</h3>
@@ -223,7 +223,7 @@ export default function AuditAnalytics() {
         </div>
 
         {/* Completion Rate */}
-        <div className="bg-surface-800 rounded-lg p-6 border border-surface-700">
+        <div className="bg-white rounded-lg p-6 border border-surface-200">
           <div className="flex items-center gap-3 mb-4">
             <CheckCircleIcon className="h-6 w-6 text-green-600" />
             <h3 className="text-lg font-semibold text-white">Audit Completion Rate</h3>
@@ -237,7 +237,7 @@ export default function AuditAnalytics() {
         </div>
 
         {/* Request Status */}
-        <div className="bg-surface-800 rounded-lg p-6 border border-surface-700">
+        <div className="bg-white rounded-lg p-6 border border-surface-200">
           <div className="flex items-center gap-3 mb-4">
             <DocumentMagnifyingGlassIcon className="h-6 w-6 text-blue-600" />
             <h3 className="text-lg font-semibold text-white">Request Completion</h3>
@@ -255,7 +255,7 @@ export default function AuditAnalytics() {
       </div>
 
       {/* Findings by Category */}
-      <div className="bg-surface-800 rounded-lg p-6 border border-surface-700">
+      <div className="bg-white rounded-lg p-6 border border-surface-200">
         <h3 className="text-lg font-semibold text-white mb-4">Findings by Category</h3>
         <div className="h-64">
           <LazyRechartsWrapper height={256}>

--- a/frontend/src/pages/AuditCalendar.tsx
+++ b/frontend/src/pages/AuditCalendar.tsx
@@ -32,7 +32,7 @@ const riskColors: Record<string, string> = {
 };
 
 const statusColors: Record<string, string> = {
-  planned: 'bg-surface-700 text-surface-700',
+  planned: 'bg-surface-200 text-surface-700',
   scheduled: 'bg-blue-500/20 text-blue-600',
   in_progress: 'bg-purple-500/20 text-purple-600',
   completed: 'bg-green-500/20 text-green-600',
@@ -114,7 +114,7 @@ export default function AuditCalendar() {
 
       {/* Capacity Overview */}
       {capacity && (
-        <div className="bg-surface-800 rounded-lg p-4 border border-surface-700">
+        <div className="bg-white rounded-lg p-4 border border-surface-200">
           <h3 className="text-sm font-medium text-surface-600 mb-2">
             {currentYear} Capacity Overview
           </h3>
@@ -129,7 +129,7 @@ export default function AuditCalendar() {
               );
             })}
           </div>
-          <div className="mt-3 pt-3 border-t border-surface-700 flex justify-between text-sm">
+          <div className="mt-3 pt-3 border-t border-surface-200 flex justify-between text-sm">
             <span className="text-surface-600">
               Total: <span className="text-white font-medium">{capacity.totalHours}h</span>
             </span>
@@ -142,15 +142,15 @@ export default function AuditCalendar() {
 
       {/* Calendar Grid */}
       {isLoading ? (
-        <div className="animate-pulse bg-surface-800 rounded-lg h-96" />
+        <div className="animate-pulse bg-white rounded-lg h-96" />
       ) : (
-        <div className="bg-surface-800 rounded-lg border border-surface-700 overflow-hidden">
+        <div className="bg-white rounded-lg border border-surface-200 overflow-hidden">
           {/* Year Headers */}
-          <div className="grid grid-cols-3 border-b border-surface-700">
+          <div className="grid grid-cols-3 border-b border-surface-200">
             {years.map((year) => (
               <div
                 key={year}
-                className="text-center py-3 text-lg font-semibold text-white border-r border-surface-700 last:border-r-0"
+                className="text-center py-3 text-lg font-semibold text-white border-r border-surface-200 last:border-r-0"
               >
                 {year}
               </div>
@@ -161,14 +161,14 @@ export default function AuditCalendar() {
           {[1, 2, 3, 4].map((quarter) => (
             <div
               key={quarter}
-              className="grid grid-cols-3 border-b border-surface-700 last:border-b-0"
+              className="grid grid-cols-3 border-b border-surface-200 last:border-b-0"
             >
               {years.map((year) => {
                 const entries = calendarData?.[year]?.[quarter] || [];
                 return (
                   <div
                     key={`${year}-${quarter}`}
-                    className="min-h-32 p-3 border-r border-surface-700 last:border-r-0"
+                    className="min-h-32 p-3 border-r border-surface-200 last:border-r-0"
                   >
                     <div className="text-xs font-medium text-surface-500 mb-2">Q{quarter}</div>
                     <div className="space-y-2">
@@ -178,7 +178,7 @@ export default function AuditCalendar() {
                           className={clsx(
                             'p-2 rounded-md border text-sm cursor-pointer hover:opacity-80 transition-opacity',
                             riskColors[entry.riskRating] ||
-                              'bg-surface-700 border-surface-600 text-surface-700'
+                              'bg-surface-200 border-surface-300 text-surface-700'
                           )}
                         >
                           <div className="flex items-center justify-between">

--- a/frontend/src/pages/AuditDetail.tsx
+++ b/frontend/src/pages/AuditDetail.tsx
@@ -222,7 +222,7 @@ export default function AuditDetail() {
         <div className="flex items-center gap-4">
           <button
             onClick={() => navigate('/audits')}
-            className="p-2 hover:bg-surface-700 rounded-lg text-surface-600 hover:text-white transition-colors"
+            className="p-2 hover:bg-surface-200 rounded-lg text-surface-600 hover:text-white transition-colors"
           >
             <ArrowLeftIcon className="w-5 h-5" />
           </button>
@@ -285,13 +285,13 @@ export default function AuditDetail() {
       </div>
       {/* Status and Key Info */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-        <div className="bg-surface-800 rounded-lg border border-surface-700 p-4">
+        <div className="bg-white rounded-lg border border-surface-200 p-4">
           <p className="text-surface-600 text-sm mb-1">Status</p>
           {isEditing ? (
             <SelectNative
               value={editForm.status}
               onChange={(e) => setEditForm({ ...editForm, status: e.target.value })}
-              className="w-full bg-surface-700 border border-surface-600 rounded-md px-3 py-2 text-white"
+              className="w-full bg-surface-200 border border-surface-300 rounded-md px-3 py-2 text-white"
             >
               {Object.entries(STATUS_CONFIG).map(([value, { label }]) => (
                 <option key={value} value={value}>
@@ -311,19 +311,19 @@ export default function AuditDetail() {
             </span>
           )}
         </div>
-        <div className="bg-surface-800 rounded-lg border border-surface-700 p-4">
+        <div className="bg-white rounded-lg border border-surface-200 p-4">
           <p className="text-surface-600 text-sm mb-1">Start Date</p>
           <p className="text-white font-medium">
             {audit?.plannedStartDate ? new Date(audit.plannedStartDate).toLocaleDateString() : '—'}
           </p>
         </div>
-        <div className="bg-surface-800 rounded-lg border border-surface-700 p-4">
+        <div className="bg-white rounded-lg border border-surface-200 p-4">
           <p className="text-surface-600 text-sm mb-1">End Date</p>
           <p className="text-white font-medium">
             {audit?.plannedEndDate ? new Date(audit.plannedEndDate).toLocaleDateString() : '—'}
           </p>
         </div>
-        <div className="bg-surface-800 rounded-lg border border-surface-700 p-4">
+        <div className="bg-white rounded-lg border border-surface-200 p-4">
           <p className="text-surface-600 text-sm mb-1">Findings</p>
           <p className="text-white font-medium">
             {audit?._count?.findings || findingsArray.length}
@@ -332,14 +332,14 @@ export default function AuditDetail() {
       </div>
       {/* Description */}
       {(audit?.description || isEditing) && (
-        <div className="bg-surface-800 rounded-lg border border-surface-700 p-6">
+        <div className="bg-white rounded-lg border border-surface-200 p-6">
           <h2 className="text-lg font-semibold text-white mb-4">Description</h2>
           {isEditing ? (
             <Textarea
               value={editForm.description || ''}
               onChange={(e) => setEditForm({ ...editForm, description: e.target.value })}
               rows={4}
-              className="w-full bg-surface-700 border border-surface-600 rounded-md px-3 py-2 text-white"
+              className="w-full bg-surface-200 border border-surface-300 rounded-md px-3 py-2 text-white"
               placeholder="Audit description..."
             />
           ) : (
@@ -350,7 +350,7 @@ export default function AuditDetail() {
       {/* Two Column Layout */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Findings */}
-        <div className="bg-surface-800 rounded-lg border border-surface-700 p-6">
+        <div className="bg-white rounded-lg border border-surface-200 p-6">
           <div className="flex items-center justify-between mb-4">
             <h2 className="text-lg font-semibold text-white">Findings</h2>
             <Link
@@ -370,7 +370,7 @@ export default function AuditDetail() {
               {findingsArray.slice(0, 5).map((finding) => (
                 <div
                   key={finding.id}
-                  className="flex items-center justify-between p-3 bg-surface-700/50 rounded-lg"
+                  className="flex items-center justify-between p-3 bg-surface-200/50 rounded-lg"
                 >
                   <div>
                     <p className="text-white font-medium">{finding.title}</p>
@@ -397,7 +397,7 @@ export default function AuditDetail() {
         </div>
 
         {/* Requests */}
-        <div className="bg-surface-800 rounded-lg border border-surface-700 p-6">
+        <div className="bg-white rounded-lg border border-surface-200 p-6">
           <div className="flex items-center justify-between mb-4">
             <h2 className="text-lg font-semibold text-white">Evidence Requests</h2>
             <Link
@@ -417,7 +417,7 @@ export default function AuditDetail() {
               {requestsArray.slice(0, 5).map((request) => (
                 <div
                   key={request.id}
-                  className="flex items-center justify-between p-3 bg-surface-700/50 rounded-lg"
+                  className="flex items-center justify-between p-3 bg-surface-200/50 rounded-lg"
                 >
                   <div>
                     <p className="text-white font-medium">{request.title}</p>
@@ -444,24 +444,24 @@ export default function AuditDetail() {
       {/* Stats Grid - only show for existing audits */}
       {!isNewAudit && audit && (
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-          <div className="bg-surface-800 rounded-lg border border-surface-700 p-4 text-center">
+          <div className="bg-white rounded-lg border border-surface-200 p-4 text-center">
             <ClipboardDocumentListIcon className="w-8 h-8 mx-auto mb-2 text-blue-600" />
             <p className="text-2xl font-bold text-white">
               {audit._count?.requests || requestsArray.length}
             </p>
             <p className="text-surface-600 text-sm">Requests</p>
           </div>
-          <div className="bg-surface-800 rounded-lg border border-surface-700 p-4 text-center">
+          <div className="bg-white rounded-lg border border-surface-200 p-4 text-center">
             <DocumentTextIcon className="w-8 h-8 mx-auto mb-2 text-purple-600" />
             <p className="text-2xl font-bold text-white">{audit._count?.evidence || 0}</p>
             <p className="text-surface-600 text-sm">Evidence</p>
           </div>
-          <div className="bg-surface-800 rounded-lg border border-surface-700 p-4 text-center">
+          <div className="bg-white rounded-lg border border-surface-200 p-4 text-center">
             <CheckCircleIcon className="w-8 h-8 mx-auto mb-2 text-green-600" />
             <p className="text-2xl font-bold text-white">{audit._count?.testResults || 0}</p>
             <p className="text-surface-600 text-sm">Tests</p>
           </div>
-          <div className="bg-surface-800 rounded-lg border border-surface-700 p-4 text-center">
+          <div className="bg-white rounded-lg border border-surface-200 p-4 text-center">
             <ExclamationTriangleIcon className="w-8 h-8 mx-auto mb-2 text-orange-600" />
             <p className="text-2xl font-bold text-white">
               {audit._count?.findings || findingsArray.length}

--- a/frontend/src/pages/AuditFindings.tsx
+++ b/frontend/src/pages/AuditFindings.tsx
@@ -252,22 +252,22 @@ export default function AuditFindings() {
       {/* Stats Cards */}
       {statsData && (
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-          <div className="bg-surface-800 rounded-lg p-4 border border-surface-700">
+          <div className="bg-white rounded-lg p-4 border border-surface-200">
             <p className="text-surface-600 text-sm">Total Findings</p>
             <p className="text-2xl font-bold text-white mt-1">{statsData.total}</p>
           </div>
-          <div className="bg-surface-800 rounded-lg p-4 border border-surface-700">
+          <div className="bg-white rounded-lg p-4 border border-surface-200">
             <p className="text-surface-600 text-sm">Overdue</p>
             <p className="text-2xl font-bold text-red-600 mt-1">{statsData.overdue}</p>
           </div>
-          <div className="bg-surface-800 rounded-lg p-4 border border-surface-700">
+          <div className="bg-white rounded-lg p-4 border border-surface-200">
             <p className="text-surface-600 text-sm">Critical/High</p>
             <p className="text-2xl font-bold text-orange-600 mt-1">
               {(statsData.bySeverity.find((s) => s.severity === 'critical')?.count || 0) +
                 (statsData.bySeverity.find((s) => s.severity === 'high')?.count || 0)}
             </p>
           </div>
-          <div className="bg-surface-800 rounded-lg p-4 border border-surface-700">
+          <div className="bg-white rounded-lg p-4 border border-surface-200">
             <p className="text-surface-600 text-sm">Open</p>
             <p className="text-2xl font-bold text-yellow-600 mt-1">
               {statsData.byStatus.find((s) => s.status === 'open')?.count || 0}
@@ -325,13 +325,13 @@ export default function AuditFindings() {
         )}
       </div>
       {showFilters && (
-        <div className="bg-surface-800 rounded-lg p-4 border border-surface-700 grid grid-cols-1 md:grid-cols-4 gap-4">
+        <div className="bg-white rounded-lg p-4 border border-surface-200 grid grid-cols-1 md:grid-cols-4 gap-4">
           <div>
             <label className="block text-sm font-medium text-surface-700 mb-1">Audit</label>
             <SelectNative
               value={filters.auditId}
               onChange={(e) => setFilter('auditId', e.target.value)}
-              className="w-full bg-surface-700 border border-surface-600 rounded-md px-3 py-2 text-white"
+              className="w-full bg-surface-200 border border-surface-300 rounded-md px-3 py-2 text-white"
             >
               <option value="">All Audits</option>
               {(audits as { id: string; name: string }[])?.map((audit) => (
@@ -346,7 +346,7 @@ export default function AuditFindings() {
             <SelectNative
               value={filters.status}
               onChange={(e) => setFilter('status', e.target.value)}
-              className="w-full bg-surface-700 border border-surface-600 rounded-md px-3 py-2 text-white"
+              className="w-full bg-surface-200 border border-surface-300 rounded-md px-3 py-2 text-white"
             >
               <option value="">All Statuses</option>
               {STATUS_OPTIONS.map((s) => (
@@ -361,7 +361,7 @@ export default function AuditFindings() {
             <SelectNative
               value={filters.severity}
               onChange={(e) => setFilter('severity', e.target.value)}
-              className="w-full bg-surface-700 border border-surface-600 rounded-md px-3 py-2 text-white"
+              className="w-full bg-surface-200 border border-surface-300 rounded-md px-3 py-2 text-white"
             >
               <option value="">All Severities</option>
               {Object.entries(SEVERITY_CONFIG).map(([value, { label }]) => (
@@ -376,7 +376,7 @@ export default function AuditFindings() {
             <SelectNative
               value={filters.category}
               onChange={(e) => setFilter('category', e.target.value)}
-              className="w-full bg-surface-700 border border-surface-600 rounded-md px-3 py-2 text-white"
+              className="w-full bg-surface-200 border border-surface-300 rounded-md px-3 py-2 text-white"
             >
               <option value="">All Categories</option>
               {CATEGORY_OPTIONS.map((c) => (
@@ -402,9 +402,9 @@ export default function AuditFindings() {
           }}
         />
       ) : (
-        <div className="bg-surface-800 rounded-lg border border-surface-700 overflow-hidden">
+        <div className="bg-white rounded-lg border border-surface-200 overflow-hidden">
           <table className="w-full">
-            <thead className="bg-surface-700">
+            <thead className="bg-surface-200">
               <tr>
                 <th className="w-10 px-4 py-3">
                   <SelectCheckbox
@@ -428,7 +428,7 @@ export default function AuditFindings() {
                 <th className="w-10"></th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-surface-700">
+            <tbody className="divide-y divide-surface-200">
               {findingsData.map((finding) => {
                 const severity = SEVERITY_CONFIG[finding.severity] || SEVERITY_CONFIG.medium;
                 const status = STATUS_CONFIG[finding.status] || STATUS_CONFIG.open;
@@ -441,7 +441,7 @@ export default function AuditFindings() {
                 return (
                   <tr
                     key={finding.id}
-                    className="hover:bg-surface-700/50 cursor-pointer"
+                    className="hover:bg-surface-200/50 cursor-pointer"
                     onClick={() => setEditingFinding(finding)}
                   >
                     <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
@@ -607,7 +607,7 @@ function FindingForm({ finding, audits, users, onSubmit, onDelete, isLoading }: 
             value={formData.auditId}
             onChange={(e) => setFormData({ ...formData, auditId: e.target.value })}
             required
-            className="w-full bg-surface-700 border border-surface-600 rounded-md px-3 py-2 text-white"
+            className="w-full bg-surface-200 border border-surface-300 rounded-md px-3 py-2 text-white"
           >
             <option value="">Select Audit</option>
             {audits?.map((audit) => (
@@ -627,7 +627,7 @@ function FindingForm({ finding, audits, users, onSubmit, onDelete, isLoading }: 
             value={formData.title}
             onChange={(e) => setFormData({ ...formData, title: e.target.value })}
             required
-            className="w-full bg-surface-700 border border-surface-600 rounded-md px-3 py-2 text-white"
+            className="w-full bg-surface-200 border border-surface-300 rounded-md px-3 py-2 text-white"
             placeholder="Finding title"
           />
         </div>
@@ -641,7 +641,7 @@ function FindingForm({ finding, audits, users, onSubmit, onDelete, isLoading }: 
             onChange={(e) => setFormData({ ...formData, description: e.target.value })}
             required
             rows={3}
-            className="w-full bg-surface-700 border border-surface-600 rounded-md px-3 py-2 text-white"
+            className="w-full bg-surface-200 border border-surface-300 rounded-md px-3 py-2 text-white"
             placeholder="Detailed description of the finding"
           />
         </div>
@@ -651,7 +651,7 @@ function FindingForm({ finding, audits, users, onSubmit, onDelete, isLoading }: 
           <SelectNative
             value={formData.category}
             onChange={(e) => setFormData({ ...formData, category: e.target.value })}
-            className="w-full bg-surface-700 border border-surface-600 rounded-md px-3 py-2 text-white"
+            className="w-full bg-surface-200 border border-surface-300 rounded-md px-3 py-2 text-white"
           >
             {CATEGORY_OPTIONS.map((c) => (
               <option key={c.value} value={c.value}>
@@ -666,7 +666,7 @@ function FindingForm({ finding, audits, users, onSubmit, onDelete, isLoading }: 
           <SelectNative
             value={formData.severity}
             onChange={(e) => setFormData({ ...formData, severity: e.target.value })}
-            className="w-full bg-surface-700 border border-surface-600 rounded-md px-3 py-2 text-white"
+            className="w-full bg-surface-200 border border-surface-300 rounded-md px-3 py-2 text-white"
           >
             {Object.entries(SEVERITY_CONFIG).map(([value, { label }]) => (
               <option key={value} value={value}>
@@ -682,7 +682,7 @@ function FindingForm({ finding, audits, users, onSubmit, onDelete, isLoading }: 
             <SelectNative
               value={formData.status}
               onChange={(e) => setFormData({ ...formData, status: e.target.value })}
-              className="w-full bg-surface-700 border border-surface-600 rounded-md px-3 py-2 text-white"
+              className="w-full bg-surface-200 border border-surface-300 rounded-md px-3 py-2 text-white"
             >
               {STATUS_OPTIONS.map((s) => (
                 <option key={s.value} value={s.value}>
@@ -699,7 +699,7 @@ function FindingForm({ finding, audits, users, onSubmit, onDelete, isLoading }: 
             type="date"
             value={formData.targetDate}
             onChange={(e) => setFormData({ ...formData, targetDate: e.target.value })}
-            className="w-full bg-surface-700 border border-surface-600 rounded-md px-3 py-2 text-white"
+            className="w-full bg-surface-200 border border-surface-300 rounded-md px-3 py-2 text-white"
           />
         </div>
 
@@ -710,7 +710,7 @@ function FindingForm({ finding, audits, users, onSubmit, onDelete, isLoading }: 
           <SelectNative
             value={formData.remediationOwner}
             onChange={(e) => setFormData({ ...formData, remediationOwner: e.target.value })}
-            className="w-full bg-surface-700 border border-surface-600 rounded-md px-3 py-2 text-white"
+            className="w-full bg-surface-200 border border-surface-300 rounded-md px-3 py-2 text-white"
           >
             <option value="">Select Owner</option>
             {users?.map((user) => (
@@ -727,7 +727,7 @@ function FindingForm({ finding, audits, users, onSubmit, onDelete, isLoading }: 
             value={formData.rootCause}
             onChange={(e) => setFormData({ ...formData, rootCause: e.target.value })}
             rows={2}
-            className="w-full bg-surface-700 border border-surface-600 rounded-md px-3 py-2 text-white"
+            className="w-full bg-surface-200 border border-surface-300 rounded-md px-3 py-2 text-white"
             placeholder="Root cause analysis"
           />
         </div>
@@ -738,7 +738,7 @@ function FindingForm({ finding, audits, users, onSubmit, onDelete, isLoading }: 
             value={formData.impact}
             onChange={(e) => setFormData({ ...formData, impact: e.target.value })}
             rows={2}
-            className="w-full bg-surface-700 border border-surface-600 rounded-md px-3 py-2 text-white"
+            className="w-full bg-surface-200 border border-surface-300 rounded-md px-3 py-2 text-white"
             placeholder="Business impact of this finding"
           />
         </div>
@@ -749,7 +749,7 @@ function FindingForm({ finding, audits, users, onSubmit, onDelete, isLoading }: 
             value={formData.recommendation}
             onChange={(e) => setFormData({ ...formData, recommendation: e.target.value })}
             rows={2}
-            className="w-full bg-surface-700 border border-surface-600 rounded-md px-3 py-2 text-white"
+            className="w-full bg-surface-200 border border-surface-300 rounded-md px-3 py-2 text-white"
             placeholder="Recommended remediation steps"
           />
         </div>
@@ -762,7 +762,7 @@ function FindingForm({ finding, audits, users, onSubmit, onDelete, isLoading }: 
             value={formData.remediationPlan}
             onChange={(e) => setFormData({ ...formData, remediationPlan: e.target.value })}
             rows={2}
-            className="w-full bg-surface-700 border border-surface-600 rounded-md px-3 py-2 text-white"
+            className="w-full bg-surface-200 border border-surface-300 rounded-md px-3 py-2 text-white"
             placeholder="Detailed remediation plan"
           />
         </div>
@@ -776,13 +776,13 @@ function FindingForm({ finding, audits, users, onSubmit, onDelete, isLoading }: 
               value={formData.managementResponse}
               onChange={(e) => setFormData({ ...formData, managementResponse: e.target.value })}
               rows={2}
-              className="w-full bg-surface-700 border border-surface-600 rounded-md px-3 py-2 text-white"
+              className="w-full bg-surface-200 border border-surface-300 rounded-md px-3 py-2 text-white"
               placeholder="Management's response to this finding"
             />
           </div>
         )}
       </div>
-      <div className="flex justify-between pt-4 border-t border-surface-700">
+      <div className="flex justify-between pt-4 border-t border-surface-200">
         {onDelete && (
           <Button type="button" variant="danger" onClick={onDelete}>
             Delete Finding

--- a/frontend/src/pages/AuditLog.tsx
+++ b/frontend/src/pages/AuditLog.tsx
@@ -177,7 +177,7 @@ export default function AuditLog() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-surface-100">Audit Log</h1>
+          <h1 className="text-2xl font-bold text-surface-900">Audit Log</h1>
           <p className="text-surface-600 mt-1">
             Track all actions and changes across your GRC platform
           </p>
@@ -197,13 +197,13 @@ export default function AuditLog() {
         <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
           <div className="card p-4">
             <div className="text-sm text-surface-600">Total Events</div>
-            <div className="text-2xl font-bold text-surface-100 mt-1">
+            <div className="text-2xl font-bold text-surface-900 mt-1">
               {stats.totalLogs?.toLocaleString()}
             </div>
           </div>
           <div className="card p-4">
             <div className="text-sm text-surface-600">Top Action</div>
-            <div className="text-2xl font-bold text-surface-100 mt-1 capitalize">
+            <div className="text-2xl font-bold text-surface-900 mt-1 capitalize">
               {stats.actionBreakdown?.[0]?.action || '-'}
             </div>
             <div className="text-xs text-surface-500">
@@ -212,7 +212,7 @@ export default function AuditLog() {
           </div>
           <div className="card p-4">
             <div className="text-sm text-surface-600">Top Entity Type</div>
-            <div className="text-2xl font-bold text-surface-100 mt-1 capitalize">
+            <div className="text-2xl font-bold text-surface-900 mt-1 capitalize">
               {stats.entityTypeBreakdown?.[0]?.entityType || '-'}
             </div>
             <div className="text-xs text-surface-500">
@@ -221,7 +221,7 @@ export default function AuditLog() {
           </div>
           <div className="card p-4">
             <div className="text-sm text-surface-600">Active Users</div>
-            <div className="text-2xl font-bold text-surface-100 mt-1">
+            <div className="text-2xl font-bold text-surface-900 mt-1">
               {stats.topUsers?.length || 0}
             </div>
           </div>
@@ -268,7 +268,7 @@ export default function AuditLog() {
 
         {/* Expanded Filters */}
         {isFiltersOpen && (
-          <div className="grid grid-cols-1 md:grid-cols-5 gap-4 pt-4 border-t border-surface-800">
+          <div className="grid grid-cols-1 md:grid-cols-5 gap-4 pt-4 border-t border-surface-200">
             {/* Entity Type */}
             <div>
               <label className="block text-sm text-surface-600 mb-1">Entity Type</label>
@@ -348,7 +348,7 @@ export default function AuditLog() {
               <div className="md:col-span-5 flex justify-end">
                 <button
                   onClick={clearFilters}
-                  className="text-sm text-surface-600 hover:text-surface-200 flex items-center gap-1"
+                  className="text-sm text-surface-600 hover:text-surface-800 flex items-center gap-1"
                 >
                   <XMarkIcon className="w-4 h-4" />
                   Clear all filters
@@ -363,7 +363,7 @@ export default function AuditLog() {
         <div className="overflow-x-auto">
           <table className="w-full">
             <thead>
-              <tr className="border-b border-surface-800">
+              <tr className="border-b border-surface-200">
                 <th className="text-left text-sm font-medium text-surface-600 px-4 py-3">
                   Timestamp
                 </th>
@@ -423,7 +423,7 @@ export default function AuditLog() {
                 logs.map((log: any) => {
                   const actionConfig = ACTION_CONFIG[log.action] || {
                     color: 'text-surface-600',
-                    bg: 'bg-surface-800',
+                    bg: 'bg-white',
                   };
                   const EntityIcon = ENTITY_ICONS[log.entityType] || DocumentIcon;
                   const isExpanded = expandedRow === log.id;
@@ -431,12 +431,12 @@ export default function AuditLog() {
                   return (
                     <React.Fragment key={log.id}>
                       <tr
-                        className="border-b border-surface-800/50 hover:bg-surface-800/30 transition-colors cursor-pointer"
+                        className="border-b border-surface-200/50 hover:bg-white/30 transition-colors cursor-pointer"
                         onClick={() => setExpandedRow(isExpanded ? null : log.id)}
                       >
                         <td className="px-4 py-3">
                           <div
-                            className="text-sm text-surface-200"
+                            className="text-sm text-surface-800"
                             title={formatDate(log.timestamp)}
                           >
                             {formatRelativeTime(log.timestamp)}
@@ -444,11 +444,11 @@ export default function AuditLog() {
                         </td>
                         <td className="px-4 py-3">
                           <div className="flex items-center gap-2">
-                            <div className="w-7 h-7 rounded-full bg-surface-700 flex items-center justify-center">
+                            <div className="w-7 h-7 rounded-full bg-surface-200 flex items-center justify-center">
                               <UserIcon className="w-4 h-4 text-surface-600" />
                             </div>
                             <div>
-                              <div className="text-sm text-surface-200">
+                              <div className="text-sm text-surface-800">
                                 {log.userName || 'System'}
                               </div>
                               {log.userEmail && (
@@ -505,7 +505,7 @@ export default function AuditLog() {
 
                       {/* Expanded Details */}
                       {isExpanded && (
-                        <tr className="bg-surface-800/20">
+                        <tr className="bg-white/20">
                           <td colSpan={6} className="px-4 py-4">
                             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                               {/* Left - Details */}
@@ -548,7 +548,7 @@ export default function AuditLog() {
                                     <h4 className="text-sm font-medium text-surface-700">
                                       Changes
                                     </h4>
-                                    <pre className="text-xs text-surface-600 bg-surface-900/50 p-3 rounded-lg overflow-auto max-h-[200px]">
+                                    <pre className="text-xs text-surface-600 bg-white/50 p-3 rounded-lg overflow-auto max-h-[200px]">
                                       {JSON.stringify(log.changes, null, 2)}
                                     </pre>
                                   </>
@@ -558,7 +558,7 @@ export default function AuditLog() {
                                     <h4 className="text-sm font-medium text-surface-700">
                                       Metadata
                                     </h4>
-                                    <pre className="text-xs text-surface-600 bg-surface-900/50 p-3 rounded-lg overflow-auto max-h-[200px]">
+                                    <pre className="text-xs text-surface-600 bg-white/50 p-3 rounded-lg overflow-auto max-h-[200px]">
                                       {JSON.stringify(log.metadata, null, 2)}
                                     </pre>
                                   </>
@@ -578,7 +578,7 @@ export default function AuditLog() {
 
         {/* Pagination */}
         {pagination.pages > 1 && (
-          <div className="flex items-center justify-between px-4 py-3 border-t border-surface-800">
+          <div className="flex items-center justify-between px-4 py-3 border-t border-surface-200">
             <div className="text-sm text-surface-500">
               Showing {(pagination.page - 1) * pagination.limit + 1} to{' '}
               {Math.min(pagination.page * pagination.limit, pagination.total)} of{' '}

--- a/frontend/src/pages/AuditNew.tsx
+++ b/frontend/src/pages/AuditNew.tsx
@@ -140,12 +140,12 @@ export default function AuditNew() {
       <div>
         <Link
           to="/audits"
-          className="inline-flex items-center text-sm text-surface-600 hover:text-surface-100 mb-4"
+          className="inline-flex items-center text-sm text-surface-600 hover:text-surface-900 mb-4"
         >
           <ArrowLeftIcon className="w-4 h-4 mr-1" />
           Back to Audits
         </Link>
-        <h1 className="text-2xl font-bold text-surface-100">Create New Audit</h1>
+        <h1 className="text-2xl font-bold text-surface-900">Create New Audit</h1>
         <p className="text-surface-600 mt-1">Start a new compliance audit</p>
       </div>
       {/* Form */}
@@ -280,7 +280,7 @@ export default function AuditNew() {
         </div>
 
         {/* Actions */}
-        <div className="flex items-center justify-end gap-3 pt-4 border-t border-surface-700">
+        <div className="flex items-center justify-end gap-3 pt-4 border-t border-surface-200">
           <Button type="button" variant="secondary" onClick={() => navigate('/audits')}>
             Cancel
           </Button>

--- a/frontend/src/pages/AuditRequests.tsx
+++ b/frontend/src/pages/AuditRequests.tsx
@@ -169,16 +169,16 @@ export default function AuditRequests() {
         <div className="flex items-start gap-4">
           <button
             onClick={() => navigate('/audit-requests')}
-            className="p-2 hover:bg-surface-700 rounded-lg text-surface-600 mt-1"
+            className="p-2 hover:bg-surface-200 rounded-lg text-surface-600 mt-1"
           >
             <ArrowLeftIcon className="w-5 h-5" />
           </button>
           <div>
-            <h1 className="text-2xl font-semibold text-surface-100">Create Audit Request</h1>
+            <h1 className="text-2xl font-semibold text-surface-900">Create Audit Request</h1>
             <p className="text-surface-600 mt-1">Create a new evidence or documentation request</p>
           </div>
         </div>
-        <div className="bg-surface-800 border border-surface-700 rounded-lg p-6">
+        <div className="bg-white border border-surface-200 rounded-lg p-6">
           <form onSubmit={handleCreateRequest} className="space-y-4">
             <div>
               <label className="block text-sm font-medium text-surface-700 mb-1">
@@ -188,7 +188,7 @@ export default function AuditRequests() {
                 type="text"
                 value={createForm.title}
                 onChange={(e) => setCreateForm({ ...createForm, title: e.target.value })}
-                className="w-full bg-surface-700 border border-surface-600 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+                className="w-full bg-surface-200 border border-surface-300 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
                 placeholder="e.g., SOC 2 Evidence - Access Control Logs"
               />
             </div>
@@ -200,7 +200,7 @@ export default function AuditRequests() {
               <SelectNative
                 value={createForm.auditId}
                 onChange={(e) => setCreateForm({ ...createForm, auditId: e.target.value })}
-                className="w-full bg-surface-700 border border-surface-600 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+                className="w-full bg-surface-200 border border-surface-300 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
               >
                 <option value="">Select an audit...</option>
                 {audits.map((audit) => (
@@ -222,7 +222,7 @@ export default function AuditRequests() {
                 <SelectNative
                   value={createForm.category}
                   onChange={(e) => setCreateForm({ ...createForm, category: e.target.value })}
-                  className="w-full bg-surface-700 border border-surface-600 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  className="w-full bg-surface-200 border border-surface-300 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
                 >
                   {Object.entries(categoryLabels).map(([value, label]) => (
                     <option key={value} value={value}>
@@ -237,7 +237,7 @@ export default function AuditRequests() {
                 <SelectNative
                   value={createForm.priority}
                   onChange={(e) => setCreateForm({ ...createForm, priority: e.target.value })}
-                  className="w-full bg-surface-700 border border-surface-600 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  className="w-full bg-surface-200 border border-surface-300 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
                 >
                   <option value="low">Low</option>
                   <option value="medium">Medium</option>
@@ -252,7 +252,7 @@ export default function AuditRequests() {
                   type="date"
                   value={createForm.dueDate}
                   onChange={(e) => setCreateForm({ ...createForm, dueDate: e.target.value })}
-                  className="w-full bg-surface-700 border border-surface-600 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  className="w-full bg-surface-200 border border-surface-300 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
                 />
               </div>
             </div>
@@ -263,7 +263,7 @@ export default function AuditRequests() {
                 value={createForm.description}
                 onChange={(e) => setCreateForm({ ...createForm, description: e.target.value })}
                 rows={3}
-                className="w-full bg-surface-700 border border-surface-600 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+                className="w-full bg-surface-200 border border-surface-300 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
                 placeholder="Describe what evidence or documentation is needed..."
               />
             </div>
@@ -290,7 +290,7 @@ export default function AuditRequests() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-semibold text-surface-100">Audit Requests</h1>
+          <h1 className="text-2xl font-semibold text-surface-900">Audit Requests</h1>
           <p className="text-surface-600 mt-1">
             Manage evidence and documentation requests from auditors
           </p>
@@ -311,14 +311,14 @@ export default function AuditRequests() {
             placeholder="Search requests..."
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
-            className="w-full pl-10 pr-4 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 placeholder-surface-500 focus:outline-none focus:ring-2 focus:ring-brand-500"
+            className="w-full pl-10 pr-4 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 placeholder-surface-500 focus:outline-none focus:ring-2 focus:ring-brand-500"
           />
         </div>
 
         <SelectNative
           value={statusFilter}
           onChange={(e) => setStatusFilter(e.target.value)}
-          className="px-4 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:ring-2 focus:ring-brand-500"
+          className="px-4 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:ring-2 focus:ring-brand-500"
         >
           <option value="">All Statuses</option>
           <option value="open">Open</option>
@@ -333,7 +333,7 @@ export default function AuditRequests() {
         <SelectNative
           value={priorityFilter}
           onChange={(e) => setPriorityFilter(e.target.value)}
-          className="px-4 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:ring-2 focus:ring-brand-500"
+          className="px-4 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:ring-2 focus:ring-brand-500"
         >
           <option value="">All Priorities</option>
           <option value="low">Low</option>
@@ -371,12 +371,12 @@ export default function AuditRequests() {
             <Link
               key={request.id}
               to={`/audit-requests/${request.id}`}
-              className="block bg-surface-800 border border-surface-700 rounded-lg p-6 hover:border-brand-500 transition-colors"
+              className="block bg-white border border-surface-200 rounded-lg p-6 hover:border-brand-500 transition-colors"
             >
               <div className="flex items-start justify-between mb-4">
                 <div className="flex-1">
                   <div className="flex items-center gap-3 mb-2">
-                    <h3 className="text-lg font-semibold text-surface-100">{request.title}</h3>
+                    <h3 className="text-lg font-semibold text-surface-900">{request.title}</h3>
                     <span className="text-sm text-surface-500">#{request.requestNumber}</span>
                     <span className={`${priorityColors[request.priority]}`}>
                       <ExclamationTriangleIcon className="w-5 h-5" />
@@ -400,7 +400,7 @@ export default function AuditRequests() {
                 </span>
               </div>
 
-              <div className="flex items-center gap-6 pt-4 border-t border-surface-700 text-sm text-surface-600">
+              <div className="flex items-center gap-6 pt-4 border-t border-surface-200 text-sm text-surface-600">
                 <div className="flex items-center gap-2">
                   <DocumentTextIcon className="w-5 h-5" />
                   <span>{request._count.evidence} evidence items</span>

--- a/frontend/src/pages/AuditTemplates.tsx
+++ b/frontend/src/pages/AuditTemplates.tsx
@@ -152,7 +152,7 @@ export default function AuditTemplates() {
         <SelectNative
           value={selectedType}
           onChange={(e) => setSelectedType(e.target.value)}
-          className="bg-surface-800 border border-surface-600 rounded-lg px-3 py-2 text-white"
+          className="bg-white border border-surface-300 rounded-lg px-3 py-2 text-white"
         >
           <option value="">All Types</option>
           {Object.entries(auditTypeLabels).map(([value, label]) => (
@@ -166,7 +166,7 @@ export default function AuditTemplates() {
       {isLoading ? (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {[1, 2, 3].map((i) => (
-            <div key={i} className="animate-pulse bg-surface-800 rounded-lg p-6 h-48" />
+            <div key={i} className="animate-pulse bg-white rounded-lg p-6 h-48" />
           ))}
         </div>
       ) : (
@@ -174,7 +174,7 @@ export default function AuditTemplates() {
           {(templates as AuditTemplate[]).map((template) => (
             <div
               key={template.id}
-              className="bg-surface-800 rounded-lg p-6 border border-surface-700 hover:border-surface-500 transition-colors"
+              className="bg-white rounded-lg p-6 border border-surface-200 hover:border-surface-500 transition-colors"
             >
               <div className="flex items-start justify-between">
                 <div className="flex items-center gap-3">
@@ -197,11 +197,11 @@ export default function AuditTemplates() {
               </p>
 
               <div className="mt-4 flex flex-wrap gap-2 text-xs">
-                <span className="bg-surface-700 text-surface-700 px-2 py-1 rounded">
+                <span className="bg-surface-200 text-surface-700 px-2 py-1 rounded">
                   {auditTypeLabels[template.auditType] || template.auditType}
                 </span>
                 {template.framework && (
-                  <span className="bg-surface-700 text-surface-700 px-2 py-1 rounded">
+                  <span className="bg-surface-200 text-surface-700 px-2 py-1 rounded">
                     {template.framework}
                   </span>
                 )}
@@ -217,7 +217,7 @@ export default function AuditTemplates() {
                 </div>
               </div>
 
-              <div className="mt-4 pt-4 border-t border-surface-700 flex gap-2">
+              <div className="mt-4 pt-4 border-t border-surface-200 flex gap-2">
                 <Link to={`/audits/new?templateId=${template.id}`} className="flex-1">
                   <Button variant="primary" size="sm" className="w-full">
                     Use Template
@@ -262,7 +262,7 @@ export default function AuditTemplates() {
           <h2 className="text-xl font-semibold text-white">Create Audit Template</h2>
           <button
             onClick={() => setShowCreateModal(false)}
-            className="p-1 hover:bg-surface-700 rounded"
+            className="p-1 hover:bg-surface-200 rounded"
           >
             <XMarkIcon className="h-5 w-5 text-surface-600" />
           </button>
@@ -277,7 +277,7 @@ export default function AuditTemplates() {
               type="text"
               value={createForm.name}
               onChange={(e) => setCreateForm({ ...createForm, name: e.target.value })}
-              className="w-full bg-surface-700 border border-surface-600 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+              className="w-full bg-surface-200 border border-surface-300 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
               placeholder="e.g., SOC 2 Annual Audit"
             />
           </div>
@@ -288,7 +288,7 @@ export default function AuditTemplates() {
               value={createForm.description}
               onChange={(e) => setCreateForm({ ...createForm, description: e.target.value })}
               rows={3}
-              className="w-full bg-surface-700 border border-surface-600 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+              className="w-full bg-surface-200 border border-surface-300 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
               placeholder="Describe the purpose of this template..."
             />
           </div>
@@ -299,7 +299,7 @@ export default function AuditTemplates() {
               <SelectNative
                 value={createForm.auditType}
                 onChange={(e) => setCreateForm({ ...createForm, auditType: e.target.value })}
-                className="w-full bg-surface-700 border border-surface-600 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+                className="w-full bg-surface-200 border border-surface-300 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
               >
                 {Object.entries(auditTypeLabels).map(([value, label]) => (
                   <option key={value} value={value}>
@@ -315,7 +315,7 @@ export default function AuditTemplates() {
                 type="text"
                 value={createForm.framework}
                 onChange={(e) => setCreateForm({ ...createForm, framework: e.target.value })}
-                className="w-full bg-surface-700 border border-surface-600 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+                className="w-full bg-surface-200 border border-surface-300 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
                 placeholder="e.g., SOC 2, ISO 27001"
               />
             </div>

--- a/frontend/src/pages/AuditWorkpapers.tsx
+++ b/frontend/src/pages/AuditWorkpapers.tsx
@@ -185,7 +185,7 @@ export default function AuditWorkpapers() {
         {Object.entries(statusConfig).map(([status, config]) => {
           const count = workpapers.filter((w) => w.status === status).length;
           return (
-            <div key={status} className="bg-surface-800 rounded-lg p-4 border border-surface-700">
+            <div key={status} className="bg-white rounded-lg p-4 border border-surface-200">
               <div className="flex items-center gap-2">
                 <config.icon className={clsx('h-5 w-5', config.color)} />
                 <span className="text-surface-600 text-sm">{config.label}</span>
@@ -199,13 +199,13 @@ export default function AuditWorkpapers() {
       {isLoading ? (
         <div className="animate-pulse space-y-4">
           {[1, 2, 3].map((i) => (
-            <div key={i} className="bg-surface-800 rounded-lg h-20" />
+            <div key={i} className="bg-white rounded-lg h-20" />
           ))}
         </div>
       ) : (
-        <div className="bg-surface-800 rounded-lg border border-surface-700 overflow-hidden">
+        <div className="bg-white rounded-lg border border-surface-200 overflow-hidden">
           <table className="w-full">
-            <thead className="bg-surface-900">
+            <thead className="bg-white">
               <tr>
                 <th className="text-left px-4 py-3 text-sm font-medium text-surface-600">Number</th>
                 <th className="text-left px-4 py-3 text-sm font-medium text-surface-600">Title</th>
@@ -222,11 +222,11 @@ export default function AuditWorkpapers() {
                 </th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-surface-700">
+            <tbody className="divide-y divide-surface-200">
               {workpapers.map((wp) => {
                 const config = statusConfig[wp.status];
                 return (
-                  <tr key={wp.id} className="hover:bg-surface-700/50">
+                  <tr key={wp.id} className="hover:bg-surface-200/50">
                     <td className="px-4 py-3">
                       <span className="font-mono text-sm text-brand-400">{wp.workpaperNumber}</span>
                     </td>
@@ -309,7 +309,7 @@ export default function AuditWorkpapers() {
           <h2 className="text-xl font-semibold text-white">Create Workpaper</h2>
           <button
             onClick={() => setShowCreateModal(false)}
-            className="p-1 hover:bg-surface-700 rounded"
+            className="p-1 hover:bg-surface-200 rounded"
           >
             <XMarkIcon className="h-5 w-5 text-surface-600" />
           </button>
@@ -322,7 +322,7 @@ export default function AuditWorkpapers() {
               type="text"
               value={createForm.title}
               onChange={(e) => setCreateForm((prev) => ({ ...prev, title: e.target.value }))}
-              className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+              className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
               placeholder="Workpaper title"
             />
           </div>
@@ -334,7 +334,7 @@ export default function AuditWorkpapers() {
               onChange={(e) =>
                 setCreateForm((prev) => ({ ...prev, workpaperType: e.target.value }))
               }
-              className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+              className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
             >
               <option value="procedure">Procedure</option>
               <option value="walkthrough">Walkthrough</option>
@@ -349,7 +349,7 @@ export default function AuditWorkpapers() {
             <Textarea
               value={createForm.content}
               onChange={(e) => setCreateForm((prev) => ({ ...prev, content: e.target.value }))}
-              className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white h-32"
+              className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white h-32"
               placeholder="Workpaper content..."
             />
           </div>

--- a/frontend/src/pages/Audits.tsx
+++ b/frontend/src/pages/Audits.tsx
@@ -83,7 +83,7 @@ export default function Audits() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-semibold text-surface-100">Audits</h1>
+          <h1 className="text-2xl font-semibold text-surface-900">Audits</h1>
           <p className="text-surface-600 mt-1">Manage internal and external compliance audits</p>
         </div>
         <div className="flex gap-3">
@@ -111,14 +111,14 @@ export default function Audits() {
             placeholder="Search audits..."
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
-            className="w-full pl-10 pr-4 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 placeholder-surface-500 focus:outline-none focus:ring-2 focus:ring-brand-500"
+            className="w-full pl-10 pr-4 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 placeholder-surface-500 focus:outline-none focus:ring-2 focus:ring-brand-500"
           />
         </div>
 
         <SelectNative
           value={statusFilter}
           onChange={(e) => setStatusFilter(e.target.value)}
-          className="px-4 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:ring-2 focus:ring-brand-500"
+          className="px-4 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:ring-2 focus:ring-brand-500"
         >
           <option value="">All Statuses</option>
           <option value="planning">Planning</option>
@@ -132,7 +132,7 @@ export default function Audits() {
         <SelectNative
           value={typeFilter}
           onChange={(e) => setTypeFilter(e.target.value)}
-          className="px-4 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:ring-2 focus:ring-brand-500"
+          className="px-4 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:ring-2 focus:ring-brand-500"
         >
           <option value="">All Types</option>
           <option value="internal">Internal</option>
@@ -162,12 +162,12 @@ export default function Audits() {
             <Link
               key={audit.id}
               to={`/audits/${audit.id}`}
-              className="block bg-surface-800 border border-surface-700 rounded-lg p-6 hover:border-brand-500 transition-colors"
+              className="block bg-white border border-surface-200 rounded-lg p-6 hover:border-brand-500 transition-colors"
             >
               <div className="flex items-start justify-between mb-4">
                 <div>
                   <div className="flex items-center gap-3 mb-2">
-                    <h3 className="text-lg font-semibold text-surface-100">{audit.name}</h3>
+                    <h3 className="text-lg font-semibold text-surface-900">{audit.name}</h3>
                     <span className="text-sm text-surface-500">#{audit.auditId}</span>
                     {audit.isExternal && (
                       <span className="px-2 py-1 bg-purple-600/20 text-purple-600 rounded text-xs font-medium">
@@ -190,29 +190,29 @@ export default function Audits() {
                 </span>
               </div>
 
-              <div className="grid grid-cols-4 gap-4 pt-4 border-t border-surface-700">
+              <div className="grid grid-cols-4 gap-4 pt-4 border-t border-surface-200">
                 <div>
                   <div className="text-sm text-surface-500 mb-1">Requests</div>
-                  <div className="text-lg font-semibold text-surface-100">
+                  <div className="text-lg font-semibold text-surface-900">
                     {audit._count.requests}
                   </div>
                 </div>
                 <div>
                   <div className="text-sm text-surface-500 mb-1">Evidence</div>
-                  <div className="text-lg font-semibold text-surface-100">
+                  <div className="text-lg font-semibold text-surface-900">
                     {audit._count.evidence}
                   </div>
                 </div>
                 <div>
                   <div className="text-sm text-surface-500 mb-1">Tests</div>
-                  <div className="text-lg font-semibold text-surface-100">
+                  <div className="text-lg font-semibold text-surface-900">
                     {audit._count.testResults}
                   </div>
                 </div>
                 <div>
                   <div className="text-sm text-surface-500 mb-1">Findings</div>
                   <div className="flex items-baseline gap-2">
-                    <div className="text-lg font-semibold text-surface-100">
+                    <div className="text-lg font-semibold text-surface-900">
                       {audit._count.findings}
                     </div>
                     {audit.criticalFindings > 0 && (

--- a/frontend/src/pages/AwarenessTraining.tsx
+++ b/frontend/src/pages/AwarenessTraining.tsx
@@ -180,7 +180,7 @@ export default function AwarenessTraining() {
           />
 
           {/* Category Filter */}
-          <div className="flex items-center gap-3 border-b border-gray-200 dark:border-surface-700 pb-4">
+          <div className="flex items-center gap-3 border-b border-gray-200 dark:border-surface-200 pb-4">
             <span className="text-gray-500 dark:text-surface-500 text-sm font-medium">Filter:</span>
             <div className="flex gap-1">
               {['all', 'social-engineering', 'privacy', 'secure-coding', 'general'].map((cat) => (
@@ -190,7 +190,7 @@ export default function AwarenessTraining() {
                   className={`px-4 py-2 rounded-lg text-sm font-medium transition-all ${
                     categoryFilter === cat
                       ? 'bg-brand-500/10 text-brand-500 dark:text-brand-400 border border-brand-500/30'
-                      : 'text-gray-600 dark:text-surface-600 hover:text-gray-900 dark:hover:text-surface-200 hover:bg-gray-100 dark:hover:bg-surface-800'
+                      : 'text-gray-600 dark:text-surface-600 hover:text-gray-900 dark:hover:text-surface-800 hover:bg-gray-100 dark:hover:bg-white'
                   }`}
                 >
                   {cat === 'all' ? 'All Modules' : getCategoryLabel(cat as any)}
@@ -221,14 +221,14 @@ function StatsOverview({ stats }: { stats: TrainingStats }) {
   const completionPercent = Math.round((stats.completedModules / stats.totalModules) * 100);
 
   return (
-    <div className="bg-white/50 dark:bg-surface-800/50 rounded-xl border border-gray-200 dark:border-surface-700 p-6">
+    <div className="bg-white/50 dark:bg-white/50 rounded-xl border border-gray-200 dark:border-surface-200 p-6">
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-lg font-medium text-gray-900 dark:text-white">Training Progress</h2>
         <span className="text-2xl font-bold text-brand-500 dark:text-brand-400">
           {completionPercent}%
         </span>
       </div>
-      <div className="h-2 bg-gray-200 dark:bg-surface-700 rounded-full overflow-hidden mb-6">
+      <div className="h-2 bg-gray-200 dark:bg-surface-200 rounded-full overflow-hidden mb-6">
         <div
           className="h-full bg-brand-500 transition-all duration-500"
           style={{ width: `${completionPercent}%` }}
@@ -343,11 +343,11 @@ function TrainingCard({
   const isInProgress = progress?.status === 'in_progress';
 
   return (
-    <div className="bg-white dark:bg-surface-800 rounded-xl border border-gray-200 dark:border-surface-700 overflow-hidden hover:border-gray-300 dark:hover:border-surface-600 transition-all group">
+    <div className="bg-white dark:bg-white rounded-xl border border-gray-200 dark:border-surface-200 overflow-hidden hover:border-gray-300 dark:hover:border-surface-300 transition-all group">
       {/* Header */}
-      <div className="p-5 border-b border-gray-200 dark:border-surface-700">
+      <div className="p-5 border-b border-gray-200 dark:border-surface-200">
         <div className="flex items-start justify-between mb-3">
-          <div className="p-2.5 bg-gray-100 dark:bg-surface-700/50 rounded-lg group-hover:bg-brand-500/10 transition-colors">
+          <div className="p-2.5 bg-gray-100 dark:bg-surface-200/50 rounded-lg group-hover:bg-brand-500/10 transition-colors">
             <ModuleIcon
               type={module.iconType}
               className="w-6 h-6 text-gray-500 dark:text-surface-700 group-hover:text-brand-500 dark:group-hover:text-brand-400 transition-colors"
@@ -379,7 +379,7 @@ function TrainingCard({
       <div className="p-5">
         {/* Tags */}
         <div className="flex items-center gap-2 mb-4">
-          <span className="text-xs text-gray-500 dark:text-surface-500 bg-gray-100 dark:bg-surface-700/50 px-2 py-1 rounded">
+          <span className="text-xs text-gray-500 dark:text-surface-500 bg-gray-100 dark:bg-surface-200/50 px-2 py-1 rounded">
             {getCategoryLabel(module.category)}
           </span>
           <span className={`text-xs px-2 py-1 rounded ${getDifficultyColor(module.difficulty)}`}>
@@ -394,7 +394,7 @@ function TrainingCard({
               <span>Progress</span>
               <span>{progress.slideProgress}%</span>
             </div>
-            <div className="h-1.5 bg-gray-200 dark:bg-surface-700 rounded-full overflow-hidden">
+            <div className="h-1.5 bg-gray-200 dark:bg-surface-200 rounded-full overflow-hidden">
               <div
                 className={`h-full ${isCompleted ? 'bg-emerald-500' : 'bg-brand-500'} transition-all`}
                 style={{ width: `${progress.slideProgress}%` }}
@@ -464,9 +464,9 @@ function TrainingViewer({
   }, [onComplete]);
 
   return (
-    <div className={`${isFullscreen ? 'fixed inset-0 z-50' : ''} bg-gray-100 dark:bg-surface-900`}>
+    <div className={`${isFullscreen ? 'fixed inset-0 z-50' : ''} bg-gray-100 dark:bg-white`}>
       {/* Header */}
-      <div className="bg-white dark:bg-surface-800 border-b border-gray-200 dark:border-surface-700 px-4 py-3 flex items-center justify-between">
+      <div className="bg-white dark:bg-white border-b border-gray-200 dark:border-surface-200 px-4 py-3 flex items-center justify-between">
         <div className="flex items-center gap-4">
           <Button
             variant="ghost"
@@ -476,7 +476,7 @@ function TrainingViewer({
             Back
           </Button>
           <div className="flex items-center gap-3">
-            <div className="p-2 bg-gray-100 dark:bg-surface-700 rounded-lg">
+            <div className="p-2 bg-gray-100 dark:bg-surface-200 rounded-lg">
               <ModuleIcon
                 type={module.iconType}
                 className="w-5 h-5 text-brand-500 dark:text-brand-400"
@@ -510,7 +510,7 @@ function TrainingViewer({
           )}
           <button
             onClick={() => setIsFullscreen(!isFullscreen)}
-            className="p-2 text-gray-500 dark:text-surface-600 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-surface-700 rounded-lg transition-colors"
+            className="p-2 text-gray-500 dark:text-surface-600 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-surface-200 rounded-lg transition-colors"
             title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
           >
             {isFullscreen ? (
@@ -579,7 +579,7 @@ function ProgressDashboard({
               return (
                 <div
                   key={module.id}
-                  className="bg-white dark:bg-surface-800 rounded-xl border border-gray-200 dark:border-surface-700 p-4 flex items-center gap-4"
+                  className="bg-white dark:bg-white rounded-xl border border-gray-200 dark:border-surface-200 p-4 flex items-center gap-4"
                 >
                   <div className="p-2.5 bg-amber-500/10 rounded-lg">
                     <ModuleIcon
@@ -592,7 +592,7 @@ function ProgressDashboard({
                       {module.title}
                     </h4>
                     <div className="flex items-center gap-3 mt-2">
-                      <div className="flex-1 h-1.5 bg-gray-200 dark:bg-surface-700 rounded-full overflow-hidden">
+                      <div className="flex-1 h-1.5 bg-gray-200 dark:bg-surface-200 rounded-full overflow-hidden">
                         <div
                           className="h-full bg-amber-500"
                           style={{ width: `${moduleProgress?.slideProgress || 0}%` }}
@@ -629,7 +629,7 @@ function ProgressDashboard({
               return (
                 <div
                   key={module.id}
-                  className="bg-white dark:bg-surface-800 rounded-xl border border-emerald-500/20 p-4"
+                  className="bg-white dark:bg-white rounded-xl border border-emerald-500/20 p-4"
                 >
                   <div className="flex items-start gap-3 mb-3">
                     <div className="p-2 bg-emerald-500/10 rounded-lg">
@@ -649,7 +649,7 @@ function ProgressDashboard({
                       )}
                     </div>
                   </div>
-                  <div className="flex items-center justify-between pt-3 border-t border-gray-200 dark:border-surface-700">
+                  <div className="flex items-center justify-between pt-3 border-t border-gray-200 dark:border-surface-200">
                     <span className="text-emerald-500 dark:text-emerald-600 text-xs font-medium flex items-center gap-1">
                       <SparklesIcon className="w-3.5 h-3.5" /> Certificate Earned
                     </span>
@@ -678,9 +678,9 @@ function ProgressDashboard({
             {notStartedModules.map((module) => (
               <div
                 key={module.id}
-                className="bg-white dark:bg-surface-800 rounded-xl border border-gray-200 dark:border-surface-700 p-4 flex items-center gap-4"
+                className="bg-white dark:bg-white rounded-xl border border-gray-200 dark:border-surface-200 p-4 flex items-center gap-4"
               >
-                <div className="p-2.5 bg-gray-100 dark:bg-surface-700/50 rounded-lg">
+                <div className="p-2.5 bg-gray-100 dark:bg-surface-200/50 rounded-lg">
                   <ModuleIcon
                     type={module.iconType}
                     className="w-5 h-5 text-gray-500 dark:text-surface-600"

--- a/frontend/src/pages/BCDRDashboard.tsx
+++ b/frontend/src/pages/BCDRDashboard.tsx
@@ -172,7 +172,7 @@ export default function BCDRDashboard() {
   if (isLoading) {
     return (
       <div className="p-6 space-y-6 animate-pulse">
-        <div className="h-8 bg-surface-700 rounded w-1/4"></div>
+        <div className="h-8 bg-surface-200 rounded w-1/4"></div>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
           {[1, 2, 3, 4].map((i) => (
             <div key={i} className="card p-6 h-32"></div>
@@ -187,7 +187,7 @@ export default function BCDRDashboard() {
       <div className="p-6">
         <div className="card p-8 text-center">
           <ExclamationCircleIcon className="w-12 h-12 mx-auto mb-4 text-red-600" />
-          <h2 className="text-lg font-semibold text-surface-100 mb-2">
+          <h2 className="text-lg font-semibold text-surface-900 mb-2">
             Failed to load BC/DR Dashboard
           </h2>
           <p className="text-surface-600 mb-4">
@@ -255,7 +255,7 @@ export default function BCDRDashboard() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-surface-100">BC/DR Dashboard</h1>
+          <h1 className="text-2xl font-bold text-surface-900">BC/DR Dashboard</h1>
           <p className="text-surface-600 mt-1">Business Continuity & Disaster Recovery Overview</p>
         </div>
         <div className="flex gap-3">
@@ -275,7 +275,7 @@ export default function BCDRDashboard() {
       <div className="card p-6 bg-gradient-to-r from-brand-900/50 to-surface-800">
         <div className="flex items-center justify-between">
           <div>
-            <h2 className="text-lg font-semibold text-surface-200">BC/DR Readiness Score</h2>
+            <h2 className="text-lg font-semibold text-surface-800">BC/DR Readiness Score</h2>
             <p className="text-surface-600 text-sm mt-1">
               Overall preparedness based on RTO coverage, plan coverage, and test success rate
             </p>
@@ -299,7 +299,7 @@ export default function BCDRDashboard() {
           <div className="flex items-center justify-between">
             <div>
               <p className="text-sm text-surface-600">Business Processes</p>
-              <p className="text-3xl font-bold text-surface-100 mt-1">
+              <p className="text-3xl font-bold text-surface-900 mt-1">
                 {summary.processes?.total ?? 0}
               </p>
               <div className="flex items-center gap-2 mt-2 text-xs">
@@ -323,7 +323,7 @@ export default function BCDRDashboard() {
           <div className="flex items-center justify-between">
             <div>
               <p className="text-sm text-surface-600">BC/DR Plans</p>
-              <p className="text-3xl font-bold text-surface-100 mt-1">
+              <p className="text-3xl font-bold text-surface-900 mt-1">
                 {summary.plans?.total ?? 0}
               </p>
               <div className="flex items-center gap-2 mt-2 text-xs">
@@ -341,7 +341,7 @@ export default function BCDRDashboard() {
           <div className="flex items-center justify-between">
             <div>
               <p className="text-sm text-surface-600">DR Tests</p>
-              <p className="text-3xl font-bold text-surface-100 mt-1">
+              <p className="text-3xl font-bold text-surface-900 mt-1">
                 {summary.tests?.completed_count ?? 0}
               </p>
               <div className="flex items-center gap-2 mt-2 text-xs">
@@ -363,7 +363,7 @@ export default function BCDRDashboard() {
           <div className="flex items-center justify-between">
             <div>
               <p className="text-sm text-surface-600">Runbooks</p>
-              <p className="text-3xl font-bold text-surface-100 mt-1">
+              <p className="text-3xl font-bold text-surface-900 mt-1">
                 {summary.runbooks?.total ?? 0}
               </p>
               <div className="flex items-center gap-2 mt-2 text-xs">
@@ -388,7 +388,7 @@ export default function BCDRDashboard() {
         {/* Upcoming Tests */}
         <div className="card p-6">
           <div className="flex items-center justify-between mb-4">
-            <h2 className="text-lg font-semibold text-surface-100">Upcoming DR Tests</h2>
+            <h2 className="text-lg font-semibold text-surface-900">Upcoming DR Tests</h2>
             <Link to="/bcdr/tests" className="text-brand-400 text-sm hover:text-brand-300">
               View all →
             </Link>
@@ -399,10 +399,10 @@ export default function BCDRDashboard() {
                 <Link
                   key={test.id}
                   to={`/bcdr/tests/${test.id}`}
-                  className="flex items-center justify-between p-3 rounded-lg bg-surface-800/50 hover:bg-surface-700/50 transition-colors"
+                  className="flex items-center justify-between p-3 rounded-lg bg-white/50 hover:bg-surface-200/50 transition-colors"
                 >
                   <div>
-                    <p className="text-surface-100 font-medium">{test.name}</p>
+                    <p className="text-surface-900 font-medium">{test.name}</p>
                     <p className="text-surface-600 text-sm">{test.test_type}</p>
                   </div>
                   <div className="text-right">
@@ -430,7 +430,7 @@ export default function BCDRDashboard() {
         {/* Overdue Items */}
         <div className="card p-6">
           <div className="flex items-center justify-between mb-4">
-            <h2 className="text-lg font-semibold text-surface-100">Overdue Items</h2>
+            <h2 className="text-lg font-semibold text-surface-900">Overdue Items</h2>
             {(summary.overdueItems?.totalOverdue ?? 0) > 0 && (
               <Badge variant="danger">{summary.overdueItems?.totalOverdue} items</Badge>
             )}
@@ -450,7 +450,7 @@ export default function BCDRDashboard() {
                 >
                   <DocumentTextIcon className="w-5 h-5 text-red-600 flex-shrink-0" />
                   <div className="flex-1 min-w-0">
-                    <p className="text-surface-100 truncate">{plan.title}</p>
+                    <p className="text-surface-900 truncate">{plan.title}</p>
                     <p className="text-red-600 text-xs">Review overdue</p>
                   </div>
                 </Link>
@@ -463,7 +463,7 @@ export default function BCDRDashboard() {
                 >
                   <ShieldExclamationIcon className="w-5 h-5 text-yellow-600 flex-shrink-0" />
                   <div className="flex-1 min-w-0">
-                    <p className="text-surface-100 truncate">{process.title}</p>
+                    <p className="text-surface-900 truncate">{process.title}</p>
                     <p className="text-yellow-600 text-xs">BIA review overdue</p>
                   </div>
                 </Link>
@@ -476,7 +476,7 @@ export default function BCDRDashboard() {
                 >
                   <XCircleIcon className="w-5 h-5 text-orange-600 flex-shrink-0" />
                   <div className="flex-1 min-w-0">
-                    <p className="text-surface-100 truncate">{finding.title}</p>
+                    <p className="text-surface-900 truncate">{finding.title}</p>
                     <p className="text-orange-600 text-xs">Remediation overdue</p>
                   </div>
                 </Link>
@@ -491,7 +491,7 @@ export default function BCDRDashboard() {
         {/* Pending Attestations */}
         <div className="card p-6">
           <div className="flex items-center justify-between mb-4">
-            <h2 className="text-lg font-semibold text-surface-100 flex items-center gap-2">
+            <h2 className="text-lg font-semibold text-surface-900 flex items-center gap-2">
               <ClipboardDocumentCheckIcon className="w-5 h-5 text-surface-600" />
               Pending Attestations
             </h2>
@@ -516,7 +516,7 @@ export default function BCDRDashboard() {
                 >
                   <ClipboardDocumentCheckIcon className="w-5 h-5 text-yellow-600 flex-shrink-0" />
                   <div className="flex-1 min-w-0">
-                    <p className="text-surface-100 truncate">{attestation.plan_title}</p>
+                    <p className="text-surface-900 truncate">{attestation.plan_title}</p>
                     <p className="text-yellow-600 text-xs capitalize">
                       {attestation.attestation_type?.replace('_', ' ')} attestation
                     </p>
@@ -538,7 +538,7 @@ export default function BCDRDashboard() {
         {/* Vendor Recovery Gaps */}
         <div className="card p-6">
           <div className="flex items-center justify-between mb-4">
-            <h2 className="text-lg font-semibold text-surface-100 flex items-center gap-2">
+            <h2 className="text-lg font-semibold text-surface-900 flex items-center gap-2">
               <BuildingOfficeIcon className="w-5 h-5 text-surface-600" />
               Vendor Recovery Gaps
             </h2>
@@ -561,7 +561,7 @@ export default function BCDRDashboard() {
                 >
                   <BuildingOfficeIcon className="w-5 h-5 text-red-600 flex-shrink-0" />
                   <div className="flex-1 min-w-0">
-                    <p className="text-surface-100 truncate">{gap.vendor_name}</p>
+                    <p className="text-surface-900 truncate">{gap.vendor_name}</p>
                     <p className="text-red-600 text-xs">
                       RTO gap: {gap.rto_gap_hours}h for {gap.process_name}
                     </p>
@@ -580,42 +580,42 @@ export default function BCDRDashboard() {
 
       {/* Quick Links */}
       <div className="card p-6">
-        <h2 className="text-lg font-semibold text-surface-100 mb-4">Quick Actions</h2>
+        <h2 className="text-lg font-semibold text-surface-900 mb-4">Quick Actions</h2>
         <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
           <Link
             to="/bcdr/processes/new"
-            className="p-4 rounded-lg bg-surface-800/50 hover:bg-surface-700/50 transition-colors text-center"
+            className="p-4 rounded-lg bg-white/50 hover:bg-surface-200/50 transition-colors text-center"
           >
             <ShieldExclamationIcon className="w-8 h-8 mx-auto mb-2 text-brand-400" />
-            <span className="text-surface-200 text-sm">Add Process</span>
+            <span className="text-surface-800 text-sm">Add Process</span>
           </Link>
           <Link
             to="/bcdr/plans/new"
-            className="p-4 rounded-lg bg-surface-800/50 hover:bg-surface-700/50 transition-colors text-center"
+            className="p-4 rounded-lg bg-white/50 hover:bg-surface-200/50 transition-colors text-center"
           >
             <DocumentTextIcon className="w-8 h-8 mx-auto mb-2 text-blue-600" />
-            <span className="text-surface-200 text-sm">Create Plan</span>
+            <span className="text-surface-800 text-sm">Create Plan</span>
           </Link>
           <Link
             to="/bcdr/tests/new"
-            className="p-4 rounded-lg bg-surface-800/50 hover:bg-surface-700/50 transition-colors text-center"
+            className="p-4 rounded-lg bg-white/50 hover:bg-surface-200/50 transition-colors text-center"
           >
             <BeakerIcon className="w-8 h-8 mx-auto mb-2 text-purple-600" />
-            <span className="text-surface-200 text-sm">Schedule Test</span>
+            <span className="text-surface-800 text-sm">Schedule Test</span>
           </Link>
           <Link
             to="/bcdr/runbooks/new"
-            className="p-4 rounded-lg bg-surface-800/50 hover:bg-surface-700/50 transition-colors text-center"
+            className="p-4 rounded-lg bg-white/50 hover:bg-surface-200/50 transition-colors text-center"
           >
             <BookOpenIcon className="w-8 h-8 mx-auto mb-2 text-teal-600" />
-            <span className="text-surface-200 text-sm">Create Runbook</span>
+            <span className="text-surface-800 text-sm">Create Runbook</span>
           </Link>
           <Link
             to="/bcdr/recovery-teams"
-            className="p-4 rounded-lg bg-surface-800/50 hover:bg-surface-700/50 transition-colors text-center"
+            className="p-4 rounded-lg bg-white/50 hover:bg-surface-200/50 transition-colors text-center"
           >
             <UserGroupIcon className="w-8 h-8 mx-auto mb-2 text-green-600" />
-            <span className="text-surface-200 text-sm">Recovery Teams</span>
+            <span className="text-surface-800 text-sm">Recovery Teams</span>
           </Link>
         </div>
       </div>

--- a/frontend/src/pages/BCDRPlanDetail.tsx
+++ b/frontend/src/pages/BCDRPlanDetail.tsx
@@ -77,7 +77,7 @@ const STATUS_OPTIONS = [
   { value: 'in_review', label: 'In Review', color: 'bg-yellow-500/20 text-yellow-600' },
   { value: 'approved', label: 'Approved', color: 'bg-blue-500/20 text-blue-600' },
   { value: 'published', label: 'Published', color: 'bg-green-500/20 text-green-600' },
-  { value: 'archived', label: 'Archived', color: 'bg-surface-700 text-surface-600' },
+  { value: 'archived', label: 'Archived', color: 'bg-surface-200 text-surface-600' },
 ];
 
 const PLAN_TYPES = [
@@ -234,7 +234,7 @@ export default function BCDRPlanDetail() {
       <div className="p-6">
         <div className="card p-8 text-center">
           <ExclamationCircleIcon className="w-12 h-12 mx-auto mb-4 text-red-600" />
-          <h2 className="text-lg font-semibold text-surface-100 mb-2">BC/DR Plan Not Found</h2>
+          <h2 className="text-lg font-semibold text-surface-900 mb-2">BC/DR Plan Not Found</h2>
           <p className="text-surface-600 mb-4">The requested plan could not be loaded.</p>
           <Button onClick={() => navigate('/bcdr/plans')}>Back to Plans</Button>
         </div>
@@ -249,12 +249,12 @@ export default function BCDRPlanDetail() {
         <div className="flex items-start gap-4">
           <button
             onClick={() => navigate('/bcdr/plans')}
-            className="p-2 hover:bg-surface-700 rounded-lg text-surface-600 mt-1"
+            className="p-2 hover:bg-surface-200 rounded-lg text-surface-600 mt-1"
           >
             <ArrowLeftIcon className="w-5 h-5" />
           </button>
           <div>
-            <h1 className="text-2xl font-bold text-surface-100">Create New BC/DR Plan</h1>
+            <h1 className="text-2xl font-bold text-surface-900">Create New BC/DR Plan</h1>
             <p className="text-surface-600">Fill out the form below to create a new plan</p>
           </div>
         </div>
@@ -335,7 +335,7 @@ export default function BCDRPlanDetail() {
         <div className="flex items-start gap-4">
           <button
             onClick={() => navigate('/bcdr/plans')}
-            className="p-2 hover:bg-surface-700 rounded-lg text-surface-600 mt-1"
+            className="p-2 hover:bg-surface-200 rounded-lg text-surface-600 mt-1"
           >
             <ArrowLeftIcon className="w-5 h-5" />
           </button>
@@ -343,7 +343,7 @@ export default function BCDRPlanDetail() {
             <div className="flex items-center gap-3 mb-2">
               <DocumentTextIcon className="w-8 h-8 text-brand-400" />
               <div>
-                <h1 className="text-2xl font-bold text-surface-100">{plan.title}</h1>
+                <h1 className="text-2xl font-bold text-surface-900">{plan.title}</h1>
                 <p className="text-surface-600 text-sm">
                   {plan.plan_id} • v{plan.version}
                 </p>
@@ -355,7 +355,7 @@ export default function BCDRPlanDetail() {
               >
                 {statusConfig.label}
               </span>
-              <span className="px-3 py-1 rounded-full text-sm font-medium bg-surface-700 text-surface-700">
+              <span className="px-3 py-1 rounded-full text-sm font-medium bg-surface-200 text-surface-700">
                 {getPlanTypeLabel(plan.plan_type)}
               </span>
             </div>
@@ -373,7 +373,7 @@ export default function BCDRPlanDetail() {
         </div>
       </div>
       {/* Tabs */}
-      <div className="border-b border-surface-700">
+      <div className="border-b border-surface-200">
         <nav className="flex gap-6">
           {(['overview', 'processes', 'tests', 'controls'] as const).map((tab) => (
             <button
@@ -383,7 +383,7 @@ export default function BCDRPlanDetail() {
                 'pb-3 px-1 text-sm font-medium border-b-2 transition-colors capitalize',
                 activeTab === tab
                   ? 'border-brand-500 text-brand-400'
-                  : 'border-transparent text-surface-600 hover:text-surface-200'
+                  : 'border-transparent text-surface-600 hover:text-surface-800'
               )}
             >
               {tab}
@@ -396,27 +396,27 @@ export default function BCDRPlanDetail() {
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
           <div className="lg:col-span-2 space-y-6">
             <div className="card p-6">
-              <h3 className="text-lg font-semibold text-surface-100 mb-4">Description</h3>
+              <h3 className="text-lg font-semibold text-surface-900 mb-4">Description</h3>
               <p className="text-surface-700">{plan.description || 'No description provided.'}</p>
             </div>
 
             {plan.objectives && (
               <div className="card p-6">
-                <h3 className="text-lg font-semibold text-surface-100 mb-4">Objectives</h3>
+                <h3 className="text-lg font-semibold text-surface-900 mb-4">Objectives</h3>
                 <p className="text-surface-700 whitespace-pre-wrap">{plan.objectives}</p>
               </div>
             )}
 
             {plan.scope && (
               <div className="card p-6">
-                <h3 className="text-lg font-semibold text-surface-100 mb-4">Scope</h3>
+                <h3 className="text-lg font-semibold text-surface-900 mb-4">Scope</h3>
                 <p className="text-surface-700 whitespace-pre-wrap">{plan.scope}</p>
               </div>
             )}
 
             {(plan.activation_criteria || plan.deactivation_criteria) && (
               <div className="card p-6">
-                <h3 className="text-lg font-semibold text-surface-100 mb-4">Activation Criteria</h3>
+                <h3 className="text-lg font-semibold text-surface-900 mb-4">Activation Criteria</h3>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                   {plan.activation_criteria && (
                     <div>
@@ -440,7 +440,7 @@ export default function BCDRPlanDetail() {
 
             {plan.assumptions && (
               <div className="card p-6">
-                <h3 className="text-lg font-semibold text-surface-100 mb-4">Assumptions</h3>
+                <h3 className="text-lg font-semibold text-surface-900 mb-4">Assumptions</h3>
                 <p className="text-surface-700 whitespace-pre-wrap">{plan.assumptions}</p>
               </div>
             )}
@@ -448,21 +448,21 @@ export default function BCDRPlanDetail() {
 
           <div className="space-y-6">
             <div className="card p-6">
-              <h3 className="text-lg font-semibold text-surface-100 mb-4">Details</h3>
+              <h3 className="text-lg font-semibold text-surface-900 mb-4">Details</h3>
               <div className="space-y-4">
                 <div>
                   <p className="text-surface-600 text-sm">Owner</p>
-                  <p className="text-surface-100">{plan.owner_name || '-'}</p>
+                  <p className="text-surface-900">{plan.owner_name || '-'}</p>
                 </div>
                 <div>
                   <p className="text-surface-600 text-sm">Effective Date</p>
-                  <p className="text-surface-100">
+                  <p className="text-surface-900">
                     {plan.effective_date ? new Date(plan.effective_date).toLocaleDateString() : '-'}
                   </p>
                 </div>
                 <div>
                   <p className="text-surface-600 text-sm">Next Review</p>
-                  <p className="text-surface-100">
+                  <p className="text-surface-900">
                     {plan.next_review_due
                       ? new Date(plan.next_review_due).toLocaleDateString()
                       : '-'}
@@ -470,7 +470,7 @@ export default function BCDRPlanDetail() {
                 </div>
                 <div>
                   <p className="text-surface-600 text-sm">Last Reviewed</p>
-                  <p className="text-surface-100">
+                  <p className="text-surface-900">
                     {plan.last_reviewed_at
                       ? new Date(plan.last_reviewed_at).toLocaleDateString()
                       : 'Never'}
@@ -480,23 +480,23 @@ export default function BCDRPlanDetail() {
             </div>
 
             <div className="card p-6">
-              <h3 className="text-lg font-semibold text-surface-100 mb-4">Statistics</h3>
+              <h3 className="text-lg font-semibold text-surface-900 mb-4">Statistics</h3>
               <div className="space-y-3">
                 <div className="flex justify-between">
                   <span className="text-surface-600">In-Scope Processes</span>
-                  <span className="text-surface-100">{plan.in_scope_processes?.length || 0}</span>
+                  <span className="text-surface-900">{plan.in_scope_processes?.length || 0}</span>
                 </div>
                 <div className="flex justify-between">
                   <span className="text-surface-600">DR Tests</span>
-                  <span className="text-surface-100">{plan.dr_tests?.length || 0}</span>
+                  <span className="text-surface-900">{plan.dr_tests?.length || 0}</span>
                 </div>
                 <div className="flex justify-between">
                   <span className="text-surface-600">Linked Controls</span>
-                  <span className="text-surface-100">{plan.linked_controls?.length || 0}</span>
+                  <span className="text-surface-900">{plan.linked_controls?.length || 0}</span>
                 </div>
                 <div className="flex justify-between">
                   <span className="text-surface-600">Communication Plans</span>
-                  <span className="text-surface-100">{plan.communication_plans?.length || 0}</span>
+                  <span className="text-surface-900">{plan.communication_plans?.length || 0}</span>
                 </div>
               </div>
             </div>
@@ -505,7 +505,7 @@ export default function BCDRPlanDetail() {
       )}
       {activeTab === 'processes' && (
         <div className="card p-6">
-          <h3 className="text-lg font-semibold text-surface-100 mb-4">
+          <h3 className="text-lg font-semibold text-surface-900 mb-4">
             In-Scope Business Processes
           </h3>
           {plan.in_scope_processes && plan.in_scope_processes.length > 0 ? (
@@ -514,16 +514,16 @@ export default function BCDRPlanDetail() {
                 <Link
                   key={process.id}
                   to={`/bcdr/processes/${process.id}`}
-                  className="flex items-center justify-between p-4 rounded-lg bg-surface-800/50 hover:bg-surface-700/50 transition-colors"
+                  className="flex items-center justify-between p-4 rounded-lg bg-white/50 hover:bg-surface-200/50 transition-colors"
                 >
                   <div className="flex items-center gap-3">
                     <ShieldExclamationIcon className="w-5 h-5 text-surface-600" />
                     <div>
-                      <p className="text-surface-100 font-medium">{process.name}</p>
+                      <p className="text-surface-900 font-medium">{process.name}</p>
                       <p className="text-surface-600 text-sm">{process.process_id}</p>
                     </div>
                   </div>
-                  <span className="px-2 py-1 rounded text-xs font-medium bg-surface-700 text-surface-700 capitalize">
+                  <span className="px-2 py-1 rounded text-xs font-medium bg-surface-200 text-surface-700 capitalize">
                     {process.criticality_tier?.replace('_', ' ')}
                   </span>
                 </Link>
@@ -537,7 +537,7 @@ export default function BCDRPlanDetail() {
       {activeTab === 'tests' && (
         <div className="card p-6">
           <div className="flex items-center justify-between mb-4">
-            <h3 className="text-lg font-semibold text-surface-100">DR Tests</h3>
+            <h3 className="text-lg font-semibold text-surface-900">DR Tests</h3>
             <Link
               to="/bcdr/tests/new"
               className="inline-flex items-center rounded-md border border-surface-300 bg-white px-3 h-8 text-small font-medium !text-surface-900 hover:bg-surface-100 transition-colors"
@@ -551,7 +551,7 @@ export default function BCDRPlanDetail() {
                 <Link
                   key={test.id}
                   to={`/bcdr/tests/${test.id}`}
-                  className="flex items-center justify-between p-4 rounded-lg bg-surface-800/50 hover:bg-surface-700/50 transition-colors"
+                  className="flex items-center justify-between p-4 rounded-lg bg-white/50 hover:bg-surface-200/50 transition-colors"
                 >
                   <div className="flex items-center gap-3">
                     {test.result === 'passed' ? (
@@ -562,7 +562,7 @@ export default function BCDRPlanDetail() {
                       <CalendarIcon className="w-5 h-5 text-surface-600" />
                     )}
                     <div>
-                      <p className="text-surface-100 font-medium">{test.name}</p>
+                      <p className="text-surface-900 font-medium">{test.name}</p>
                       <p className="text-surface-600 text-sm">
                         {test.scheduled_date
                           ? new Date(test.scheduled_date).toLocaleDateString()
@@ -577,7 +577,7 @@ export default function BCDRPlanDetail() {
                         ? 'bg-green-500/20 text-green-600'
                         : test.status === 'in_progress'
                           ? 'bg-yellow-500/20 text-yellow-600'
-                          : 'bg-surface-700 text-surface-700'
+                          : 'bg-surface-200 text-surface-700'
                     )}
                   >
                     {test.status?.replace('_', ' ')}
@@ -592,17 +592,17 @@ export default function BCDRPlanDetail() {
       )}
       {activeTab === 'controls' && (
         <div className="card p-6">
-          <h3 className="text-lg font-semibold text-surface-100 mb-4">Linked Controls</h3>
+          <h3 className="text-lg font-semibold text-surface-900 mb-4">Linked Controls</h3>
           {plan.linked_controls && plan.linked_controls.length > 0 ? (
             <div className="space-y-2">
               {plan.linked_controls.map((control) => (
                 <Link
                   key={control.id}
                   to={`/controls/${control.id}`}
-                  className="flex items-center justify-between p-4 rounded-lg bg-surface-800/50 hover:bg-surface-700/50 transition-colors"
+                  className="flex items-center justify-between p-4 rounded-lg bg-white/50 hover:bg-surface-200/50 transition-colors"
                 >
                   <div>
-                    <p className="text-surface-100 font-medium">{control.title}</p>
+                    <p className="text-surface-900 font-medium">{control.title}</p>
                     <p className="text-surface-600 text-sm">{control.control_id}</p>
                   </div>
                 </Link>
@@ -615,11 +615,11 @@ export default function BCDRPlanDetail() {
       )}
       {/* Edit Modal */}
       <Dialog open={showEditModal} onClose={() => setShowEditModal(false)}>
-        <div className="p-6 border-b border-surface-700 flex items-center justify-between">
+        <div className="p-6 border-b border-surface-200 flex items-center justify-between">
           <h2 className="text-xl font-semibold text-white">Edit BC/DR Plan</h2>
           <button
             onClick={() => setShowEditModal(false)}
-            className="p-2 hover:bg-surface-700 rounded-lg text-surface-600"
+            className="p-2 hover:bg-surface-200 rounded-lg text-surface-600"
           >
             <XMarkIcon className="w-5 h-5" />
           </button>
@@ -747,7 +747,7 @@ export default function BCDRPlanDetail() {
             />
           </div>
 
-          <div className="flex justify-end gap-3 pt-4 border-t border-surface-700">
+          <div className="flex justify-end gap-3 pt-4 border-t border-surface-200">
             <Button variant="secondary" type="button" onClick={() => setShowEditModal(false)}>
               Cancel
             </Button>

--- a/frontend/src/pages/BCDRPlans.tsx
+++ b/frontend/src/pages/BCDRPlans.tsx
@@ -37,7 +37,7 @@ const statusColors: Record<string, string> = {
   in_review: 'bg-yellow-500/20 text-yellow-600',
   approved: 'bg-blue-500/20 text-blue-600',
   published: 'bg-green-500/20 text-green-600',
-  archived: 'bg-surface-700 text-surface-600',
+  archived: 'bg-surface-200 text-surface-600',
   expired: 'bg-red-500/20 text-red-600',
 };
 
@@ -89,7 +89,7 @@ export default function BCDRPlans() {
       <div className="p-6">
         <div className="card p-8 text-center">
           <ExclamationCircleIcon className="w-12 h-12 mx-auto mb-4 text-red-600" />
-          <h2 className="text-lg font-semibold text-surface-100 mb-2">
+          <h2 className="text-lg font-semibold text-surface-900 mb-2">
             Failed to load BC/DR Plans
           </h2>
           <p className="text-surface-600 mb-4">
@@ -108,7 +108,7 @@ export default function BCDRPlans() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-surface-100">BC/DR Plans</h1>
+          <h1 className="text-2xl font-bold text-surface-900">BC/DR Plans</h1>
           <p className="text-surface-600 mt-1">
             Manage business continuity and disaster recovery plans
           </p>
@@ -171,9 +171,9 @@ export default function BCDRPlans() {
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {[1, 2, 3].map((i) => (
             <div key={i} className="card p-6 animate-pulse">
-              <div className="h-6 bg-surface-700 rounded w-3/4 mb-4"></div>
-              <div className="h-4 bg-surface-700 rounded w-1/2 mb-2"></div>
-              <div className="h-4 bg-surface-700 rounded w-2/3"></div>
+              <div className="h-6 bg-surface-200 rounded w-3/4 mb-4"></div>
+              <div className="h-4 bg-surface-200 rounded w-1/2 mb-2"></div>
+              <div className="h-4 bg-surface-200 rounded w-2/3"></div>
             </div>
           ))}
         </div>
@@ -211,7 +211,7 @@ export default function BCDRPlans() {
                 <span className="text-surface-600 text-xs">v{plan.version}</span>
               </div>
 
-              <h3 className="text-lg font-semibold text-surface-100 mb-1">{plan.title}</h3>
+              <h3 className="text-lg font-semibold text-surface-900 mb-1">{plan.title}</h3>
               <p className="text-surface-600 text-sm mb-3">{plan.plan_id}</p>
 
               <div className="space-y-2 text-sm">

--- a/frontend/src/pages/BusinessProcessDetail.tsx
+++ b/frontend/src/pages/BusinessProcessDetail.tsx
@@ -217,7 +217,7 @@ export default function BusinessProcessDetail() {
       <div className="p-6">
         <div className="card p-8 text-center">
           <ExclamationCircleIcon className="w-12 h-12 mx-auto mb-4 text-red-600" />
-          <h2 className="text-lg font-semibold text-surface-100 mb-2">
+          <h2 className="text-lg font-semibold text-surface-900 mb-2">
             Business Process Not Found
           </h2>
           <p className="text-surface-600 mb-4">
@@ -238,7 +238,7 @@ export default function BusinessProcessDetail() {
         <div className="flex items-start gap-4">
           <button
             onClick={() => navigate('/bcdr/processes')}
-            className="p-2 hover:bg-surface-700 rounded-lg text-surface-600 mt-1"
+            className="p-2 hover:bg-surface-200 rounded-lg text-surface-600 mt-1"
           >
             <ArrowLeftIcon className="w-5 h-5" />
           </button>
@@ -246,7 +246,7 @@ export default function BusinessProcessDetail() {
             <div className="flex items-center gap-3 mb-2">
               <ShieldExclamationIcon className="w-8 h-8 text-brand-400" />
               <div>
-                <h1 className="text-2xl font-bold text-surface-100">{process.name}</h1>
+                <h1 className="text-2xl font-bold text-surface-900">{process.name}</h1>
                 <p className="text-surface-600 text-sm">{process.process_id}</p>
               </div>
             </div>
@@ -289,7 +289,7 @@ export default function BusinessProcessDetail() {
         </div>
       </div>
       {/* Tabs */}
-      <div className="border-b border-surface-700">
+      <div className="border-b border-surface-200">
         <nav className="flex gap-6">
           {(['overview', 'dependencies', 'assets', 'plans'] as const).map((tab) => (
             <button
@@ -299,7 +299,7 @@ export default function BusinessProcessDetail() {
                 'pb-3 px-1 text-sm font-medium border-b-2 transition-colors capitalize',
                 activeTab === tab
                   ? 'border-brand-500 text-brand-400'
-                  : 'border-transparent text-surface-600 hover:text-surface-200'
+                  : 'border-transparent text-surface-600 hover:text-surface-800'
               )}
             >
               {tab}
@@ -313,32 +313,32 @@ export default function BusinessProcessDetail() {
           {/* Main Info */}
           <div className="lg:col-span-2 space-y-6">
             <div className="card p-6">
-              <h3 className="text-lg font-semibold text-surface-100 mb-4">Description</h3>
+              <h3 className="text-lg font-semibold text-surface-900 mb-4">Description</h3>
               <p className="text-surface-700">
                 {process.description || 'No description provided.'}
               </p>
             </div>
 
             <div className="card p-6">
-              <h3 className="text-lg font-semibold text-surface-100 mb-4">Recovery Objectives</h3>
+              <h3 className="text-lg font-semibold text-surface-900 mb-4">Recovery Objectives</h3>
               <div className="grid grid-cols-3 gap-4">
-                <div className="p-4 rounded-lg bg-surface-800/50">
+                <div className="p-4 rounded-lg bg-white/50">
                   <p className="text-surface-600 text-sm">RTO</p>
-                  <p className="text-2xl font-bold text-surface-100">
+                  <p className="text-2xl font-bold text-surface-900">
                     {process.rto_hours || 'N/A'}h
                   </p>
                   <p className="text-surface-500 text-xs">Recovery Time Objective</p>
                 </div>
-                <div className="p-4 rounded-lg bg-surface-800/50">
+                <div className="p-4 rounded-lg bg-white/50">
                   <p className="text-surface-600 text-sm">RPO</p>
-                  <p className="text-2xl font-bold text-surface-100">
+                  <p className="text-2xl font-bold text-surface-900">
                     {process.rpo_hours || 'N/A'}h
                   </p>
                   <p className="text-surface-500 text-xs">Recovery Point Objective</p>
                 </div>
-                <div className="p-4 rounded-lg bg-surface-800/50">
+                <div className="p-4 rounded-lg bg-white/50">
                   <p className="text-surface-600 text-sm">MTPD</p>
-                  <p className="text-2xl font-bold text-surface-100">
+                  <p className="text-2xl font-bold text-surface-900">
                     {process.mtpd_hours || 'N/A'}h
                   </p>
                   <p className="text-surface-500 text-xs">Max Tolerable Downtime</p>
@@ -348,37 +348,37 @@ export default function BusinessProcessDetail() {
 
             {process.impact_description && (
               <div className="card p-6">
-                <h3 className="text-lg font-semibold text-surface-100 mb-4">Business Impact</h3>
+                <h3 className="text-lg font-semibold text-surface-900 mb-4">Business Impact</h3>
                 <p className="text-surface-700">{process.impact_description}</p>
               </div>
             )}
 
             <div className="card p-6">
-              <h3 className="text-lg font-semibold text-surface-100 mb-4">Continuity Details</h3>
+              <h3 className="text-lg font-semibold text-surface-900 mb-4">Continuity Details</h3>
               <div className="grid grid-cols-2 gap-4">
                 <div>
                   <p className="text-surface-600 text-sm">Recovery Priority</p>
-                  <p className="text-surface-100">{process.recovery_priority || 'Not set'}</p>
+                  <p className="text-surface-900">{process.recovery_priority || 'Not set'}</p>
                 </div>
                 <div>
                   <p className="text-surface-600 text-sm">Minimum Staff Required</p>
-                  <p className="text-surface-100">{process.minimum_staff_required || 'Not set'}</p>
+                  <p className="text-surface-900">{process.minimum_staff_required || 'Not set'}</p>
                 </div>
                 <div>
                   <p className="text-surface-600 text-sm">Alternate Site Required</p>
-                  <p className="text-surface-100">
+                  <p className="text-surface-900">
                     {process.alternate_site_required ? 'Yes' : 'No'}
                   </p>
                 </div>
                 <div>
                   <p className="text-surface-600 text-sm">Manual Workaround Available</p>
-                  <p className="text-surface-100">
+                  <p className="text-surface-900">
                     {process.manual_workaround_available ? 'Yes' : 'No'}
                   </p>
                 </div>
               </div>
               {process.workaround_description && (
-                <div className="mt-4 pt-4 border-t border-surface-700">
+                <div className="mt-4 pt-4 border-t border-surface-200">
                   <p className="text-surface-600 text-sm mb-2">Workaround Description</p>
                   <p className="text-surface-700">{process.workaround_description}</p>
                 </div>
@@ -389,15 +389,15 @@ export default function BusinessProcessDetail() {
           {/* Sidebar */}
           <div className="space-y-6">
             <div className="card p-6">
-              <h3 className="text-lg font-semibold text-surface-100 mb-4">Details</h3>
+              <h3 className="text-lg font-semibold text-surface-900 mb-4">Details</h3>
               <div className="space-y-4">
                 <div>
                   <p className="text-surface-600 text-sm">Department</p>
-                  <p className="text-surface-100">{process.department || '-'}</p>
+                  <p className="text-surface-900">{process.department || '-'}</p>
                 </div>
                 <div>
                   <p className="text-surface-600 text-sm">Owner</p>
-                  <p className="text-surface-100">{process.owner_name || '-'}</p>
+                  <p className="text-surface-900">{process.owner_name || '-'}</p>
                   {process.owner_email && (
                     <p className="text-surface-500 text-sm">{process.owner_email}</p>
                   )}
@@ -406,7 +406,7 @@ export default function BusinessProcessDetail() {
                   <p className="text-surface-600 text-sm">Next Review Due</p>
                   <p
                     className={clsx(
-                      'text-surface-100',
+                      'text-surface-900',
                       process.next_review_due &&
                         isOverdue(process.next_review_due) &&
                         'text-red-600'
@@ -419,7 +419,7 @@ export default function BusinessProcessDetail() {
                 </div>
                 <div>
                   <p className="text-surface-600 text-sm">Last Reviewed</p>
-                  <p className="text-surface-100">
+                  <p className="text-surface-900">
                     {process.last_reviewed_at
                       ? new Date(process.last_reviewed_at).toLocaleDateString()
                       : 'Never'}
@@ -429,23 +429,23 @@ export default function BusinessProcessDetail() {
             </div>
 
             <div className="card p-6">
-              <h3 className="text-lg font-semibold text-surface-100 mb-4">Statistics</h3>
+              <h3 className="text-lg font-semibold text-surface-900 mb-4">Statistics</h3>
               <div className="space-y-3">
                 <div className="flex justify-between">
                   <span className="text-surface-600">Dependencies</span>
-                  <span className="text-surface-100">{process.dependencies?.length || 0}</span>
+                  <span className="text-surface-900">{process.dependencies?.length || 0}</span>
                 </div>
                 <div className="flex justify-between">
                   <span className="text-surface-600">Assets</span>
-                  <span className="text-surface-100">{process.assets?.length || 0}</span>
+                  <span className="text-surface-900">{process.assets?.length || 0}</span>
                 </div>
                 <div className="flex justify-between">
                   <span className="text-surface-600">BC/DR Plans</span>
-                  <span className="text-surface-100">{process.bcdr_plans?.length || 0}</span>
+                  <span className="text-surface-900">{process.bcdr_plans?.length || 0}</span>
                 </div>
                 <div className="flex justify-between">
                   <span className="text-surface-600">Recovery Strategies</span>
-                  <span className="text-surface-100">
+                  <span className="text-surface-900">
                     {process.recovery_strategies?.length || 0}
                   </span>
                 </div>
@@ -456,19 +456,19 @@ export default function BusinessProcessDetail() {
       )}
       {activeTab === 'dependencies' && (
         <div className="card p-6">
-          <h3 className="text-lg font-semibold text-surface-100 mb-4">Process Dependencies</h3>
+          <h3 className="text-lg font-semibold text-surface-900 mb-4">Process Dependencies</h3>
           {process.dependencies && process.dependencies.length > 0 ? (
             <div className="space-y-2">
               {process.dependencies.map((dep) => (
                 <Link
                   key={dep.id}
                   to={`/bcdr/processes/${dep.dependent_process_id}`}
-                  className="flex items-center justify-between p-4 rounded-lg bg-surface-800/50 hover:bg-surface-700/50 transition-colors"
+                  className="flex items-center justify-between p-4 rounded-lg bg-white/50 hover:bg-surface-200/50 transition-colors"
                 >
                   <div className="flex items-center gap-3">
                     <LinkIcon className="w-5 h-5 text-surface-600" />
                     <div>
-                      <p className="text-surface-100 font-medium">{dep.dependent_process_name}</p>
+                      <p className="text-surface-900 font-medium">{dep.dependent_process_name}</p>
                       <p className="text-surface-600 text-sm capitalize">{dep.dependency_type}</p>
                     </div>
                   </div>
@@ -482,19 +482,19 @@ export default function BusinessProcessDetail() {
       )}
       {activeTab === 'assets' && (
         <div className="card p-6">
-          <h3 className="text-lg font-semibold text-surface-100 mb-4">Supporting Assets</h3>
+          <h3 className="text-lg font-semibold text-surface-900 mb-4">Supporting Assets</h3>
           {process.assets && process.assets.length > 0 ? (
             <div className="space-y-2">
               {process.assets.map((asset) => (
                 <Link
                   key={asset.id}
                   to={`/assets/${asset.asset_id}`}
-                  className="flex items-center justify-between p-4 rounded-lg bg-surface-800/50 hover:bg-surface-700/50 transition-colors"
+                  className="flex items-center justify-between p-4 rounded-lg bg-white/50 hover:bg-surface-200/50 transition-colors"
                 >
                   <div className="flex items-center gap-3">
                     <CubeIcon className="w-5 h-5 text-surface-600" />
                     <div>
-                      <p className="text-surface-100 font-medium">{asset.asset_name}</p>
+                      <p className="text-surface-900 font-medium">{asset.asset_name}</p>
                       <p className="text-surface-600 text-sm capitalize">{asset.asset_type}</p>
                     </div>
                   </div>
@@ -508,23 +508,23 @@ export default function BusinessProcessDetail() {
       )}
       {activeTab === 'plans' && (
         <div className="card p-6">
-          <h3 className="text-lg font-semibold text-surface-100 mb-4">BC/DR Plans</h3>
+          <h3 className="text-lg font-semibold text-surface-900 mb-4">BC/DR Plans</h3>
           {process.bcdr_plans && process.bcdr_plans.length > 0 ? (
             <div className="space-y-2">
               {process.bcdr_plans.map((plan) => (
                 <Link
                   key={plan.id}
                   to={`/bcdr/plans/${plan.id}`}
-                  className="flex items-center justify-between p-4 rounded-lg bg-surface-800/50 hover:bg-surface-700/50 transition-colors"
+                  className="flex items-center justify-between p-4 rounded-lg bg-white/50 hover:bg-surface-200/50 transition-colors"
                 >
                   <div className="flex items-center gap-3">
                     <DocumentTextIcon className="w-5 h-5 text-surface-600" />
                     <div>
-                      <p className="text-surface-100 font-medium">{plan.title}</p>
+                      <p className="text-surface-900 font-medium">{plan.title}</p>
                       <p className="text-surface-600 text-sm">{plan.plan_id}</p>
                     </div>
                   </div>
-                  <span className="px-2 py-1 rounded text-xs font-medium bg-surface-700 text-surface-700 capitalize">
+                  <span className="px-2 py-1 rounded text-xs font-medium bg-surface-200 text-surface-700 capitalize">
                     {plan.status}
                   </span>
                 </Link>
@@ -537,11 +537,11 @@ export default function BusinessProcessDetail() {
       )}
       {/* Edit Modal */}
       <Dialog open={showEditModal} onClose={() => setShowEditModal(false)}>
-        <div className="p-6 border-b border-surface-700 flex items-center justify-between">
+        <div className="p-6 border-b border-surface-200 flex items-center justify-between">
           <h2 className="text-xl font-semibold text-white">Edit Business Process</h2>
           <button
             onClick={() => setShowEditModal(false)}
-            className="p-2 hover:bg-surface-700 rounded-lg text-surface-600"
+            className="p-2 hover:bg-surface-200 rounded-lg text-surface-600"
           >
             <XMarkIcon className="w-5 h-5" />
           </button>
@@ -712,7 +712,7 @@ export default function BusinessProcessDetail() {
                     alternate_site_required: e.target.checked,
                   }))
                 }
-                className="rounded border-surface-600 bg-surface-700 text-brand-600"
+                className="rounded border-surface-300 bg-surface-200 text-brand-600"
               />
               <span className="text-surface-700 text-sm">Alternate Site Required</span>
             </label>
@@ -726,7 +726,7 @@ export default function BusinessProcessDetail() {
                     manual_workaround_available: e.target.checked,
                   }))
                 }
-                className="rounded border-surface-600 bg-surface-700 text-brand-600"
+                className="rounded border-surface-300 bg-surface-200 text-brand-600"
               />
               <span className="text-surface-700 text-sm">Manual Workaround Available</span>
             </label>
@@ -748,7 +748,7 @@ export default function BusinessProcessDetail() {
             </div>
           )}
 
-          <div className="flex justify-end gap-3 pt-4 border-t border-surface-700">
+          <div className="flex justify-end gap-3 pt-4 border-t border-surface-200">
             <Button variant="secondary" type="button" onClick={() => setShowEditModal(false)}>
               Cancel
             </Button>

--- a/frontend/src/pages/BusinessProcesses.tsx
+++ b/frontend/src/pages/BusinessProcesses.tsx
@@ -87,7 +87,7 @@ export default function BusinessProcesses() {
       <div className="p-6">
         <div className="card p-8 text-center">
           <ExclamationCircleIcon className="w-12 h-12 mx-auto mb-4 text-red-600" />
-          <h2 className="text-lg font-semibold text-surface-100 mb-2">
+          <h2 className="text-lg font-semibold text-surface-900 mb-2">
             Failed to load Business Processes
           </h2>
           <p className="text-surface-600 mb-4">
@@ -106,7 +106,7 @@ export default function BusinessProcesses() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-surface-100">Business Processes</h1>
+          <h1 className="text-2xl font-bold text-surface-900">Business Processes</h1>
           <p className="text-surface-600 mt-1">
             Manage critical business processes and their impact analysis
           </p>
@@ -166,7 +166,7 @@ export default function BusinessProcesses() {
         ) : (
           <div className="overflow-x-auto">
             <table className="w-full">
-              <thead className="bg-surface-800/50">
+              <thead className="bg-white/50">
                 <tr>
                   <th className="text-left p-4 text-surface-700 font-medium">Process</th>
                   <th className="text-left p-4 text-surface-700 font-medium">Criticality</th>
@@ -177,13 +177,13 @@ export default function BusinessProcesses() {
                   <th className="text-left p-4 text-surface-700 font-medium">Status</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-surface-700">
+              <tbody className="divide-y divide-surface-200">
                 {processes.map((process: BusinessProcess) => (
-                  <tr key={process.id} className="hover:bg-surface-800/30 transition-colors">
+                  <tr key={process.id} className="hover:bg-white/30 transition-colors">
                     <td className="p-4">
                       <Link
                         to={`/bcdr/processes/${process.id}`}
-                        className="text-surface-100 font-medium hover:text-brand-400 transition-colors"
+                        className="text-surface-900 font-medium hover:text-brand-400 transition-colors"
                       >
                         {process.name}
                       </Link>
@@ -253,7 +253,7 @@ export default function BusinessProcesses() {
 
         {/* Pagination */}
         {totalPages > 1 && (
-          <div className="flex items-center justify-between p-4 border-t border-surface-700">
+          <div className="flex items-center justify-between p-4 border-t border-surface-200">
             <Button
               onClick={() => setPage((p) => Math.max(1, p - 1))}
               disabled={page === 1}

--- a/frontend/src/pages/CommunicationPlanDetail.tsx
+++ b/frontend/src/pages/CommunicationPlanDetail.tsx
@@ -170,7 +170,7 @@ export default function CommunicationPlanDetail() {
       <div className="p-6">
         <div className="card p-8 text-center">
           <ExclamationCircleIcon className="w-12 h-12 mx-auto mb-4 text-red-600" />
-          <h2 className="text-lg font-semibold text-surface-100 mb-2">
+          <h2 className="text-lg font-semibold text-surface-900 mb-2">
             Communication Plan Not Found
           </h2>
           <p className="text-surface-600 mb-4">The requested plan could not be loaded.</p>
@@ -187,12 +187,12 @@ export default function CommunicationPlanDetail() {
         <div className="flex items-start gap-4">
           <button
             onClick={() => navigate('/bcdr/communication')}
-            className="p-2 hover:bg-surface-700 rounded-lg text-surface-600 mt-1"
+            className="p-2 hover:bg-surface-200 rounded-lg text-surface-600 mt-1"
           >
             <ArrowLeftIcon className="w-5 h-5" />
           </button>
           <div>
-            <h1 className="text-2xl font-bold text-surface-100">Create Communication Plan</h1>
+            <h1 className="text-2xl font-bold text-surface-900">Create Communication Plan</h1>
             <p className="text-surface-600 mt-1">
               Set up emergency contact lists and communication protocols
             </p>
@@ -212,7 +212,7 @@ export default function CommunicationPlanDetail() {
                 type="text"
                 value={editForm.name}
                 onChange={(e) => setEditForm({ ...editForm, name: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-surface-100 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-surface-900 focus:outline-none focus:ring-2 focus:ring-primary-500"
                 placeholder="e.g., Emergency Response Communication Plan"
                 required
               />
@@ -223,7 +223,7 @@ export default function CommunicationPlanDetail() {
               <SelectNative
                 value={editForm.plan_type}
                 onChange={(e) => setEditForm({ ...editForm, plan_type: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-surface-100 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-surface-900 focus:outline-none focus:ring-2 focus:ring-primary-500"
               >
                 {PLAN_TYPES.map((type) => (
                   <option key={type.value} value={type.value}>
@@ -239,7 +239,7 @@ export default function CommunicationPlanDetail() {
                 value={editForm.description}
                 onChange={(e) => setEditForm({ ...editForm, description: e.target.value })}
                 rows={4}
-                className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-surface-100 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-surface-900 focus:outline-none focus:ring-2 focus:ring-primary-500"
                 placeholder="Describe the purpose and scope of this communication plan..."
               />
             </div>
@@ -250,7 +250,7 @@ export default function CommunicationPlanDetail() {
                 id="is_active"
                 checked={editForm.is_active}
                 onChange={(e) => setEditForm({ ...editForm, is_active: e.target.checked })}
-                className="w-4 h-4 rounded bg-surface-700 border-surface-600 text-primary-500 focus:ring-primary-500"
+                className="w-4 h-4 rounded bg-surface-200 border-surface-300 text-primary-500 focus:ring-primary-500"
               />
               <label htmlFor="is_active" className="text-sm text-surface-700">
                 Active (plan is ready for use)
@@ -285,14 +285,14 @@ export default function CommunicationPlanDetail() {
         <div className="flex items-start gap-4">
           <button
             onClick={() => navigate('/bcdr/communication')}
-            className="p-2 hover:bg-surface-700 rounded-lg text-surface-600 mt-1"
+            className="p-2 hover:bg-surface-200 rounded-lg text-surface-600 mt-1"
           >
             <ArrowLeftIcon className="w-5 h-5" />
           </button>
           <div>
             <div className="flex items-center gap-3 mb-2">
               <MegaphoneIcon className="w-8 h-8 text-orange-600" />
-              <h1 className="text-2xl font-bold text-surface-100">{plan.name}</h1>
+              <h1 className="text-2xl font-bold text-surface-900">{plan.name}</h1>
               <span
                 className={clsx(
                   'px-2 py-1 text-xs font-medium rounded-full',
@@ -330,8 +330,8 @@ export default function CommunicationPlanDetail() {
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <div className="lg:col-span-2">
           <div className="card">
-            <div className="p-4 border-b border-surface-700 flex items-center justify-between">
-              <h2 className="text-lg font-semibold text-surface-100">
+            <div className="p-4 border-b border-surface-200 flex items-center justify-between">
+              <h2 className="text-lg font-semibold text-surface-900">
                 <UserGroupIcon className="w-5 h-5 inline mr-2 text-surface-600" />
                 Contacts ({plan.contacts?.length || 0})
               </h2>
@@ -340,14 +340,14 @@ export default function CommunicationPlanDetail() {
                 Add Contact
               </Button>
             </div>
-            <div className="divide-y divide-surface-700">
+            <div className="divide-y divide-surface-200">
               {plan.contacts && plan.contacts.length > 0 ? (
                 plan.contacts.map((contact) => (
-                  <div key={contact.id} className="p-4 hover:bg-surface-700/50">
+                  <div key={contact.id} className="p-4 hover:bg-surface-200/50">
                     <div className="flex items-start justify-between">
                       <div>
                         <div className="flex items-center gap-2 mb-1">
-                          <span className="font-medium text-surface-100">{contact.name}</span>
+                          <span className="font-medium text-surface-900">{contact.name}</span>
                           <Badge variant="info">Level {contact.escalation_level}</Badge>
                         </div>
                         <p className="text-sm text-surface-600">{contact.title}</p>
@@ -383,15 +383,15 @@ export default function CommunicationPlanDetail() {
             <div className="space-y-3">
               <div>
                 <span className="text-xs text-surface-500">Linked BC/DR Plan</span>
-                <p className="text-surface-100">{plan.bcdr_plan_title || 'None'}</p>
+                <p className="text-surface-900">{plan.bcdr_plan_title || 'None'}</p>
               </div>
               <div>
                 <span className="text-xs text-surface-500">Created</span>
-                <p className="text-surface-100">{new Date(plan.created_at).toLocaleDateString()}</p>
+                <p className="text-surface-900">{new Date(plan.created_at).toLocaleDateString()}</p>
               </div>
               <div>
                 <span className="text-xs text-surface-500">Last Updated</span>
-                <p className="text-surface-100">{new Date(plan.updated_at).toLocaleDateString()}</p>
+                <p className="text-surface-900">{new Date(plan.updated_at).toLocaleDateString()}</p>
               </div>
             </div>
           </div>
@@ -399,11 +399,11 @@ export default function CommunicationPlanDetail() {
       </div>
       {/* Edit Modal */}
       <Dialog open={showEditModal} onClose={() => setShowEditModal(false)}>
-        <div className="p-4 border-b border-surface-700 flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-surface-100">Edit Communication Plan</h2>
+        <div className="p-4 border-b border-surface-200 flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-surface-900">Edit Communication Plan</h2>
           <button
             onClick={() => setShowEditModal(false)}
-            className="p-1 hover:bg-surface-700 rounded"
+            className="p-1 hover:bg-surface-200 rounded"
           >
             <XMarkIcon className="w-5 h-5 text-surface-600" />
           </button>
@@ -421,7 +421,7 @@ export default function CommunicationPlanDetail() {
               type="text"
               value={editForm.name}
               onChange={(e) => setEditForm({ ...editForm, name: e.target.value })}
-              className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-surface-100"
+              className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-surface-900"
               required
             />
           </div>
@@ -430,7 +430,7 @@ export default function CommunicationPlanDetail() {
             <SelectNative
               value={editForm.plan_type}
               onChange={(e) => setEditForm({ ...editForm, plan_type: e.target.value })}
-              className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-surface-100"
+              className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-surface-900"
             >
               {PLAN_TYPES.map((type) => (
                 <option key={type.value} value={type.value}>
@@ -445,7 +445,7 @@ export default function CommunicationPlanDetail() {
               value={editForm.description}
               onChange={(e) => setEditForm({ ...editForm, description: e.target.value })}
               rows={3}
-              className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-surface-100"
+              className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-surface-900"
             />
           </div>
           <div className="flex items-center gap-2">
@@ -454,7 +454,7 @@ export default function CommunicationPlanDetail() {
               id="edit_is_active"
               checked={editForm.is_active}
               onChange={(e) => setEditForm({ ...editForm, is_active: e.target.checked })}
-              className="w-4 h-4 rounded bg-surface-700 border-surface-600 text-primary-500"
+              className="w-4 h-4 rounded bg-surface-200 border-surface-300 text-primary-500"
             />
             <label htmlFor="edit_is_active" className="text-sm text-surface-700">
               Active
@@ -472,7 +472,7 @@ export default function CommunicationPlanDetail() {
       </Dialog>
       {/* Delete Confirmation */}
       <Dialog open={showDeleteConfirm} onClose={() => setShowDeleteConfirm(false)}>
-        <h2 className="text-lg font-semibold text-surface-100 mb-2">Delete Communication Plan?</h2>
+        <h2 className="text-lg font-semibold text-surface-900 mb-2">Delete Communication Plan?</h2>
         <p className="text-surface-600 mb-4">
           This will permanently delete "{plan.name}" and all associated contacts. This action cannot
           be undone.

--- a/frontend/src/pages/CommunicationPlans.tsx
+++ b/frontend/src/pages/CommunicationPlans.tsx
@@ -104,7 +104,7 @@ export default function CommunicationPlans() {
       <div className="p-6">
         <div className="card p-8 text-center">
           <ExclamationCircleIcon className="w-12 h-12 mx-auto mb-4 text-red-600" />
-          <h2 className="text-lg font-semibold text-surface-100 mb-2">
+          <h2 className="text-lg font-semibold text-surface-900 mb-2">
             Failed to load Communication Plans
           </h2>
           <p className="text-surface-600 mb-4">
@@ -123,7 +123,7 @@ export default function CommunicationPlans() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-surface-100">Communication Plans</h1>
+          <h1 className="text-2xl font-bold text-surface-900">Communication Plans</h1>
           <p className="text-surface-600 mt-1">
             Emergency contact lists and communication protocols
           </p>
@@ -206,7 +206,7 @@ export default function CommunicationPlans() {
                       L{level}
                     </div>
                     <div>
-                      <h2 className="text-lg font-semibold text-surface-100">
+                      <h2 className="text-lg font-semibold text-surface-900">
                         Level {level} Contacts
                       </h2>
                       <p className="text-surface-600 text-sm">
@@ -223,11 +223,11 @@ export default function CommunicationPlans() {
                     {(contacts as EscalationContact[]).map((contact) => (
                       <div
                         key={contact.id}
-                        className="p-4 rounded-lg bg-surface-800/50 border border-surface-700"
+                        className="p-4 rounded-lg bg-white/50 border border-surface-200"
                       >
                         <div className="flex items-start justify-between mb-2">
                           <div>
-                            <h3 className="text-surface-100 font-medium">{contact.name}</h3>
+                            <h3 className="text-surface-900 font-medium">{contact.name}</h3>
                             {contact.title && (
                               <p className="text-surface-600 text-sm">{contact.title}</p>
                             )}
@@ -264,7 +264,7 @@ export default function CommunicationPlans() {
                         </div>
 
                         {contact.role_in_plan && (
-                          <p className="text-surface-500 text-xs mt-2 pt-2 border-t border-surface-700">
+                          <p className="text-surface-500 text-xs mt-2 pt-2 border-t border-surface-200">
                             Role: {contact.role_in_plan}
                           </p>
                         )}
@@ -293,9 +293,9 @@ export default function CommunicationPlans() {
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
               {[1, 2, 3].map((i) => (
                 <div key={i} className="card p-6 animate-pulse">
-                  <div className="h-6 bg-surface-700 rounded w-3/4 mb-4"></div>
-                  <div className="h-4 bg-surface-700 rounded w-1/2 mb-2"></div>
-                  <div className="h-4 bg-surface-700 rounded w-2/3"></div>
+                  <div className="h-6 bg-surface-200 rounded w-3/4 mb-4"></div>
+                  <div className="h-4 bg-surface-200 rounded w-1/2 mb-2"></div>
+                  <div className="h-4 bg-surface-200 rounded w-2/3"></div>
                 </div>
               ))}
             </div>
@@ -332,12 +332,12 @@ export default function CommunicationPlans() {
                         {plan.is_active ? 'Active' : 'Inactive'}
                       </span>
                     </div>
-                    <span className="px-2 py-0.5 rounded bg-surface-700 text-surface-700 text-xs">
+                    <span className="px-2 py-0.5 rounded bg-surface-200 text-surface-700 text-xs">
                       {planTypeLabels[plan.plan_type] || plan.plan_type}
                     </span>
                   </div>
 
-                  <h3 className="text-lg font-semibold text-surface-100 mb-1">{plan.name}</h3>
+                  <h3 className="text-lg font-semibold text-surface-900 mb-1">{plan.name}</h3>
 
                   {plan.description && (
                     <p className="text-surface-600 text-sm mb-4 line-clamp-2">{plan.description}</p>

--- a/frontend/src/pages/ComplianceCalendarPage.tsx
+++ b/frontend/src/pages/ComplianceCalendarPage.tsx
@@ -7,7 +7,7 @@ export default function ComplianceCalendarPage() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-surface-100 flex items-center gap-3">
+          <h1 className="text-2xl font-bold text-surface-900 flex items-center gap-3">
             <CalendarDaysIcon className="w-8 h-8 text-brand-500" />
             Compliance Calendar
           </h1>

--- a/frontend/src/pages/ConfigAsCode.tsx
+++ b/frontend/src/pages/ConfigAsCode.tsx
@@ -154,21 +154,21 @@ function ConfigAsCodeContent() {
     <div className="space-y-6 animate-fade-in">
       {/* Header */}
       <div>
-        <h1 className="text-2xl font-bold text-surface-100">Configuration as Code</h1>
+        <h1 className="text-2xl font-bold text-surface-900">Configuration as Code</h1>
         <p className="text-surface-600 mt-1">
           Manage your GRC resources declaratively with version control
         </p>
       </div>
 
       {/* Tabs */}
-      <div className="border-b border-surface-700">
+      <div className="border-b border-surface-200">
         <nav className="flex gap-4">
           <button
             onClick={() => setActiveTab('ide')}
             className={
               activeTab === 'ide'
                 ? 'px-4 py-2 border-b-2 border-brand-500 text-brand-300 font-medium'
-                : 'px-4 py-2 text-surface-600 hover:text-surface-200'
+                : 'px-4 py-2 text-surface-600 hover:text-surface-800'
             }
           >
             <div className="flex items-center gap-2">
@@ -181,7 +181,7 @@ function ConfigAsCodeContent() {
             className={
               activeTab === 'export'
                 ? 'px-4 py-2 border-b-2 border-brand-500 text-brand-300 font-medium'
-                : 'px-4 py-2 text-surface-600 hover:text-surface-200'
+                : 'px-4 py-2 text-surface-600 hover:text-surface-800'
             }
           >
             <div className="flex items-center gap-2">
@@ -255,7 +255,7 @@ function ExportImportContent({
       <div className="card p-6">
         <div className="flex items-center gap-3 mb-4">
           <ArrowDownTrayIcon className="w-6 h-6 text-brand-400" />
-          <h2 className="text-lg font-semibold text-surface-100">Export Configuration</h2>
+          <h2 className="text-lg font-semibold text-surface-900">Export Configuration</h2>
         </div>
         <p className="text-surface-600 mb-4">
           Export your current GRC state to a configuration file for version control.
@@ -330,7 +330,7 @@ function ExportImportContent({
       <div className="card p-6">
         <div className="flex items-center gap-3 mb-4">
           <ArrowUpTrayIcon className="w-6 h-6 text-brand-400" />
-          <h2 className="text-lg font-semibold text-surface-100">Import Configuration</h2>
+          <h2 className="text-lg font-semibold text-surface-900">Import Configuration</h2>
         </div>
         <p className="text-surface-600 mb-4">
           Import a configuration file to apply changes to your GRC resources.
@@ -383,7 +383,7 @@ function ExportImportContent({
               value={importConfig}
               onChange={(e) => setImportConfig(e.target.value)}
               placeholder="Paste your configuration here or upload a file..."
-              className="w-full h-64 px-4 py-3 bg-surface-800 border border-surface-700 rounded-lg text-surface-200 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+              className="w-full h-64 px-4 py-3 bg-white border border-surface-200 rounded-lg text-surface-800 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
             />
           </div>
 
@@ -410,11 +410,11 @@ function ExportImportContent({
         </div>
       </div>
       {/* Info Section */}
-      <div className="bg-surface-800 border border-surface-700 rounded-lg p-4">
+      <div className="bg-white border border-surface-200 rounded-lg p-4">
         <div className="flex items-start gap-3">
           <CodeBracketIcon className="w-5 h-5 text-brand-400 flex-shrink-0 mt-0.5" />
           <div>
-            <h3 className="text-sm font-medium text-surface-200 mb-1">
+            <h3 className="text-sm font-medium text-surface-800 mb-1">
               About Configuration as Code
             </h3>
             <p className="text-sm text-surface-600">

--- a/frontend/src/pages/ContractDetail.tsx
+++ b/frontend/src/pages/ContractDetail.tsx
@@ -79,10 +79,10 @@ function ContractForm({ contract, onSave, onCancel }: ContractFormProps) {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
-      <div className="bg-surface-900 border border-surface-800 rounded-lg p-6 space-y-6">
+      <div className="bg-white border border-surface-200 rounded-lg p-6 space-y-6">
         {/* Basic Information */}
         <div>
-          <h3 className="text-lg font-medium text-surface-100 mb-4">Basic Information</h3>
+          <h3 className="text-lg font-medium text-surface-900 mb-4">Basic Information</h3>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
               <label className="block text-sm font-medium text-surface-600 mb-1">
@@ -92,7 +92,7 @@ function ContractForm({ contract, onSave, onCancel }: ContractFormProps) {
                 type="text"
                 value={formData.title}
                 onChange={(e) => setFormData({ ...formData, title: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
                 required
               />
             </div>
@@ -103,7 +103,7 @@ function ContractForm({ contract, onSave, onCancel }: ContractFormProps) {
               <SelectNative
                 value={formData.contractType}
                 onChange={(e) => setFormData({ ...formData, contractType: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
                 required
               >
                 <option value="msa">MSA</option>
@@ -119,7 +119,7 @@ function ContractForm({ contract, onSave, onCancel }: ContractFormProps) {
               <SelectNative
                 value={formData.status}
                 onChange={(e) => setFormData({ ...formData, status: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
                 required
               >
                 <option value="active">Active</option>
@@ -134,7 +134,7 @@ function ContractForm({ contract, onSave, onCancel }: ContractFormProps) {
                 type="text"
                 value={formData.vendorId}
                 onChange={(e) => setFormData({ ...formData, vendorId: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
                 required
               />
             </div>
@@ -148,13 +148,13 @@ function ContractForm({ contract, onSave, onCancel }: ContractFormProps) {
             value={formData.description || ''}
             onChange={(e) => setFormData({ ...formData, description: e.target.value })}
             rows={3}
-            className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+            className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
           />
         </div>
 
         {/* Financial Information */}
         <div>
-          <h3 className="text-lg font-medium text-surface-100 mb-4">Financial Information</h3>
+          <h3 className="text-lg font-medium text-surface-900 mb-4">Financial Information</h3>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
               <label className="block text-sm font-medium text-surface-600 mb-1">
@@ -169,7 +169,7 @@ function ContractForm({ contract, onSave, onCancel }: ContractFormProps) {
                     contractValue: parseFloat(e.target.value) || undefined,
                   })
                 }
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               />
             </div>
             <div>
@@ -177,7 +177,7 @@ function ContractForm({ contract, onSave, onCancel }: ContractFormProps) {
               <SelectNative
                 value={formData.currency}
                 onChange={(e) => setFormData({ ...formData, currency: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               >
                 <option value="USD">USD</option>
                 <option value="EUR">EUR</option>
@@ -189,7 +189,7 @@ function ContractForm({ contract, onSave, onCancel }: ContractFormProps) {
 
         {/* Dates */}
         <div>
-          <h3 className="text-lg font-medium text-surface-100 mb-4">Important Dates</h3>
+          <h3 className="text-lg font-medium text-surface-900 mb-4">Important Dates</h3>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             <div>
               <label className="block text-sm font-medium text-surface-600 mb-1">
@@ -199,7 +199,7 @@ function ContractForm({ contract, onSave, onCancel }: ContractFormProps) {
                 type="date"
                 value={formData.startDate}
                 onChange={(e) => setFormData({ ...formData, startDate: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
                 required
               />
             </div>
@@ -209,7 +209,7 @@ function ContractForm({ contract, onSave, onCancel }: ContractFormProps) {
                 type="date"
                 value={formData.endDate}
                 onChange={(e) => setFormData({ ...formData, endDate: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
                 required
               />
             </div>
@@ -221,7 +221,7 @@ function ContractForm({ contract, onSave, onCancel }: ContractFormProps) {
                 type="date"
                 value={formData.renewalDate || ''}
                 onChange={(e) => setFormData({ ...formData, renewalDate: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               />
             </div>
           </div>
@@ -231,7 +231,7 @@ function ContractForm({ contract, onSave, onCancel }: ContractFormProps) {
                 type="checkbox"
                 checked={formData.autoRenew}
                 onChange={(e) => setFormData({ ...formData, autoRenew: e.target.checked })}
-                className="w-4 h-4 bg-surface-800 border-surface-700 rounded text-brand-600 focus:ring-brand-500"
+                className="w-4 h-4 bg-white border-surface-200 rounded text-brand-600 focus:ring-brand-500"
               />
               <span className="text-sm text-surface-700">Auto-renew contract</span>
             </label>
@@ -240,14 +240,14 @@ function ContractForm({ contract, onSave, onCancel }: ContractFormProps) {
 
         {/* Compliance Requirements */}
         <div>
-          <h3 className="text-lg font-medium text-surface-100 mb-4">Compliance Requirements</h3>
+          <h3 className="text-lg font-medium text-surface-900 mb-4">Compliance Requirements</h3>
           <div className="space-y-2">
             <label className="flex items-center gap-2">
               <input
                 type="checkbox"
                 checked={formData.requiresSoc2}
                 onChange={(e) => setFormData({ ...formData, requiresSoc2: e.target.checked })}
-                className="w-4 h-4 bg-surface-800 border-surface-700 rounded text-brand-600 focus:ring-brand-500"
+                className="w-4 h-4 bg-white border-surface-200 rounded text-brand-600 focus:ring-brand-500"
               />
               <span className="text-sm text-surface-700">SOC 2 Required</span>
             </label>
@@ -256,7 +256,7 @@ function ContractForm({ contract, onSave, onCancel }: ContractFormProps) {
                 type="checkbox"
                 checked={formData.requiresIso27001}
                 onChange={(e) => setFormData({ ...formData, requiresIso27001: e.target.checked })}
-                className="w-4 h-4 bg-surface-800 border-surface-700 rounded text-brand-600 focus:ring-brand-500"
+                className="w-4 h-4 bg-white border-surface-200 rounded text-brand-600 focus:ring-brand-500"
               />
               <span className="text-sm text-surface-700">ISO 27001 Required</span>
             </label>
@@ -265,7 +265,7 @@ function ContractForm({ contract, onSave, onCancel }: ContractFormProps) {
                 type="checkbox"
                 checked={formData.requiresHipaa}
                 onChange={(e) => setFormData({ ...formData, requiresHipaa: e.target.checked })}
-                className="w-4 h-4 bg-surface-800 border-surface-700 rounded text-brand-600 focus:ring-brand-500"
+                className="w-4 h-4 bg-white border-surface-200 rounded text-brand-600 focus:ring-brand-500"
               />
               <span className="text-sm text-surface-700">HIPAA Required</span>
             </label>
@@ -274,7 +274,7 @@ function ContractForm({ contract, onSave, onCancel }: ContractFormProps) {
                 type="checkbox"
                 checked={formData.requiresGdpr}
                 onChange={(e) => setFormData({ ...formData, requiresGdpr: e.target.checked })}
-                className="w-4 h-4 bg-surface-800 border-surface-700 rounded text-brand-600 focus:ring-brand-500"
+                className="w-4 h-4 bg-white border-surface-200 rounded text-brand-600 focus:ring-brand-500"
               />
               <span className="text-sm text-surface-700">GDPR Required</span>
             </label>
@@ -286,7 +286,7 @@ function ContractForm({ contract, onSave, onCancel }: ContractFormProps) {
         <button
           type="button"
           onClick={onCancel}
-          className="px-4 py-2 text-surface-700 hover:text-surface-100 transition-colors"
+          className="px-4 py-2 text-surface-700 hover:text-surface-900 transition-colors"
         >
           Cancel
         </button>
@@ -312,23 +312,23 @@ function ContractView({
 }) {
   return (
     <div className="space-y-6">
-      <div className="bg-surface-900 border border-surface-800 rounded-lg p-6 space-y-6">
+      <div className="bg-white border border-surface-200 rounded-lg p-6 space-y-6">
         {/* Header */}
         <div className="flex items-start justify-between">
           <div>
-            <h2 className="text-2xl font-bold text-surface-100">{contract.title}</h2>
+            <h2 className="text-2xl font-bold text-surface-900">{contract.title}</h2>
             <p className="mt-1 text-surface-600">{contract.vendor.name}</p>
           </div>
           <div className="flex items-center gap-2">
             <button
               onClick={onEdit}
-              className="p-2 text-surface-600 hover:text-surface-100 hover:bg-surface-800 rounded-lg transition-colors"
+              className="p-2 text-surface-600 hover:text-surface-900 hover:bg-white rounded-lg transition-colors"
             >
               <PencilIcon className="w-5 h-5" />
             </button>
             <button
               onClick={onDelete}
-              className="p-2 text-red-600 hover:text-red-700 hover:bg-surface-800 rounded-lg transition-colors"
+              className="p-2 text-red-600 hover:text-red-700 hover:bg-white rounded-lg transition-colors"
             >
               <TrashIcon className="w-5 h-5" />
             </button>
@@ -337,11 +337,11 @@ function ContractView({
 
         {/* Basic Information */}
         <div>
-          <h3 className="text-lg font-medium text-surface-100 mb-4">Basic Information</h3>
+          <h3 className="text-lg font-medium text-surface-900 mb-4">Basic Information</h3>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div>
               <dt className="text-sm font-medium text-surface-600 mb-1">Contract Type</dt>
-              <dd className="text-sm text-surface-100 uppercase">{contract.contractType}</dd>
+              <dd className="text-sm text-surface-900 uppercase">{contract.contractType}</dd>
             </div>
             <div>
               <dt className="text-sm font-medium text-surface-600 mb-1">Status</dt>
@@ -354,7 +354,7 @@ function ContractView({
                         ? 'bg-red-500/20 text-red-600'
                         : contract.status === 'pending'
                           ? 'bg-yellow-500/20 text-yellow-600'
-                          : 'bg-surface-700 text-surface-600'
+                          : 'bg-surface-200 text-surface-600'
                   }`}
                 >
                   {contract.status}
@@ -364,7 +364,7 @@ function ContractView({
             {contract.description && (
               <div className="md:col-span-2">
                 <dt className="text-sm font-medium text-surface-600 mb-1">Description</dt>
-                <dd className="text-sm text-surface-100">{contract.description}</dd>
+                <dd className="text-sm text-surface-900">{contract.description}</dd>
               </div>
             )}
           </div>
@@ -373,11 +373,11 @@ function ContractView({
         {/* Financial Information */}
         {contract.contractValue && (
           <div>
-            <h3 className="text-lg font-medium text-surface-100 mb-4">Financial Information</h3>
+            <h3 className="text-lg font-medium text-surface-900 mb-4">Financial Information</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               <div>
                 <dt className="text-sm font-medium text-surface-600 mb-1">Contract Value</dt>
-                <dd className="text-sm text-surface-100">
+                <dd className="text-sm text-surface-900">
                   {contract.currency} {contract.contractValue.toLocaleString()}
                 </dd>
               </div>
@@ -387,24 +387,24 @@ function ContractView({
 
         {/* Important Dates */}
         <div>
-          <h3 className="text-lg font-medium text-surface-100 mb-4">Important Dates</h3>
+          <h3 className="text-lg font-medium text-surface-900 mb-4">Important Dates</h3>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             <div>
               <dt className="text-sm font-medium text-surface-600 mb-1">Start Date</dt>
-              <dd className="text-sm text-surface-100">
+              <dd className="text-sm text-surface-900">
                 {new Date(contract.startDate).toLocaleDateString()}
               </dd>
             </div>
             <div>
               <dt className="text-sm font-medium text-surface-600 mb-1">End Date</dt>
-              <dd className="text-sm text-surface-100">
+              <dd className="text-sm text-surface-900">
                 {new Date(contract.endDate).toLocaleDateString()}
               </dd>
             </div>
             {contract.renewalDate && (
               <div>
                 <dt className="text-sm font-medium text-surface-600 mb-1">Renewal Date</dt>
-                <dd className="text-sm text-surface-100">
+                <dd className="text-sm text-surface-900">
                   {new Date(contract.renewalDate).toLocaleDateString()}
                 </dd>
               </div>
@@ -413,14 +413,14 @@ function ContractView({
           <div className="mt-4">
             <span className="text-sm text-surface-600">
               Auto-renew:{' '}
-              <span className="text-surface-100">{contract.autoRenew ? 'Yes' : 'No'}</span>
+              <span className="text-surface-900">{contract.autoRenew ? 'Yes' : 'No'}</span>
             </span>
           </div>
         </div>
 
         {/* Compliance Requirements */}
         <div>
-          <h3 className="text-lg font-medium text-surface-100 mb-4">Compliance Requirements</h3>
+          <h3 className="text-lg font-medium text-surface-900 mb-4">Compliance Requirements</h3>
           <div className="flex flex-wrap gap-2">
             {contract.requiresSoc2 && (
               <span className="px-3 py-1 bg-brand-600/20 text-brand-400 text-sm rounded-full">
@@ -456,11 +456,11 @@ function ContractView({
         {/* Document */}
         {contract.storagePath && (
           <div>
-            <h3 className="text-lg font-medium text-surface-100 mb-4">Contract Document</h3>
+            <h3 className="text-lg font-medium text-surface-900 mb-4">Contract Document</h3>
             <div className="flex items-center gap-3">
               <DocumentArrowDownIcon className="w-5 h-5 text-surface-600" />
               <div className="flex-1">
-                <p className="text-sm font-medium text-surface-100">{contract.filename}</p>
+                <p className="text-sm font-medium text-surface-900">{contract.filename}</p>
                 <p className="text-xs text-surface-500">
                   {contract.size
                     ? `${(contract.size / 1024 / 1024).toFixed(2)} MB`
@@ -550,12 +550,12 @@ export default function ContractDetail() {
       <div className="flex items-center gap-4">
         <button
           onClick={() => navigate('/contracts')}
-          className="p-2 text-surface-600 hover:text-surface-100 hover:bg-surface-800 rounded-lg transition-colors"
+          className="p-2 text-surface-600 hover:text-surface-900 hover:bg-white rounded-lg transition-colors"
         >
           <ArrowLeftIcon className="w-5 h-5" />
         </button>
         <div>
-          <h1 className="text-3xl font-bold text-surface-100">
+          <h1 className="text-3xl font-bold text-surface-900">
             {id === 'new' ? 'New Contract' : 'Contract Details'}
           </h1>
           {contract && (
@@ -583,14 +583,14 @@ export default function ContractDetail() {
       ) : null}
       {/* Delete Confirmation Modal */}
       <Dialog open={showDeleteConfirm} onClose={() => setShowDeleteConfirm(false)}>
-        <h3 className="text-lg font-semibold text-surface-100 mb-2">Delete Contract</h3>
+        <h3 className="text-lg font-semibold text-surface-900 mb-2">Delete Contract</h3>
         <p className="text-surface-600 mb-6">
           Are you sure you want to delete this contract? This action cannot be undone.
         </p>
         <div className="flex justify-end gap-2">
           <button
             onClick={() => setShowDeleteConfirm(false)}
-            className="px-4 py-2 bg-surface-800 text-surface-100 rounded-lg hover:bg-surface-700 transition-colors"
+            className="px-4 py-2 bg-white text-surface-900 rounded-lg hover:bg-surface-200 transition-colors"
           >
             Cancel
           </button>

--- a/frontend/src/pages/Contracts.tsx
+++ b/frontend/src/pages/Contracts.tsx
@@ -65,9 +65,9 @@ export default function Contracts() {
           }}
         />
       ) : (
-        <div className="bg-surface-800 border border-surface-700 rounded-xl overflow-hidden">
+        <div className="bg-white border border-surface-200 rounded-xl overflow-hidden">
           <table className="w-full">
-            <thead className="bg-surface-700/50 border-b border-surface-700">
+            <thead className="bg-surface-200/50 border-b border-surface-200">
               <tr>
                 <th className="px-6 py-3 text-left text-xs font-medium text-surface-600 uppercase tracking-wider">
                   Contract
@@ -89,12 +89,12 @@ export default function Contracts() {
                 </th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-surface-700">
+            <tbody className="divide-y divide-surface-200">
               {(contracts as any[]).map((contract) => (
                 <tr
                   key={contract.id}
                   onClick={() => navigate(`/contracts/${contract.id}`)}
-                  className="hover:bg-surface-700/50 cursor-pointer transition-colors"
+                  className="hover:bg-surface-200/50 cursor-pointer transition-colors"
                 >
                   <td className="px-6 py-4">
                     <div>

--- a/frontend/src/pages/ControlDetail.tsx
+++ b/frontend/src/pages/ControlDetail.tsx
@@ -268,14 +268,14 @@ export default function ControlDetail() {
         <div>
           <Link
             to={backUrl}
-            className="inline-flex items-center text-sm text-surface-600 hover:text-surface-100 mb-4"
+            className="inline-flex items-center text-sm text-surface-600 hover:text-surface-900 mb-4"
           >
             <ArrowLeftIcon className="w-4 h-4 mr-1" />
             Back to Controls
           </Link>
           <div className="flex items-center gap-3">
             <span className="font-mono text-brand-400 text-lg">{control.controlId}</span>
-            <h1 className="text-2xl font-bold text-surface-100">{control.title}</h1>
+            <h1 className="text-2xl font-bold text-surface-900">{control.title}</h1>
             <RealTimePresence entityType="control" entityId={control.id} />
           </div>
           <p className="text-surface-600 mt-2 max-w-2xl">{control.description}</p>
@@ -303,9 +303,9 @@ export default function ControlDetail() {
       </div>
       {/* Edit Modal */}
       <Dialog open={isEditing} onClose={() => setIsEditing(false)}>
-        <div className="p-4 border-b border-surface-800 flex items-center justify-between sticky top-0 bg-surface-900">
-          <h2 className="text-lg font-semibold text-surface-100">Edit Control</h2>
-          <button onClick={() => setIsEditing(false)} className="p-1 hover:bg-surface-700 rounded">
+        <div className="p-4 border-b border-surface-200 flex items-center justify-between sticky top-0 bg-white">
+          <h2 className="text-lg font-semibold text-surface-900">Edit Control</h2>
+          <button onClick={() => setIsEditing(false)} className="p-1 hover:bg-surface-200 rounded">
             <XMarkIcon className="w-5 h-5 text-surface-600" />
           </button>
         </div>
@@ -358,7 +358,7 @@ export default function ControlDetail() {
 
           {/* Implementation Details Section */}
           {control.implementation && (
-            <div className="border-t border-surface-800 pt-6">
+            <div className="border-t border-surface-200 pt-6">
               <h3 className="text-sm font-semibold text-surface-700 mb-3 uppercase tracking-wide">
                 Implementation Details
               </h3>
@@ -425,7 +425,7 @@ export default function ControlDetail() {
             </div>
           )}
         </div>
-        <div className="p-4 border-t border-surface-800 flex justify-end gap-3 sticky bottom-0 bg-surface-900">
+        <div className="p-4 border-t border-surface-200 flex justify-end gap-3 sticky bottom-0 bg-white">
           <Button variant="secondary" onClick={() => setIsEditing(false)}>
             Cancel
           </Button>
@@ -442,7 +442,7 @@ export default function ControlDetail() {
         <div className="lg:col-span-2 space-y-6">
           {/* Status Card */}
           <div className="card p-6">
-            <h2 className="text-lg font-semibold text-surface-100 mb-4">Implementation Status</h2>
+            <h2 className="text-lg font-semibold text-surface-900 mb-4">Implementation Status</h2>
             {implementation ? (
               <div className="space-y-4">
                 <div>
@@ -461,22 +461,22 @@ export default function ControlDetail() {
                   </SelectNative>
                 </div>
 
-                <div className="grid grid-cols-2 gap-4 pt-4 border-t border-surface-800">
+                <div className="grid grid-cols-2 gap-4 pt-4 border-t border-surface-200">
                   <div>
                     <p className="text-sm text-surface-500">Owner</p>
-                    <p className="text-surface-200">
+                    <p className="text-surface-800">
                       {implementation.owner?.displayName || 'Unassigned'}
                     </p>
                   </div>
                   <div>
                     <p className="text-sm text-surface-500">Testing Frequency</p>
-                    <p className="text-surface-200 capitalize">
+                    <p className="text-surface-800 capitalize">
                       {implementation.testingFrequency?.replace('_', ' ') || 'Quarterly'}
                     </p>
                   </div>
                   <div>
                     <p className="text-sm text-surface-500">Last Tested</p>
-                    <p className="text-surface-200">
+                    <p className="text-surface-800">
                       {implementation?.lastTestDate
                         ? new Date(implementation.lastTestDate).toLocaleDateString()
                         : 'Never'}
@@ -484,7 +484,7 @@ export default function ControlDetail() {
                   </div>
                   <div>
                     <p className="text-sm text-surface-500">Effectiveness Score</p>
-                    <p className="text-surface-200">
+                    <p className="text-surface-800">
                       {implementation.effectivenessScore !== null
                         ? `${implementation.effectivenessScore}%`
                         : 'Not rated'}
@@ -493,7 +493,7 @@ export default function ControlDetail() {
                 </div>
 
                 {implementation.implementationNotes && (
-                  <div className="pt-4 border-t border-surface-800">
+                  <div className="pt-4 border-t border-surface-200">
                     <p className="text-sm text-surface-500 mb-2">Implementation Notes</p>
                     <p className="text-surface-700 text-sm">{implementation.implementationNotes}</p>
                   </div>
@@ -507,7 +507,7 @@ export default function ControlDetail() {
           {/* Evidence Card */}
           <div className="card p-6">
             <div className="flex items-center justify-between mb-4">
-              <h2 className="text-lg font-semibold text-surface-100">Evidence</h2>
+              <h2 className="text-lg font-semibold text-surface-900">Evidence</h2>
               <Link to={`/evidence?controlId=${id}`} className="text-sm">
                 <LinkIcon className="w-4 h-4 mr-2" />
                 Link Evidence
@@ -518,7 +518,7 @@ export default function ControlDetail() {
                 {control?.evidenceLinks?.map((link: any) => (
                   <div
                     key={link.id}
-                    className="flex items-center justify-between p-3 bg-surface-800 rounded-lg group"
+                    className="flex items-center justify-between p-3 bg-white rounded-lg group"
                   >
                     <Link
                       to={`/evidence/${link.evidence.id}`}
@@ -526,7 +526,7 @@ export default function ControlDetail() {
                     >
                       <DocumentTextIcon className="w-5 h-5 text-surface-600" />
                       <div className="min-w-0">
-                        <p className="text-sm font-medium text-surface-200 hover:text-brand-400 truncate">
+                        <p className="text-sm font-medium text-surface-800 hover:text-brand-400 truncate">
                           {link.evidence.title}
                         </p>
                         <p className="text-xs text-surface-500">
@@ -569,7 +569,7 @@ export default function ControlDetail() {
           {/* Linked Policies Card */}
           <div className="card p-6">
             <div className="flex items-center justify-between mb-4">
-              <h2 className="text-lg font-semibold text-surface-100">Linked Policies</h2>
+              <h2 className="text-lg font-semibold text-surface-900">Linked Policies</h2>
               {hasPermission('policies:write') && (
                 <Button
                   onClick={() => setIsLinkPolicyOpen(true)}
@@ -589,7 +589,7 @@ export default function ControlDetail() {
                 {control?.policyLinks?.map((link: any) => (
                   <div
                     key={link.id}
-                    className="flex items-center justify-between p-3 bg-surface-800 rounded-lg group"
+                    className="flex items-center justify-between p-3 bg-white rounded-lg group"
                   >
                     <Link
                       to={`/policies/${link.policy?.id}`}
@@ -597,7 +597,7 @@ export default function ControlDetail() {
                     >
                       <DocumentTextIcon className="w-5 h-5 text-brand-400" />
                       <div className="min-w-0">
-                        <p className="text-sm font-medium text-surface-200 truncate">
+                        <p className="text-sm font-medium text-surface-800 truncate">
                           {link.policy?.title}
                         </p>
                         <p className="text-xs text-surface-500 capitalize">
@@ -649,13 +649,13 @@ export default function ControlDetail() {
 
           {/* Test History Card */}
           <div className="card p-6">
-            <h2 className="text-lg font-semibold text-surface-100 mb-4">Test History</h2>
+            <h2 className="text-lg font-semibold text-surface-900 mb-4">Test History</h2>
             {(implementation?.tests?.length ?? 0) > 0 ? (
               <div className="space-y-3">
                 {implementation?.tests?.map((test: any) => (
                   <div
                     key={test.id}
-                    className="flex items-start justify-between p-3 bg-surface-800 rounded-lg"
+                    className="flex items-start justify-between p-3 bg-white rounded-lg"
                   >
                     <div>
                       <div className="flex items-center gap-2">
@@ -689,23 +689,23 @@ export default function ControlDetail() {
         <div className="space-y-6">
           {/* Details Card */}
           <div className="card p-6">
-            <h3 className="text-sm font-semibold text-surface-100 mb-4">Details</h3>
+            <h3 className="text-sm font-semibold text-surface-900 mb-4">Details</h3>
             <dl className="space-y-3">
               <div>
                 <dt className="text-xs text-surface-500">Category</dt>
-                <dd className="text-sm text-surface-200 capitalize mt-1">
+                <dd className="text-sm text-surface-800 capitalize mt-1">
                   {control.category.replace('_', ' ')}
                 </dd>
               </div>
               {(control as any)?.subcategory && (
                 <div>
                   <dt className="text-xs text-surface-500">Subcategory</dt>
-                  <dd className="text-sm text-surface-200 mt-1">{(control as any).subcategory}</dd>
+                  <dd className="text-sm text-surface-800 mt-1">{(control as any).subcategory}</dd>
                 </div>
               )}
               <div>
                 <dt className="text-xs text-surface-500">Type</dt>
-                <dd className="text-sm text-surface-200 mt-1">
+                <dd className="text-sm text-surface-800 mt-1">
                   {control.isCustom ? 'Custom' : 'System'}
                 </dd>
               </div>
@@ -729,7 +729,7 @@ export default function ControlDetail() {
           {/* Framework Mappings Card */}
           <div className="card p-6">
             <div className="flex items-center justify-between mb-4">
-              <h3 className="text-sm font-semibold text-surface-100">Framework Mappings</h3>
+              <h3 className="text-sm font-semibold text-surface-900">Framework Mappings</h3>
               {canEditMappings && (
                 <button
                   type="button"
@@ -751,7 +751,7 @@ export default function ControlDetail() {
                     <div
                       key={mapping.id}
                       role="listitem"
-                      className="group relative p-2 bg-surface-800 rounded-lg"
+                      className="group relative p-2 bg-white rounded-lg"
                     >
                       <div className="flex items-start justify-between gap-2">
                         <div className="flex-1 min-w-0">
@@ -777,14 +777,14 @@ export default function ControlDetail() {
                               aria-haspopup="menu"
                               aria-expanded={isMenuOpen}
                               onClick={() => setMappingMenuOpenId(isMenuOpen ? null : mapping.id)}
-                              className="opacity-60 group-hover:opacity-100 focus:opacity-100 p-1 rounded hover:bg-surface-700 transition-opacity"
+                              className="opacity-60 group-hover:opacity-100 focus:opacity-100 p-1 rounded hover:bg-surface-200 transition-opacity"
                             >
                               <EllipsisVerticalIcon className="w-4 h-4 text-surface-600" />
                             </button>
                             {isMenuOpen && (
                               <div
                                 role="menu"
-                                className="absolute right-0 top-full mt-1 w-32 rounded-md border border-surface-700 bg-surface-900 shadow-lg z-10"
+                                className="absolute right-0 top-full mt-1 w-32 rounded-md border border-surface-200 bg-white shadow-lg z-10"
                               >
                                 {canEditMappings && (
                                   <button
@@ -799,7 +799,7 @@ export default function ControlDetail() {
                                         frameworkId: mapping.frameworkId,
                                       });
                                     }}
-                                    className="w-full text-left px-3 py-2 text-xs text-surface-200 hover:bg-surface-800 first:rounded-t-md"
+                                    className="w-full text-left px-3 py-2 text-xs text-surface-800 hover:bg-white first:rounded-t-md"
                                   >
                                     Edit
                                   </button>
@@ -820,7 +820,7 @@ export default function ControlDetail() {
                                         },
                                       });
                                     }}
-                                    className="w-full text-left px-3 py-2 text-xs text-surface-200 hover:bg-surface-800"
+                                    className="w-full text-left px-3 py-2 text-xs text-surface-800 hover:bg-white"
                                   >
                                     Copy to framework…
                                   </button>
@@ -832,7 +832,7 @@ export default function ControlDetail() {
                                     setMappingMenuOpenId(null);
                                     setHistoryDrawerMappingId(mapping.id);
                                   }}
-                                  className="flex items-center gap-2 w-full text-left px-3 py-2 text-xs text-surface-200 hover:bg-surface-800"
+                                  className="flex items-center gap-2 w-full text-left px-3 py-2 text-xs text-surface-800 hover:bg-white"
                                 >
                                   <ClockIcon className="w-3.5 h-3.5" aria-hidden="true" />
                                   History
@@ -845,7 +845,7 @@ export default function ControlDetail() {
                                       setMappingMenuOpenId(null);
                                       setMappingDeleteConfirmId(mapping.id);
                                     }}
-                                    className="w-full text-left px-3 py-2 text-xs text-red-600 hover:bg-surface-800 last:rounded-b-md"
+                                    className="w-full text-left px-3 py-2 text-xs text-red-600 hover:bg-white last:rounded-b-md"
                                   >
                                     Delete
                                   </button>
@@ -856,13 +856,13 @@ export default function ControlDetail() {
                         )}
                       </div>
                       {isConfirmingDelete && (
-                        <div className="mt-2 p-2 bg-surface-900 border border-surface-700 rounded">
+                        <div className="mt-2 p-2 bg-white border border-surface-200 rounded">
                           <p className="text-xs text-surface-700 mb-2">Delete this mapping?</p>
                           <div className="flex justify-end gap-2">
                             <button
                               type="button"
                               onClick={() => setMappingDeleteConfirmId(null)}
-                              className="text-xs px-2 py-1 text-surface-700 hover:text-surface-100"
+                              className="text-xs px-2 py-1 text-surface-700 hover:text-surface-900"
                             >
                               Cancel
                             </button>
@@ -972,7 +972,7 @@ export default function ControlDetail() {
           {/* Guidance Card */}
           {control.guidance && (
             <div className="card p-6">
-              <h3 className="text-sm font-semibold text-surface-100 mb-4">
+              <h3 className="text-sm font-semibold text-surface-900 mb-4">
                 Implementation Guidance
               </h3>
               <p className="text-sm text-surface-600">{control.guidance}</p>
@@ -983,7 +983,7 @@ export default function ControlDetail() {
       {/* Tabs Section */}
       <div className="card overflow-hidden">
         {/* Tab Navigation */}
-        <div className="border-b border-surface-700 px-4">
+        <div className="border-b border-surface-200 px-4">
           <nav className="flex gap-6" aria-label="Tabs">
             <button
               onClick={() => setActiveTab('comments')}
@@ -991,7 +991,7 @@ export default function ControlDetail() {
                 'py-3 px-1 border-b-2 font-medium text-sm transition-colors flex items-center gap-2',
                 activeTab === 'comments'
                   ? 'border-brand-500 text-brand-400'
-                  : 'border-transparent text-surface-600 hover:text-surface-200 hover:border-surface-600'
+                  : 'border-transparent text-surface-600 hover:text-surface-800 hover:border-surface-300'
               )}
             >
               <ChatBubbleLeftRightIcon className="w-4 h-4" />
@@ -1003,7 +1003,7 @@ export default function ControlDetail() {
                 'py-3 px-1 border-b-2 font-medium text-sm transition-colors flex items-center gap-2',
                 activeTab === 'tasks'
                   ? 'border-brand-500 text-brand-400'
-                  : 'border-transparent text-surface-600 hover:text-surface-200 hover:border-surface-600'
+                  : 'border-transparent text-surface-600 hover:text-surface-800 hover:border-surface-300'
               )}
             >
               <ClipboardDocumentCheckIcon className="w-4 h-4" />
@@ -1015,7 +1015,7 @@ export default function ControlDetail() {
                 'py-3 px-1 border-b-2 font-medium text-sm transition-colors flex items-center gap-2',
                 activeTab === 'history'
                   ? 'border-brand-500 text-brand-400'
-                  : 'border-transparent text-surface-600 hover:text-surface-200 hover:border-surface-600'
+                  : 'border-transparent text-surface-600 hover:text-surface-800 hover:border-surface-300'
               )}
             >
               <ClockIcon className="w-4 h-4" />
@@ -1045,7 +1045,7 @@ export default function ControlDetail() {
       )}
       {/* Delete Confirmation Modal */}
       <Dialog open={showDeleteConfirm} onClose={() => setShowDeleteConfirm(false)}>
-        <h3 className="text-lg font-semibold text-surface-100 mb-2">Delete Control</h3>
+        <h3 className="text-lg font-semibold text-surface-900 mb-2">Delete Control</h3>
         <p className="text-surface-600 mb-6">
           Are you sure you want to delete "{control?.title}"? This action cannot be undone.
         </p>
@@ -1130,8 +1130,8 @@ function LinkPolicyModal({
   return (
     <Dialog open onClose={onClose}>
       <div className="flex items-center justify-between mb-4">
-        <h2 className="text-lg font-semibold text-surface-100">Link Policies to Control</h2>
-        <button onClick={onClose} className="text-surface-600 hover:text-surface-100">
+        <h2 className="text-lg font-semibold text-surface-900">Link Policies to Control</h2>
+        <button onClick={onClose} className="text-surface-600 hover:text-surface-900">
           <XMarkIcon className="w-5 h-5" />
         </button>
       </div>
@@ -1154,7 +1154,7 @@ function LinkPolicyModal({
       <div className="flex-1 overflow-y-auto space-y-2 min-h-[200px] max-h-[300px]">
         {isLoadingPolicies ? (
           <div className="flex items-center justify-center py-8">
-            <div className="animate-spin w-6 h-6 border-2 border-surface-700 rounded-full border-t-brand-500"></div>
+            <div className="animate-spin w-6 h-6 border-2 border-surface-200 rounded-full border-t-brand-500"></div>
             <span className="ml-2 text-surface-600">Searching...</span>
           </div>
         ) : availablePolicies.length === 0 ? (
@@ -1169,17 +1169,17 @@ function LinkPolicyModal({
                 'flex items-center gap-3 p-3 rounded-lg cursor-pointer transition-colors',
                 selectedPolicyIds.includes(policy.id)
                   ? 'bg-brand-500/20 border border-brand-500/50'
-                  : 'bg-surface-800 hover:bg-surface-700'
+                  : 'bg-white hover:bg-surface-200'
               )}
             >
               <input
                 type="checkbox"
                 checked={selectedPolicyIds.includes(policy.id)}
                 onChange={() => togglePolicy(policy.id)}
-                className="rounded border-surface-600"
+                className="rounded border-surface-300"
               />
               <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium text-surface-200 truncate">{policy.title}</p>
+                <p className="text-sm font-medium text-surface-800 truncate">{policy.title}</p>
                 <p className="text-xs text-surface-500 capitalize">
                   {policy.category?.replace(/_/g, ' ')} • v{policy.version} • {policy.status}
                 </p>
@@ -1195,7 +1195,7 @@ function LinkPolicyModal({
         </p>
       )}
 
-      <div className="flex justify-end gap-3 mt-4 pt-4 border-t border-surface-800">
+      <div className="flex justify-end gap-3 mt-4 pt-4 border-t border-surface-200">
         <Button variant="secondary" onClick={onClose}>
           Cancel
         </Button>

--- a/frontend/src/pages/ControlNew.tsx
+++ b/frontend/src/pages/ControlNew.tsx
@@ -119,12 +119,12 @@ export default function ControlNew() {
       <div>
         <Link
           to="/controls"
-          className="inline-flex items-center text-sm text-surface-600 hover:text-surface-100 mb-4"
+          className="inline-flex items-center text-sm text-surface-600 hover:text-surface-900 mb-4"
         >
           <ArrowLeftIcon className="w-4 h-4 mr-1" />
           Back to Controls
         </Link>
-        <h1 className="text-2xl font-bold text-surface-100">Create New Control</h1>
+        <h1 className="text-2xl font-bold text-surface-900">Create New Control</h1>
         <p className="text-surface-600 mt-1">Add a new control to your compliance program</p>
       </div>
       {/* Form */}
@@ -218,7 +218,7 @@ export default function ControlNew() {
         </div>
 
         {/* Actions */}
-        <div className="flex items-center justify-end gap-3 pt-4 border-t border-surface-700">
+        <div className="flex items-center justify-end gap-3 pt-4 border-t border-surface-200">
           <Button type="button" variant="secondary" onClick={() => navigate('/controls')}>
             Cancel
           </Button>

--- a/frontend/src/pages/Controls.tsx
+++ b/frontend/src/pages/Controls.tsx
@@ -251,7 +251,7 @@ export default function Controls() {
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-bold text-surface-100">Controls</h1>
+          <h1 className="text-2xl font-bold text-surface-900">Controls</h1>
           <p className="text-surface-600 mt-1">
             Manage your security controls and track implementation status
           </p>
@@ -421,7 +421,7 @@ export default function Controls() {
                         <Link
                           to={`/controls/${control.id}`}
                           state={{ from: currentUrl }}
-                          className="text-surface-100 hover:text-brand-400"
+                          className="text-surface-900 hover:text-brand-400"
                         >
                           {control.title}
                         </Link>

--- a/frontend/src/pages/CustomDashboards.tsx
+++ b/frontend/src/pages/CustomDashboards.tsx
@@ -100,7 +100,7 @@ export default function CustomDashboards() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-surface-100">Custom Dashboards</h1>
+          <h1 className="text-2xl font-bold text-surface-900">Custom Dashboards</h1>
           <p className="text-surface-600 mt-1">Create and customize your own dashboard views</p>
         </div>
         <div className="flex items-center gap-2">
@@ -115,13 +115,13 @@ export default function CustomDashboards() {
       {/* Loading state */}
       {isLoading ? (
         <div className="flex items-center justify-center py-12">
-          <div className="animate-spin w-8 h-8 border-4 border-surface-700 rounded-full border-t-brand-500" />
+          <div className="animate-spin w-8 h-8 border-4 border-surface-200 rounded-full border-t-brand-500" />
         </div>
       ) : userDashboards.length === 0 ? (
         /* Empty state */
         <div className="card p-12 text-center">
           <Squares2X2Icon className="w-12 h-12 mx-auto text-surface-500 mb-4" />
-          <h3 className="text-lg font-medium text-surface-200 mb-2">No dashboards yet</h3>
+          <h3 className="text-lg font-medium text-surface-800 mb-2">No dashboards yet</h3>
           <p className="text-surface-600 mb-6">
             Create a custom dashboard or start from a template
           </p>
@@ -148,7 +148,7 @@ export default function CustomDashboards() {
             >
               <div className="flex items-start justify-between mb-3">
                 <div className="flex items-center gap-2">
-                  <h3 className="font-medium text-surface-200">{dashboard.name}</h3>
+                  <h3 className="font-medium text-surface-800">{dashboard.name}</h3>
                   {dashboard.isDefault && (
                     <StarIconSolid className="w-4 h-4 text-yellow-600" title="Default" />
                   )}
@@ -157,7 +157,7 @@ export default function CustomDashboards() {
                   {!dashboard.isDefault && (
                     <button
                       onClick={() => setDefaultMutation.mutate(dashboard.id)}
-                      className="p-1 hover:bg-surface-700 rounded text-surface-600 hover:text-yellow-600"
+                      className="p-1 hover:bg-surface-200 rounded text-surface-600 hover:text-yellow-600"
                       title="Set as default"
                     >
                       <StarIcon className="w-4 h-4" />
@@ -189,12 +189,12 @@ export default function CustomDashboards() {
               </div>
 
               {/* Mini preview */}
-              <div className="mt-3 bg-surface-800 rounded p-2">
+              <div className="mt-3 bg-white rounded p-2">
                 <div className="grid grid-cols-6 gap-1 h-12">
                   {dashboard.widgets?.slice(0, 6).map((widget, i) => (
                     <div
                       key={widget.id || i}
-                      className="bg-surface-700 rounded"
+                      className="bg-surface-200 rounded"
                       style={{
                         gridColumn: `span ${Math.min(widget.position.w, 2)}`,
                       }}
@@ -209,7 +209,7 @@ export default function CustomDashboards() {
       {/* Templates section */}
       {templates.length > 0 && (
         <div className="mt-8">
-          <h2 className="text-lg font-semibold text-surface-200 mb-4">Organization Templates</h2>
+          <h2 className="text-lg font-semibold text-surface-800 mb-4">Organization Templates</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             {templates.slice(0, 3).map((template: Dashboard) => (
               <div
@@ -219,7 +219,7 @@ export default function CustomDashboards() {
               >
                 <div className="flex items-center gap-2 mb-2">
                   <Badge variant="info">Template</Badge>
-                  <h3 className="font-medium text-surface-200">{template.name}</h3>
+                  <h3 className="font-medium text-surface-800">{template.name}</h3>
                 </div>
                 <p className="text-sm text-surface-600 mb-2">
                   {template.widgets?.length || 0} widgets
@@ -244,7 +244,7 @@ export default function CustomDashboards() {
       )}
       {/* Create Dashboard Modal */}
       <Dialog open={showCreateModal} onClose={() => setShowCreateModal(false)}>
-        <h2 className="text-lg font-semibold text-surface-100 mb-4">Create New Dashboard</h2>
+        <h2 className="text-lg font-semibold text-surface-900 mb-4">Create New Dashboard</h2>
         <form onSubmit={handleCreate}>
           <div className="space-y-4">
             <div>

--- a/frontend/src/pages/DRTestDetail.tsx
+++ b/frontend/src/pages/DRTestDetail.tsx
@@ -266,7 +266,7 @@ export default function DRTestDetail() {
       <div className="p-6">
         <div className="card p-8 text-center">
           <ExclamationCircleIcon className="w-12 h-12 mx-auto mb-4 text-red-600" />
-          <h2 className="text-lg font-semibold text-surface-100 mb-2">DR Test Not Found</h2>
+          <h2 className="text-lg font-semibold text-surface-900 mb-2">DR Test Not Found</h2>
           <p className="text-surface-600 mb-4">The requested test could not be loaded.</p>
           <Button onClick={() => navigate('/bcdr/tests')}>Back to Tests</Button>
         </div>
@@ -281,12 +281,12 @@ export default function DRTestDetail() {
         <div className="flex items-start gap-4">
           <button
             onClick={() => navigate('/bcdr/tests')}
-            className="p-2 hover:bg-surface-700 rounded-lg text-surface-600 mt-1"
+            className="p-2 hover:bg-surface-200 rounded-lg text-surface-600 mt-1"
           >
             <ArrowLeftIcon className="w-5 h-5" />
           </button>
           <div>
-            <h1 className="text-2xl font-bold text-surface-100">Schedule New DR Test</h1>
+            <h1 className="text-2xl font-bold text-surface-900">Schedule New DR Test</h1>
             <p className="text-surface-600 mt-1">Create a new disaster recovery test</p>
           </div>
         </div>
@@ -304,7 +304,7 @@ export default function DRTestDetail() {
                 type="text"
                 value={editForm.name}
                 onChange={(e) => setEditForm({ ...editForm, name: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-surface-100 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-surface-900 focus:outline-none focus:ring-2 focus:ring-primary-500"
                 placeholder="e.g., Q1 2026 Disaster Recovery Test"
                 required
               />
@@ -316,7 +316,7 @@ export default function DRTestDetail() {
                 <SelectNative
                   value={editForm.test_type}
                   onChange={(e) => setEditForm({ ...editForm, test_type: e.target.value })}
-                  className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-surface-100 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                  className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-surface-900 focus:outline-none focus:ring-2 focus:ring-primary-500"
                 >
                   {TEST_TYPES.map((type) => (
                     <option key={type.value} value={type.value}>
@@ -333,7 +333,7 @@ export default function DRTestDetail() {
                   type="date"
                   value={editForm.scheduled_date}
                   onChange={(e) => setEditForm({ ...editForm, scheduled_date: e.target.value })}
-                  className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-surface-100 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                  className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-surface-900 focus:outline-none focus:ring-2 focus:ring-primary-500"
                 />
               </div>
             </div>
@@ -344,7 +344,7 @@ export default function DRTestDetail() {
                 value={editForm.description}
                 onChange={(e) => setEditForm({ ...editForm, description: e.target.value })}
                 rows={3}
-                className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-surface-100 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-surface-900 focus:outline-none focus:ring-2 focus:ring-primary-500"
                 placeholder="Describe the test purpose and scope..."
               />
             </div>
@@ -355,7 +355,7 @@ export default function DRTestDetail() {
                 value={editForm.objectives}
                 onChange={(e) => setEditForm({ ...editForm, objectives: e.target.value })}
                 rows={2}
-                className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-surface-100 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-surface-900 focus:outline-none focus:ring-2 focus:ring-primary-500"
                 placeholder="What are the key objectives of this test?"
               />
             </div>
@@ -366,7 +366,7 @@ export default function DRTestDetail() {
                 value={editForm.scope}
                 onChange={(e) => setEditForm({ ...editForm, scope: e.target.value })}
                 rows={2}
-                className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-surface-100 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-surface-900 focus:outline-none focus:ring-2 focus:ring-primary-500"
                 placeholder="Define the scope and systems involved..."
               />
             </div>
@@ -403,7 +403,7 @@ export default function DRTestDetail() {
         <div className="flex items-start gap-4">
           <button
             onClick={() => navigate('/bcdr/tests')}
-            className="p-2 hover:bg-surface-700 rounded-lg text-surface-600 mt-1"
+            className="p-2 hover:bg-surface-200 rounded-lg text-surface-600 mt-1"
           >
             <ArrowLeftIcon className="w-5 h-5" />
           </button>
@@ -411,7 +411,7 @@ export default function DRTestDetail() {
             <div className="flex items-center gap-3 mb-2">
               <BeakerIcon className="w-8 h-8 text-purple-600" />
               <div>
-                <h1 className="text-2xl font-bold text-surface-100">{test.name}</h1>
+                <h1 className="text-2xl font-bold text-surface-900">{test.name}</h1>
                 <p className="text-surface-600 text-sm">{test.test_id}</p>
               </div>
             </div>
@@ -427,7 +427,7 @@ export default function DRTestDetail() {
                   {resultConfig.label}
                 </span>
               )}
-              <span className="px-3 py-1 rounded-full text-sm font-medium bg-surface-700 text-surface-700">
+              <span className="px-3 py-1 rounded-full text-sm font-medium bg-surface-200 text-surface-700">
                 {getTestTypeLabel(test.test_type)}
               </span>
             </div>
@@ -451,7 +451,7 @@ export default function DRTestDetail() {
         </div>
       </div>
       {/* Tabs */}
-      <div className="border-b border-surface-700">
+      <div className="border-b border-surface-200">
         <nav className="flex gap-6">
           {(['overview', 'findings', 'participants'] as const).map((tab) => (
             <button
@@ -461,7 +461,7 @@ export default function DRTestDetail() {
                 'pb-3 px-1 text-sm font-medium border-b-2 transition-colors capitalize',
                 activeTab === tab
                   ? 'border-brand-500 text-brand-400'
-                  : 'border-transparent text-surface-600 hover:text-surface-200'
+                  : 'border-transparent text-surface-600 hover:text-surface-800'
               )}
             >
               {tab}
@@ -479,21 +479,21 @@ export default function DRTestDetail() {
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
           <div className="lg:col-span-2 space-y-6">
             <div className="card p-6">
-              <h3 className="text-lg font-semibold text-surface-100 mb-4">Description</h3>
+              <h3 className="text-lg font-semibold text-surface-900 mb-4">Description</h3>
               <p className="text-surface-700">{test.description || 'No description provided.'}</p>
             </div>
 
             {/* Recovery Metrics */}
             <div className="card p-6">
-              <h3 className="text-lg font-semibold text-surface-100 mb-4">Recovery Metrics</h3>
+              <h3 className="text-lg font-semibold text-surface-900 mb-4">Recovery Metrics</h3>
               <div className="grid grid-cols-3 gap-4">
-                <div className="p-4 rounded-lg bg-surface-800/50">
+                <div className="p-4 rounded-lg bg-white/50">
                   <p className="text-surface-600 text-sm">Target RTO</p>
-                  <p className="text-2xl font-bold text-surface-100">
+                  <p className="text-2xl font-bold text-surface-900">
                     {test.target_rto_minutes ? `${test.target_rto_minutes}m` : 'N/A'}
                   </p>
                 </div>
-                <div className="p-4 rounded-lg bg-surface-800/50">
+                <div className="p-4 rounded-lg bg-white/50">
                   <p className="text-surface-600 text-sm">Actual Recovery Time</p>
                   <p
                     className={clsx(
@@ -502,7 +502,7 @@ export default function DRTestDetail() {
                         ? 'text-green-600'
                         : rtoMet === false
                           ? 'text-red-600'
-                          : 'text-surface-100'
+                          : 'text-surface-900'
                     )}
                   >
                     {test.actual_recovery_time_minutes
@@ -510,7 +510,7 @@ export default function DRTestDetail() {
                       : 'N/A'}
                   </p>
                 </div>
-                <div className="p-4 rounded-lg bg-surface-800/50">
+                <div className="p-4 rounded-lg bg-white/50">
                   <p className="text-surface-600 text-sm">RTO Met</p>
                   <p
                     className={clsx(
@@ -519,7 +519,7 @@ export default function DRTestDetail() {
                         ? 'text-green-600'
                         : rtoMet === false
                           ? 'text-red-600'
-                          : 'text-surface-100'
+                          : 'text-surface-900'
                     )}
                   >
                     {rtoMet === null ? 'N/A' : rtoMet ? 'Yes' : 'No'}
@@ -530,14 +530,14 @@ export default function DRTestDetail() {
 
             {test.objectives && (
               <div className="card p-6">
-                <h3 className="text-lg font-semibold text-surface-100 mb-4">Objectives</h3>
+                <h3 className="text-lg font-semibold text-surface-900 mb-4">Objectives</h3>
                 <p className="text-surface-700 whitespace-pre-wrap">{test.objectives}</p>
               </div>
             )}
 
             {test.lessons_learned && (
               <div className="card p-6">
-                <h3 className="text-lg font-semibold text-surface-100 mb-4">Lessons Learned</h3>
+                <h3 className="text-lg font-semibold text-surface-900 mb-4">Lessons Learned</h3>
                 <p className="text-surface-700 whitespace-pre-wrap">{test.lessons_learned}</p>
               </div>
             )}
@@ -545,11 +545,11 @@ export default function DRTestDetail() {
 
           <div className="space-y-6">
             <div className="card p-6">
-              <h3 className="text-lg font-semibold text-surface-100 mb-4">Details</h3>
+              <h3 className="text-lg font-semibold text-surface-900 mb-4">Details</h3>
               <div className="space-y-4">
                 <div>
                   <p className="text-surface-600 text-sm">Coordinator</p>
-                  <p className="text-surface-100">{test.coordinator_name || '-'}</p>
+                  <p className="text-surface-900">{test.coordinator_name || '-'}</p>
                 </div>
                 {test.plan_title && (
                   <div>
@@ -564,14 +564,14 @@ export default function DRTestDetail() {
                 )}
                 <div>
                   <p className="text-surface-600 text-sm">Scheduled Date</p>
-                  <p className="text-surface-100">
+                  <p className="text-surface-900">
                     {test.scheduled_date ? new Date(test.scheduled_date).toLocaleString() : '-'}
                   </p>
                 </div>
                 {test.actual_start_at && (
                   <div>
                     <p className="text-surface-600 text-sm">Actual Start</p>
-                    <p className="text-surface-100">
+                    <p className="text-surface-900">
                       {new Date(test.actual_start_at).toLocaleString()}
                     </p>
                   </div>
@@ -579,7 +579,7 @@ export default function DRTestDetail() {
                 {test.actual_end_at && (
                   <div>
                     <p className="text-surface-600 text-sm">Actual End</p>
-                    <p className="text-surface-100">
+                    <p className="text-surface-900">
                       {new Date(test.actual_end_at).toLocaleString()}
                     </p>
                   </div>
@@ -588,13 +588,13 @@ export default function DRTestDetail() {
             </div>
 
             <div className="card p-6">
-              <h3 className="text-lg font-semibold text-surface-100 mb-4">Statistics</h3>
+              <h3 className="text-lg font-semibold text-surface-900 mb-4">Statistics</h3>
               <div className="space-y-3">
                 <div className="flex justify-between">
                   <span className="text-surface-600">Findings</span>
                   <span
                     className={clsx(
-                      test.findings?.length > 0 ? 'text-yellow-600' : 'text-surface-100'
+                      test.findings?.length > 0 ? 'text-yellow-600' : 'text-surface-900'
                     )}
                   >
                     {test.findings?.length || 0}
@@ -602,7 +602,7 @@ export default function DRTestDetail() {
                 </div>
                 <div className="flex justify-between">
                   <span className="text-surface-600">Participants</span>
-                  <span className="text-surface-100">{test.participants?.length || 0}</span>
+                  <span className="text-surface-900">{test.participants?.length || 0}</span>
                 </div>
               </div>
             </div>
@@ -612,7 +612,7 @@ export default function DRTestDetail() {
       {activeTab === 'findings' && (
         <div className="card p-6">
           <div className="flex items-center justify-between mb-4">
-            <h3 className="text-lg font-semibold text-surface-100">Test Findings</h3>
+            <h3 className="text-lg font-semibold text-surface-900">Test Findings</h3>
             <Button variant="secondary" size="sm">
               <PlusIcon className="w-4 h-4 mr-2" />
               Add Finding
@@ -623,15 +623,15 @@ export default function DRTestDetail() {
               {test.findings.map((finding) => (
                 <div
                   key={finding.id}
-                  className="p-4 rounded-lg bg-surface-800/50 border border-surface-700"
+                  className="p-4 rounded-lg bg-white/50 border border-surface-200"
                 >
                   <div className="flex items-start justify-between mb-2">
-                    <h4 className="text-surface-100 font-medium">{finding.title}</h4>
+                    <h4 className="text-surface-900 font-medium">{finding.title}</h4>
                     <div className="flex items-center gap-2">
                       <span
                         className={clsx(
                           'px-2 py-0.5 rounded text-xs font-medium capitalize',
-                          SEVERITY_COLORS[finding.severity] || 'bg-surface-700 text-surface-700'
+                          SEVERITY_COLORS[finding.severity] || 'bg-surface-200 text-surface-700'
                         )}
                       >
                         {finding.severity}
@@ -643,7 +643,7 @@ export default function DRTestDetail() {
                             ? 'bg-green-500/20 text-green-600'
                             : finding.remediation_status === 'in_progress'
                               ? 'bg-yellow-500/20 text-yellow-600'
-                              : 'bg-surface-700 text-surface-700'
+                              : 'bg-surface-200 text-surface-700'
                         )}
                       >
                         {finding.remediation_status?.replace('_', ' ')}
@@ -676,7 +676,7 @@ export default function DRTestDetail() {
       {activeTab === 'participants' && (
         <div className="card p-6">
           <div className="flex items-center justify-between mb-4">
-            <h3 className="text-lg font-semibold text-surface-100">Test Participants</h3>
+            <h3 className="text-lg font-semibold text-surface-900">Test Participants</h3>
             <Button variant="secondary" size="sm">
               <PlusIcon className="w-4 h-4 mr-2" />
               Add Participant
@@ -687,14 +687,14 @@ export default function DRTestDetail() {
               {test.participants.map((participant) => (
                 <div
                   key={participant.id}
-                  className="flex items-center justify-between p-4 rounded-lg bg-surface-800/50"
+                  className="flex items-center justify-between p-4 rounded-lg bg-white/50"
                 >
                   <div className="flex items-center gap-3">
-                    <div className="w-10 h-10 rounded-full bg-surface-700 flex items-center justify-center">
+                    <div className="w-10 h-10 rounded-full bg-surface-200 flex items-center justify-center">
                       <UserIcon className="w-5 h-5 text-surface-600" />
                     </div>
                     <div>
-                      <p className="text-surface-100 font-medium">{participant.user_name}</p>
+                      <p className="text-surface-900 font-medium">{participant.user_name}</p>
                       <p className="text-surface-600 text-sm">{participant.role}</p>
                     </div>
                   </div>
@@ -703,7 +703,7 @@ export default function DRTestDetail() {
                       'px-2 py-1 rounded text-xs font-medium',
                       participant.attended
                         ? 'bg-green-500/20 text-green-600'
-                        : 'bg-surface-700 text-surface-600'
+                        : 'bg-surface-200 text-surface-600'
                     )}
                   >
                     {participant.attended ? 'Attended' : 'Not Attended'}
@@ -718,11 +718,11 @@ export default function DRTestDetail() {
       )}
       {/* Edit Modal */}
       <Dialog open={showEditModal} onClose={() => setShowEditModal(false)}>
-        <div className="p-6 border-b border-surface-700 flex items-center justify-between">
+        <div className="p-6 border-b border-surface-200 flex items-center justify-between">
           <h2 className="text-xl font-semibold text-white">Edit DR Test</h2>
           <button
             onClick={() => setShowEditModal(false)}
-            className="p-2 hover:bg-surface-700 rounded-lg text-surface-600"
+            className="p-2 hover:bg-surface-200 rounded-lg text-surface-600"
           >
             <XMarkIcon className="w-5 h-5" />
           </button>
@@ -807,7 +807,7 @@ export default function DRTestDetail() {
             />
           </div>
 
-          <div className="flex justify-end gap-3 pt-4 border-t border-surface-700">
+          <div className="flex justify-end gap-3 pt-4 border-t border-surface-200">
             <Button variant="secondary" type="button" onClick={() => setShowEditModal(false)}>
               Cancel
             </Button>
@@ -819,11 +819,11 @@ export default function DRTestDetail() {
       </Dialog>
       {/* Complete Test Modal */}
       <Dialog open={showCompleteModal} onClose={() => setShowCompleteModal(false)}>
-        <div className="p-6 border-b border-surface-700 flex items-center justify-between">
+        <div className="p-6 border-b border-surface-200 flex items-center justify-between">
           <h2 className="text-xl font-semibold text-white">Complete DR Test</h2>
           <button
             onClick={() => setShowCompleteModal(false)}
-            className="p-2 hover:bg-surface-700 rounded-lg text-surface-600"
+            className="p-2 hover:bg-surface-200 rounded-lg text-surface-600"
           >
             <XMarkIcon className="w-5 h-5" />
           </button>
@@ -884,7 +884,7 @@ export default function DRTestDetail() {
             />
           </div>
 
-          <div className="flex justify-end gap-3 pt-4 border-t border-surface-700">
+          <div className="flex justify-end gap-3 pt-4 border-t border-surface-200">
             <Button variant="secondary" type="button" onClick={() => setShowCompleteModal(false)}>
               Cancel
             </Button>

--- a/frontend/src/pages/DRTests.tsx
+++ b/frontend/src/pages/DRTests.tsx
@@ -112,7 +112,7 @@ export default function DRTests() {
       <div className="p-6">
         <div className="card p-8 text-center">
           <ExclamationCircleIcon className="w-12 h-12 mx-auto mb-4 text-red-600" />
-          <h2 className="text-lg font-semibold text-surface-100 mb-2">Failed to load DR Tests</h2>
+          <h2 className="text-lg font-semibold text-surface-900 mb-2">Failed to load DR Tests</h2>
           <p className="text-surface-600 mb-4">
             {(error as Error).message || 'An unexpected error occurred'}
           </p>
@@ -129,7 +129,7 @@ export default function DRTests() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-surface-100">DR Tests</h1>
+          <h1 className="text-2xl font-bold text-surface-900">DR Tests</h1>
           <p className="text-surface-600 mt-1">Schedule and track disaster recovery tests</p>
         </div>
         <Link to="/bcdr/tests/new" className="">
@@ -142,15 +142,15 @@ export default function DRTests() {
         <div className="card p-4">
           <p className="text-surface-600 text-sm">Total Tests</p>
           {statsLoading ? (
-            <div className="h-8 w-16 bg-surface-700 rounded animate-pulse mt-1"></div>
+            <div className="h-8 w-16 bg-surface-200 rounded animate-pulse mt-1"></div>
           ) : (
-            <p className="text-2xl font-bold text-surface-100">{stats?.total || 0}</p>
+            <p className="text-2xl font-bold text-surface-900">{stats?.total || 0}</p>
           )}
         </div>
         <div className="card p-4">
           <p className="text-surface-600 text-sm">Pass Rate</p>
           {statsLoading ? (
-            <div className="h-8 w-16 bg-surface-700 rounded animate-pulse mt-1"></div>
+            <div className="h-8 w-16 bg-surface-200 rounded animate-pulse mt-1"></div>
           ) : (
             <p className="text-2xl font-bold text-green-600">{passRate}%</p>
           )}
@@ -158,7 +158,7 @@ export default function DRTests() {
         <div className="card p-4">
           <p className="text-surface-600 text-sm">Open Findings</p>
           {statsLoading ? (
-            <div className="h-8 w-16 bg-surface-700 rounded animate-pulse mt-1"></div>
+            <div className="h-8 w-16 bg-surface-200 rounded animate-pulse mt-1"></div>
           ) : (
             <p className="text-2xl font-bold text-yellow-600">{stats?.openFindingsCount || 0}</p>
           )}
@@ -166,9 +166,9 @@ export default function DRTests() {
         <div className="card p-4">
           <p className="text-surface-600 text-sm">Avg Recovery Time</p>
           {statsLoading ? (
-            <div className="h-8 w-16 bg-surface-700 rounded animate-pulse mt-1"></div>
+            <div className="h-8 w-16 bg-surface-200 rounded animate-pulse mt-1"></div>
           ) : (
-            <p className="text-2xl font-bold text-surface-100">
+            <p className="text-2xl font-bold text-surface-900">
               {stats?.avg_recovery_time ? `${Math.round(Number(stats.avg_recovery_time))}m` : 'N/A'}
             </p>
           )}
@@ -240,7 +240,7 @@ export default function DRTests() {
         ) : (
           <div className="overflow-x-auto">
             <table className="w-full">
-              <thead className="bg-surface-800/50">
+              <thead className="bg-white/50">
                 <tr>
                   <th className="text-left p-4 text-surface-700 font-medium">Test</th>
                   <th className="text-left p-4 text-surface-700 font-medium">Type</th>
@@ -251,16 +251,16 @@ export default function DRTests() {
                   <th className="text-left p-4 text-surface-700 font-medium">Coordinator</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-surface-700">
+              <tbody className="divide-y divide-surface-200">
                 {tests.map((test: DRTest) => {
                   const ResultIcon = test.result ? resultColors[test.result]?.icon : null;
 
                   return (
-                    <tr key={test.id} className="hover:bg-surface-800/30 transition-colors">
+                    <tr key={test.id} className="hover:bg-white/30 transition-colors">
                       <td className="p-4">
                         <Link
                           to={`/bcdr/tests/${test.id}`}
-                          className="text-surface-100 font-medium hover:text-brand-400 transition-colors"
+                          className="text-surface-900 font-medium hover:text-brand-400 transition-colors"
                         >
                           {test.name}
                         </Link>
@@ -330,7 +330,7 @@ export default function DRTests() {
 
         {/* Pagination */}
         {totalPages > 1 && (
-          <div className="flex items-center justify-between p-4 border-t border-surface-700">
+          <div className="flex items-center justify-between p-4 border-t border-surface-200">
             <Button
               onClick={() => setPage((p) => Math.max(1, p - 1))}
               disabled={page === 1}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -290,14 +290,14 @@ export default function Dashboard() {
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-4">
           <div>
-            <h1 className="text-2xl font-bold text-surface-100">Dashboard</h1>
+            <h1 className="text-2xl font-bold text-surface-900">Dashboard</h1>
             <p className="text-surface-600 mt-1">Your compliance overview at a glance</p>
           </div>
           {/* Dashboard Selector Dropdown */}
           <div className="relative">
             <Button
               onClick={() => setShowDashboardSelector(!showDashboardSelector)}
-              className="flex items-center gap-1 text-surface-600 hover:text-surface-200"
+              className="flex items-center gap-1 text-surface-600 hover:text-surface-800"
               variant="ghost"
             >
               <Squares2X2Icon className="w-4 h-4" />
@@ -310,8 +310,8 @@ export default function Dashboard() {
                   className="fixed inset-0 z-10"
                   onClick={() => setShowDashboardSelector(false)}
                 />
-                <div className="absolute left-0 mt-2 w-64 bg-surface-800 border border-surface-700 rounded-lg shadow-xl z-20">
-                  <div className="p-3 border-b border-surface-700">
+                <div className="absolute left-0 mt-2 w-64 bg-white border border-surface-200 rounded-lg shadow-xl z-20">
+                  <div className="p-3 border-b border-surface-200">
                     <p className="text-sm font-medium text-surface-700">My Dashboards</p>
                   </div>
                   <div className="max-h-64 overflow-y-auto">
@@ -325,9 +325,9 @@ export default function Dashboard() {
                             navigate(`/dashboards`);
                             setShowDashboardSelector(false);
                           }}
-                          className="w-full text-left px-3 py-2 hover:bg-surface-700 flex items-center justify-between group"
+                          className="w-full text-left px-3 py-2 hover:bg-surface-200 flex items-center justify-between group"
                         >
-                          <span className="text-sm text-surface-700 group-hover:text-surface-100">
+                          <span className="text-sm text-surface-700 group-hover:text-surface-900">
                             {dashboard.name}
                           </span>
                           {dashboard.isDefault && (
@@ -337,7 +337,7 @@ export default function Dashboard() {
                       ))
                     )}
                   </div>
-                  <div className="p-2 border-t border-surface-700">
+                  <div className="p-2 border-t border-surface-200">
                     <Link
                       to="/dashboards"
                       onClick={() => setShowDashboardSelector(false)}
@@ -366,11 +366,11 @@ export default function Dashboard() {
       </div>
       {/* Dashboard Configuration Modal */}
       <Dialog open={showConfigModal} onClose={() => setShowConfigModal(false)}>
-        <div className="flex items-center justify-between p-4 border-b border-surface-700">
-          <h3 className="text-lg font-semibold text-surface-100">Customize Dashboard</h3>
+        <div className="flex items-center justify-between p-4 border-b border-surface-200">
+          <h3 className="text-lg font-semibold text-surface-900">Customize Dashboard</h3>
           <button
             onClick={() => setShowConfigModal(false)}
-            className="text-surface-600 hover:text-surface-100 transition-colors"
+            className="text-surface-600 hover:text-surface-900 transition-colors"
           >
             <XMarkIcon className="w-5 h-5" />
           </button>
@@ -386,8 +386,8 @@ export default function Dashboard() {
               className={clsx(
                 'w-full flex items-center justify-between p-3 rounded-lg border transition-all',
                 config.widgets[widget]
-                  ? 'bg-brand-500/10 border-brand-500/30 text-surface-100'
-                  : 'bg-surface-800 border-surface-700 text-surface-600'
+                  ? 'bg-brand-500/10 border-brand-500/30 text-surface-900'
+                  : 'bg-white border-surface-200 text-surface-600'
               )}
             >
               <span className="font-medium">{WIDGET_LABELS[widget]}</span>
@@ -399,10 +399,10 @@ export default function Dashboard() {
             </button>
           ))}
         </div>
-        <div className="flex items-center justify-between p-4 border-t border-surface-700">
+        <div className="flex items-center justify-between p-4 border-t border-surface-200">
           <button
             onClick={resetConfig}
-            className="text-sm text-surface-600 hover:text-surface-100 transition-colors"
+            className="text-sm text-surface-600 hover:text-surface-900 transition-colors"
           >
             Reset to Default
           </button>
@@ -477,7 +477,7 @@ export default function Dashboard() {
           {config.widgets.frameworkReadiness && (
             <div className="card p-6">
               <div className="flex items-center justify-between mb-4">
-                <h2 className="text-lg font-semibold text-surface-100">Framework Readiness</h2>
+                <h2 className="text-lg font-semibold text-surface-900">Framework Readiness</h2>
                 <Link
                   to="/frameworks"
                   className="text-sm text-brand-400 hover:text-brand-300 flex items-center gap-1"
@@ -549,7 +549,7 @@ export default function Dashboard() {
           {config.widgets.controlStatus && (
             <div className="card p-6">
               <div className="flex items-center justify-between mb-4">
-                <h2 className="text-lg font-semibold text-surface-100">Control Status</h2>
+                <h2 className="text-lg font-semibold text-surface-900">Control Status</h2>
                 <Link
                   to="/controls"
                   className="text-sm text-brand-400 hover:text-brand-300 flex items-center gap-1"
@@ -610,7 +610,7 @@ export default function Dashboard() {
           {/* Vendor Risk Summary */}
           <div className="card p-6">
             <div className="flex items-center justify-between mb-4">
-              <h2 className="text-lg font-semibold text-surface-100">Vendor Risk Summary</h2>
+              <h2 className="text-lg font-semibold text-surface-900">Vendor Risk Summary</h2>
               <Link
                 to="/vendors"
                 className="text-sm text-brand-400 hover:text-brand-300 flex items-center gap-1"
@@ -624,7 +624,7 @@ export default function Dashboard() {
           {/* Risk Heat Map - Always show, with empty state if no risks */}
           <div className="card p-5 flex flex-col">
             <div className="flex items-center justify-between mb-3">
-              <h2 className="text-lg font-semibold text-surface-100">Risk Heat Map</h2>
+              <h2 className="text-lg font-semibold text-surface-900">Risk Heat Map</h2>
               <Link
                 to="/risks"
                 className="text-sm text-brand-400 hover:text-brand-300 flex items-center gap-1"
@@ -639,9 +639,9 @@ export default function Dashboard() {
                     <CompactRiskHeatMap risks={risksData.risks as any[]} showCounts />
                   </div>
                 </div>
-                <div className="flex items-center justify-between mt-4 pt-3 border-t border-surface-700">
+                <div className="flex items-center justify-between mt-4 pt-3 border-t border-surface-200">
                   <p className="text-sm text-surface-600">
-                    <span className="font-semibold text-surface-200">{risksData.risks.length}</span>{' '}
+                    <span className="font-semibold text-surface-800">{risksData.risks.length}</span>{' '}
                     risks tracked
                   </p>
                   <div className="flex items-center gap-3 text-xs">
@@ -666,7 +666,7 @@ export default function Dashboard() {
               </>
             ) : (
               <div className="flex-1 flex flex-col items-center justify-center min-h-[200px] text-center">
-                <div className="w-16 h-16 rounded-full bg-surface-700 flex items-center justify-center mb-4">
+                <div className="w-16 h-16 rounded-full bg-surface-200 flex items-center justify-center mb-4">
                   <ExclamationTriangleIcon className="w-8 h-8 text-surface-500" />
                 </div>
                 <p className="text-surface-600 text-sm mb-2">No risks registered yet</p>
@@ -688,7 +688,7 @@ export default function Dashboard() {
           {config.widgets.policyLifecycle && (
             <div className="card p-6">
               <div className="flex items-center justify-between mb-4">
-                <h2 className="text-lg font-semibold text-surface-100">Policy Lifecycle</h2>
+                <h2 className="text-lg font-semibold text-surface-900">Policy Lifecycle</h2>
                 <Link
                   to="/policies"
                   className="text-sm text-brand-400 hover:text-brand-300 flex items-center gap-1"
@@ -745,7 +745,7 @@ export default function Dashboard() {
           {/* Controls by Category - Top 6 */}
           {config.widgets.controlsByCategory && (
             <div className="card p-6">
-              <h2 className="text-lg font-semibold text-surface-100 mb-4">Controls by Category</h2>
+              <h2 className="text-lg font-semibold text-surface-900 mb-4">Controls by Category</h2>
               <div className="space-y-3">
                 {Object.entries(safeSummary.controls?.byCategory || {})
                   .sort(([, a], [, b]) => (b as number) - (a as number))
@@ -762,7 +762,7 @@ export default function Dashboard() {
                           </span>
                           <span className="text-sm text-surface-700">{String(count)}</span>
                         </div>
-                        <div className="w-full h-1.5 bg-surface-800 rounded-full overflow-hidden">
+                        <div className="w-full h-1.5 bg-white rounded-full overflow-hidden">
                           <div
                             className="h-full bg-brand-500 rounded-full"
                             style={{ width: `${percentage}%` }}
@@ -823,7 +823,7 @@ const StatCard = memo(function StatCard({
     <div
       className={clsx(
         'stat-card h-full',
-        linkTo && 'hover:border-surface-600 cursor-pointer transition-colors'
+        linkTo && 'hover:border-surface-300 cursor-pointer transition-colors'
       )}
     >
       <div className="flex items-start justify-between">
@@ -890,7 +890,7 @@ const VendorRiskSummary = memo(function VendorRiskSummary({ data }: VendorRiskSu
   if (stats.total === 0) {
     return (
       <div className="flex flex-col items-center justify-center py-8 text-center">
-        <div className="w-12 h-12 rounded-full bg-surface-700 flex items-center justify-center mb-3">
+        <div className="w-12 h-12 rounded-full bg-surface-200 flex items-center justify-center mb-3">
           <ExclamationTriangleIcon className="w-6 h-6 text-surface-500" />
         </div>
         <p className="text-surface-600 text-sm">No vendors configured yet</p>
@@ -905,15 +905,15 @@ const VendorRiskSummary = memo(function VendorRiskSummary({ data }: VendorRiskSu
     <div className="space-y-4">
       {/* Summary Stats */}
       <div className="grid grid-cols-3 gap-4">
-        <div className="text-center p-3 bg-surface-800/50 rounded-lg">
-          <p className="text-2xl font-bold text-surface-100">{stats.total}</p>
+        <div className="text-center p-3 bg-white/50 rounded-lg">
+          <p className="text-2xl font-bold text-surface-900">{stats.total}</p>
           <p className="text-xs text-surface-600">Total Vendors</p>
         </div>
-        <div className="text-center p-3 bg-surface-800/50 rounded-lg">
+        <div className="text-center p-3 bg-white/50 rounded-lg">
           <p className="text-2xl font-bold text-green-600">{stats.active}</p>
           <p className="text-xs text-surface-600">Active</p>
         </div>
-        <div className="text-center p-3 bg-surface-800/50 rounded-lg">
+        <div className="text-center p-3 bg-white/50 rounded-lg">
           <p className="text-2xl font-bold text-yellow-600">{stats.pendingReview}</p>
           <p className="text-xs text-surface-600">Pending Review</p>
         </div>
@@ -922,7 +922,7 @@ const VendorRiskSummary = memo(function VendorRiskSummary({ data }: VendorRiskSu
       {/* Criticality Breakdown */}
       <div>
         <p className="text-sm text-surface-600 mb-2">By Criticality</p>
-        <div className="flex gap-1 h-3 rounded-full overflow-hidden bg-surface-800">
+        <div className="flex gap-1 h-3 rounded-full overflow-hidden bg-white">
           {criticialityData.map(
             (item) =>
               item.count > 0 && (
@@ -955,7 +955,7 @@ const VendorRiskSummary = memo(function VendorRiskSummary({ data }: VendorRiskSu
             <Link
               key={vendor.id}
               to={`/vendors/${vendor.id}`}
-              className="flex items-center justify-between p-2 bg-surface-800/50 rounded-lg hover:bg-surface-700 transition-colors"
+              className="flex items-center justify-between p-2 bg-white/50 rounded-lg hover:bg-surface-200 transition-colors"
             >
               <div className="flex items-center gap-2">
                 <div
@@ -970,7 +970,7 @@ const VendorRiskSummary = memo(function VendorRiskSummary({ data }: VendorRiskSu
                           : 'bg-green-500'
                   )}
                 />
-                <span className="text-sm text-surface-200 truncate max-w-[180px]">
+                <span className="text-sm text-surface-800 truncate max-w-[180px]">
                   {vendor.name}
                 </span>
               </div>

--- a/frontend/src/pages/DesignSystem.tsx
+++ b/frontend/src/pages/DesignSystem.tsx
@@ -1,5 +1,15 @@
 import { useState } from 'react';
-import { Search, Plus, Filter, MoreHorizontal, Mail, Trash2 } from 'lucide-react';
+import {
+  Search,
+  Plus,
+  Filter,
+  MoreHorizontal,
+  Mail,
+  Trash2,
+  Sun,
+  Moon,
+  Monitor,
+} from 'lucide-react';
 import {
   Button,
   Card,
@@ -33,6 +43,8 @@ import {
   type BadgeVariant,
   type ButtonVariant,
 } from '@/components/ui';
+import { useTheme, Theme } from '@/contexts/ThemeContext';
+import { cn } from '@/lib/cn';
 
 const BADGE_VARIANTS: BadgeVariant[] = ['neutral', 'success', 'warning', 'danger', 'info', 'brand'];
 const BUTTON_VARIANTS: ButtonVariant[] = [
@@ -175,6 +187,40 @@ const TRENDS = {
   down: [38, 34, 30, 29, 22, 19, 14, 11],
 };
 
+function ThemeToggle() {
+  const { theme, setTheme, resolvedTheme } = useTheme();
+  const opts: { id: Theme; label: string; Icon: typeof Sun }[] = [
+    { id: 'light', label: 'Light', Icon: Sun },
+    { id: 'dark', label: 'Dark', Icon: Moon },
+    { id: 'system', label: 'System', Icon: Monitor },
+  ];
+  return (
+    <div className="inline-flex items-center gap-1 rounded-md border border-surface-200 bg-white p-0.5 dark:bg-surface-900 dark:border-surface-800">
+      {opts.map(({ id, label, Icon }) => {
+        const active = theme === id;
+        return (
+          <button
+            key={id}
+            type="button"
+            onClick={() => setTheme(id)}
+            title={`${label}${id === 'system' ? ` (currently ${resolvedTheme})` : ''}`}
+            aria-pressed={active}
+            className={cn(
+              'inline-flex items-center gap-1.5 px-2.5 h-7 rounded text-small font-medium transition-colors',
+              active
+                ? 'bg-brand-600 text-white dark:bg-brand-500'
+                : 'text-surface-700 hover:bg-surface-100 dark:text-surface-300 dark:hover:bg-surface-800'
+            )}
+          >
+            <Icon className="h-3.5 w-3.5" />
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
 export default function DesignSystem() {
   const [text, setText] = useState('');
   const [select1, setSelect1] = useState('medium');
@@ -187,7 +233,7 @@ export default function DesignSystem() {
     <div className="space-y-10 pb-16">
       <PageHeader
         title="Design System"
-        description="Tokens, primitives, and patterns. Every page on GigaChad GRC composes from this."
+        description="Tokens, primitives, and patterns. Every page on GigaChad GRC composes from this. Use the theme toggle to preview every primitive in light or dark mode."
         meta={
           <Badge variant="brand" size="sm">
             v1
@@ -195,6 +241,7 @@ export default function DesignSystem() {
         }
         actions={
           <>
+            <ThemeToggle />
             <Button variant="outline" leftIcon={<Filter className="h-4 w-4" />}>
               Filter
             </Button>

--- a/frontend/src/pages/DeveloperDocs.tsx
+++ b/frontend/src/pages/DeveloperDocs.tsx
@@ -64,7 +64,7 @@ function CopyButton({ text }: { text: string }) {
   return (
     <button
       onClick={copy}
-      className="absolute top-2 right-2 p-1.5 text-surface-600 hover:text-surface-200 hover:bg-surface-600 rounded transition-colors"
+      className="absolute top-2 right-2 p-1.5 text-surface-600 hover:text-surface-800 hover:bg-surface-600 rounded transition-colors"
       title="Copy to clipboard"
     >
       {copied ? (
@@ -78,8 +78,8 @@ function CopyButton({ text }: { text: string }) {
 
 function CodeBlock({ code, language = 'bash' }: { code: string; language?: string }) {
   return (
-    <div className="relative bg-surface-900 rounded-lg overflow-hidden my-4">
-      <div className="absolute top-0 left-0 px-3 py-1 text-xs text-surface-500 bg-surface-800 rounded-br">
+    <div className="relative bg-white rounded-lg overflow-hidden my-4">
+      <div className="absolute top-0 left-0 px-3 py-1 text-xs text-surface-500 bg-white rounded-br">
         {language}
       </div>
       <CopyButton text={code} />
@@ -95,20 +95,20 @@ function ApiDocs() {
   return (
     <div className="space-y-8">
       <section>
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">API Overview</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">API Overview</h2>
         <p className="text-surface-700 mb-4">
           GigaChad GRC provides a RESTful API for programmatic access to all platform features. All
           API requests require authentication via API key or JWT token.
         </p>
 
-        <div className="bg-surface-800/50 border border-surface-700 rounded-lg p-4">
-          <h4 className="font-semibold text-surface-200 mb-2">Base URL</h4>
+        <div className="bg-white/50 border border-surface-200 rounded-lg p-4">
+          <h4 className="font-semibold text-surface-800 mb-2">Base URL</h4>
           <code className="text-brand-400">https://api.gigachad-grc.com/v1</code>
         </div>
       </section>
 
       <section>
-        <h3 className="text-xl font-bold text-surface-100 mb-4">Authentication</h3>
+        <h3 className="text-xl font-bold text-surface-900 mb-4">Authentication</h3>
         <p className="text-surface-700 mb-4">Include your API key in the Authorization header:</p>
         <CodeBlock
           code={`curl -X GET "https://api.gigachad-grc.com/v1/controls" \\
@@ -118,19 +118,19 @@ function ApiDocs() {
       </section>
 
       <section>
-        <h3 className="text-xl font-bold text-surface-100 mb-4">Common Endpoints</h3>
+        <h3 className="text-xl font-bold text-surface-900 mb-4">Common Endpoints</h3>
 
         <div className="space-y-4">
-          <div className="bg-surface-800 rounded-lg overflow-hidden">
+          <div className="bg-white rounded-lg overflow-hidden">
             <table className="w-full text-sm">
-              <thead className="bg-surface-700">
+              <thead className="bg-surface-200">
                 <tr>
                   <th className="px-4 py-3 text-left text-surface-700 font-medium">Method</th>
                   <th className="px-4 py-3 text-left text-surface-700 font-medium">Endpoint</th>
                   <th className="px-4 py-3 text-left text-surface-700 font-medium">Description</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-surface-700">
+              <tbody className="divide-y divide-surface-200">
                 <tr>
                   <td className="px-4 py-3">
                     <span className="px-2 py-1 bg-green-500/20 text-green-600 rounded text-xs">
@@ -201,7 +201,7 @@ function ApiDocs() {
       </section>
 
       <section>
-        <h3 className="text-xl font-bold text-surface-100 mb-4">Example: Create a Control</h3>
+        <h3 className="text-xl font-bold text-surface-900 mb-4">Example: Create a Control</h3>
         <CodeBlock
           language="bash"
           code={`curl -X POST "https://api.gigachad-grc.com/v1/controls" \\
@@ -218,7 +218,7 @@ function ApiDocs() {
       </section>
 
       <section>
-        <h3 className="text-xl font-bold text-surface-100 mb-4">Response Format</h3>
+        <h3 className="text-xl font-bold text-surface-900 mb-4">Response Format</h3>
         <p className="text-surface-700 mb-4">
           All responses are JSON formatted with consistent structure:
         </p>
@@ -240,10 +240,10 @@ function ApiDocs() {
       </section>
 
       <section>
-        <h3 className="text-xl font-bold text-surface-100 mb-4">Rate Limits</h3>
-        <div className="bg-surface-800 rounded-lg overflow-hidden">
+        <h3 className="text-xl font-bold text-surface-900 mb-4">Rate Limits</h3>
+        <div className="bg-white rounded-lg overflow-hidden">
           <table className="w-full text-sm">
-            <thead className="bg-surface-700">
+            <thead className="bg-surface-200">
               <tr>
                 <th className="px-4 py-3 text-left text-surface-700 font-medium">Plan</th>
                 <th className="px-4 py-3 text-left text-surface-700 font-medium">
@@ -252,7 +252,7 @@ function ApiDocs() {
                 <th className="px-4 py-3 text-left text-surface-700 font-medium">Requests/day</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-surface-700">
+            <tbody className="divide-y divide-surface-200">
               <tr>
                 <td className="px-4 py-3 text-surface-700">Starter</td>
                 <td className="px-4 py-3 text-surface-600">60</td>
@@ -281,7 +281,7 @@ function ArchitectureDocs() {
   return (
     <div className="space-y-8">
       <section>
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">System Architecture</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">System Architecture</h2>
         <p className="text-surface-700 mb-4">
           GigaChad GRC is built on a modern microservices architecture designed for scalability,
           reliability, and security.
@@ -289,7 +289,7 @@ function ArchitectureDocs() {
       </section>
 
       <section>
-        <h3 className="text-xl font-bold text-surface-100 mb-4">Core Services</h3>
+        <h3 className="text-xl font-bold text-surface-900 mb-4">Core Services</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           {[
             {
@@ -321,9 +321,9 @@ function ArchitectureDocs() {
           ].map((service) => (
             <div
               key={service.name}
-              className="bg-surface-800/50 border border-surface-700 rounded-lg p-4"
+              className="bg-white/50 border border-surface-200 rounded-lg p-4"
             >
-              <h4 className="font-semibold text-surface-200">{service.name}</h4>
+              <h4 className="font-semibold text-surface-800">{service.name}</h4>
               <p className="text-surface-600 text-sm mt-1">{service.desc}</p>
               <code className="text-xs text-brand-400 mt-2 block">Port: {service.port}</code>
             </div>
@@ -332,16 +332,16 @@ function ArchitectureDocs() {
       </section>
 
       <section>
-        <h3 className="text-xl font-bold text-surface-100 mb-4">Technology Stack</h3>
-        <div className="bg-surface-800 rounded-lg overflow-hidden">
+        <h3 className="text-xl font-bold text-surface-900 mb-4">Technology Stack</h3>
+        <div className="bg-white rounded-lg overflow-hidden">
           <table className="w-full text-sm">
-            <thead className="bg-surface-700">
+            <thead className="bg-surface-200">
               <tr>
                 <th className="px-4 py-3 text-left text-surface-700 font-medium">Layer</th>
                 <th className="px-4 py-3 text-left text-surface-700 font-medium">Technology</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-surface-700">
+            <tbody className="divide-y divide-surface-200">
               <tr>
                 <td className="px-4 py-3 text-surface-700">Frontend</td>
                 <td className="px-4 py-3 text-surface-600">
@@ -374,8 +374,8 @@ function ArchitectureDocs() {
       </section>
 
       <section>
-        <h3 className="text-xl font-bold text-surface-100 mb-4">Data Flow</h3>
-        <div className="bg-surface-800/50 border border-surface-700 rounded-lg p-4">
+        <h3 className="text-xl font-bold text-surface-900 mb-4">Data Flow</h3>
+        <div className="bg-white/50 border border-surface-200 rounded-lg p-4">
           <ol className="space-y-3 text-surface-700">
             <li className="flex gap-3">
               <span className="flex-shrink-0 w-6 h-6 bg-brand-600 text-white rounded-full flex items-center justify-center text-sm font-bold">
@@ -418,7 +418,7 @@ function ArchitectureDocs() {
       </section>
 
       <section>
-        <h3 className="text-xl font-bold text-surface-100 mb-4">Security Architecture</h3>
+        <h3 className="text-xl font-bold text-surface-900 mb-4">Security Architecture</h3>
         <ul className="space-y-2 text-surface-700">
           <li className="flex gap-3">
             <span className="text-green-600">✓</span>
@@ -451,7 +451,7 @@ function ConfigurationDocs() {
   return (
     <div className="space-y-8">
       <section>
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Configuration Guide</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Configuration Guide</h2>
         <p className="text-surface-700 mb-4">
           GigaChad GRC uses environment variables for configuration. This guide covers all available
           configuration options.
@@ -459,45 +459,45 @@ function ConfigurationDocs() {
       </section>
 
       <section>
-        <h3 className="text-xl font-bold text-surface-100 mb-4">Required Environment Variables</h3>
-        <div className="bg-surface-800 rounded-lg overflow-hidden">
+        <h3 className="text-xl font-bold text-surface-900 mb-4">Required Environment Variables</h3>
+        <div className="bg-white rounded-lg overflow-hidden">
           <table className="w-full text-sm">
-            <thead className="bg-surface-700">
+            <thead className="bg-surface-200">
               <tr>
                 <th className="px-4 py-3 text-left text-surface-700 font-medium">Variable</th>
                 <th className="px-4 py-3 text-left text-surface-700 font-medium">Description</th>
                 <th className="px-4 py-3 text-left text-surface-700 font-medium">Example</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-surface-700">
+            <tbody className="divide-y divide-surface-200">
               <tr>
-                <td className="px-4 py-3 text-surface-200 font-mono text-xs">DATABASE_URL</td>
+                <td className="px-4 py-3 text-surface-800 font-mono text-xs">DATABASE_URL</td>
                 <td className="px-4 py-3 text-surface-600">PostgreSQL connection string</td>
                 <td className="px-4 py-3 text-surface-500 font-mono text-xs">
                   postgresql://user:pass@host:5432/db
                 </td>
               </tr>
               <tr>
-                <td className="px-4 py-3 text-surface-200 font-mono text-xs">ENCRYPTION_KEY</td>
+                <td className="px-4 py-3 text-surface-800 font-mono text-xs">ENCRYPTION_KEY</td>
                 <td className="px-4 py-3 text-surface-600">
                   32-byte hex key for credential encryption
                 </td>
                 <td className="px-4 py-3 text-surface-500 font-mono text-xs">64 hex characters</td>
               </tr>
               <tr>
-                <td className="px-4 py-3 text-surface-200 font-mono text-xs">KEYCLOAK_URL</td>
+                <td className="px-4 py-3 text-surface-800 font-mono text-xs">KEYCLOAK_URL</td>
                 <td className="px-4 py-3 text-surface-600">Keycloak server URL</td>
                 <td className="px-4 py-3 text-surface-500 font-mono text-xs">
                   http://localhost:8080
                 </td>
               </tr>
               <tr>
-                <td className="px-4 py-3 text-surface-200 font-mono text-xs">KEYCLOAK_REALM</td>
+                <td className="px-4 py-3 text-surface-800 font-mono text-xs">KEYCLOAK_REALM</td>
                 <td className="px-4 py-3 text-surface-600">Keycloak realm name</td>
                 <td className="px-4 py-3 text-surface-500 font-mono text-xs">gigachad-grc</td>
               </tr>
               <tr>
-                <td className="px-4 py-3 text-surface-200 font-mono text-xs">KEYCLOAK_CLIENT_ID</td>
+                <td className="px-4 py-3 text-surface-800 font-mono text-xs">KEYCLOAK_CLIENT_ID</td>
                 <td className="px-4 py-3 text-surface-600">Keycloak client ID</td>
                 <td className="px-4 py-3 text-surface-500 font-mono text-xs">grc-frontend</td>
               </tr>
@@ -507,7 +507,7 @@ function ConfigurationDocs() {
       </section>
 
       <section>
-        <h3 className="text-xl font-bold text-surface-100 mb-4">Example .env File</h3>
+        <h3 className="text-xl font-bold text-surface-900 mb-4">Example .env File</h3>
         <CodeBlock
           language="env"
           code={`# Database
@@ -542,7 +542,7 @@ VITE_KEYCLOAK_CLIENT_ID=grc-frontend`}
       </section>
 
       <section>
-        <h3 className="text-xl font-bold text-surface-100 mb-4">Generating Encryption Key</h3>
+        <h3 className="text-xl font-bold text-surface-900 mb-4">Generating Encryption Key</h3>
         <p className="text-surface-700 mb-4">Generate a secure 32-byte encryption key:</p>
         <CodeBlock code="openssl rand -hex 32" />
         <div className="bg-amber-50 dark:bg-yellow-500/10 border border-amber-300 dark:border-yellow-500/30 rounded-lg p-4 mt-4">
@@ -554,36 +554,36 @@ VITE_KEYCLOAK_CLIENT_ID=grc-frontend`}
       </section>
 
       <section>
-        <h3 className="text-xl font-bold text-surface-100 mb-4">Optional Configuration</h3>
-        <div className="bg-surface-800 rounded-lg overflow-hidden">
+        <h3 className="text-xl font-bold text-surface-900 mb-4">Optional Configuration</h3>
+        <div className="bg-white rounded-lg overflow-hidden">
           <table className="w-full text-sm">
-            <thead className="bg-surface-700">
+            <thead className="bg-surface-200">
               <tr>
                 <th className="px-4 py-3 text-left text-surface-700 font-medium">Variable</th>
                 <th className="px-4 py-3 text-left text-surface-700 font-medium">Default</th>
                 <th className="px-4 py-3 text-left text-surface-700 font-medium">Description</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-surface-700">
+            <tbody className="divide-y divide-surface-200">
               <tr>
-                <td className="px-4 py-3 text-surface-200 font-mono text-xs">LOG_LEVEL</td>
+                <td className="px-4 py-3 text-surface-800 font-mono text-xs">LOG_LEVEL</td>
                 <td className="px-4 py-3 text-surface-600">info</td>
                 <td className="px-4 py-3 text-surface-600">
                   Logging level (debug, info, warn, error)
                 </td>
               </tr>
               <tr>
-                <td className="px-4 py-3 text-surface-200 font-mono text-xs">CORS_ORIGINS</td>
+                <td className="px-4 py-3 text-surface-800 font-mono text-xs">CORS_ORIGINS</td>
                 <td className="px-4 py-3 text-surface-600">*</td>
                 <td className="px-4 py-3 text-surface-600">Allowed CORS origins</td>
               </tr>
               <tr>
-                <td className="px-4 py-3 text-surface-200 font-mono text-xs">SESSION_TIMEOUT</td>
+                <td className="px-4 py-3 text-surface-800 font-mono text-xs">SESSION_TIMEOUT</td>
                 <td className="px-4 py-3 text-surface-600">3600</td>
                 <td className="px-4 py-3 text-surface-600">Session timeout in seconds</td>
               </tr>
               <tr>
-                <td className="px-4 py-3 text-surface-200 font-mono text-xs">MAX_UPLOAD_SIZE</td>
+                <td className="px-4 py-3 text-surface-800 font-mono text-xs">MAX_UPLOAD_SIZE</td>
                 <td className="px-4 py-3 text-surface-600">10MB</td>
                 <td className="px-4 py-3 text-surface-600">Maximum file upload size</td>
               </tr>
@@ -600,7 +600,7 @@ function DeploymentDocs() {
   return (
     <div className="space-y-8">
       <section>
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Deployment Guide</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Deployment Guide</h2>
         <p className="text-surface-700 mb-4">
           This guide covers deploying GigaChad GRC to production environments using Docker and
           Docker Compose.
@@ -608,7 +608,7 @@ function DeploymentDocs() {
       </section>
 
       <section>
-        <h3 className="text-xl font-bold text-surface-100 mb-4">Prerequisites</h3>
+        <h3 className="text-xl font-bold text-surface-900 mb-4">Prerequisites</h3>
         <ul className="space-y-2 text-surface-700">
           <li className="flex gap-3">
             <span className="text-brand-400">•</span>
@@ -630,7 +630,7 @@ function DeploymentDocs() {
       </section>
 
       <section>
-        <h3 className="text-xl font-bold text-surface-100 mb-4">Quick Start with Docker Compose</h3>
+        <h3 className="text-xl font-bold text-surface-900 mb-4">Quick Start with Docker Compose</h3>
         <CodeBlock
           code={`# Clone the repository
 git clone https://github.com/grcengineering/gigachad-grc.git
@@ -651,65 +651,44 @@ docker-compose logs -f`}
       </section>
 
       <section>
-        <h3 className="text-xl font-bold text-surface-100 mb-4">Production Checklist</h3>
+        <h3 className="text-xl font-bold text-surface-900 mb-4">Production Checklist</h3>
         <ul className="space-y-2 text-surface-700">
           <li className="flex gap-3">
-            <input
-              type="checkbox"
-              className="mt-1 w-4 h-4 bg-surface-800 border-surface-600 rounded"
-            />
+            <input type="checkbox" className="mt-1 w-4 h-4 bg-white border-surface-300 rounded" />
             <span>
               Generate unique ENCRYPTION_KEY using{' '}
               <code className="text-brand-400 text-sm">openssl rand -hex 32</code>
             </span>
           </li>
           <li className="flex gap-3">
-            <input
-              type="checkbox"
-              className="mt-1 w-4 h-4 bg-surface-800 border-surface-600 rounded"
-            />
+            <input type="checkbox" className="mt-1 w-4 h-4 bg-white border-surface-300 rounded" />
             <span>Configure SSL/TLS certificates (Let's Encrypt or custom)</span>
           </li>
           <li className="flex gap-3">
-            <input
-              type="checkbox"
-              className="mt-1 w-4 h-4 bg-surface-800 border-surface-600 rounded"
-            />
+            <input type="checkbox" className="mt-1 w-4 h-4 bg-white border-surface-300 rounded" />
             <span>Set up database backups (daily recommended)</span>
           </li>
           <li className="flex gap-3">
-            <input
-              type="checkbox"
-              className="mt-1 w-4 h-4 bg-surface-800 border-surface-600 rounded"
-            />
+            <input type="checkbox" className="mt-1 w-4 h-4 bg-white border-surface-300 rounded" />
             <span>Configure firewall rules (allow ports 80, 443)</span>
           </li>
           <li className="flex gap-3">
-            <input
-              type="checkbox"
-              className="mt-1 w-4 h-4 bg-surface-800 border-surface-600 rounded"
-            />
+            <input type="checkbox" className="mt-1 w-4 h-4 bg-white border-surface-300 rounded" />
             <span>Set up monitoring and alerting</span>
           </li>
           <li className="flex gap-3">
-            <input
-              type="checkbox"
-              className="mt-1 w-4 h-4 bg-surface-800 border-surface-600 rounded"
-            />
+            <input type="checkbox" className="mt-1 w-4 h-4 bg-white border-surface-300 rounded" />
             <span>Configure log aggregation</span>
           </li>
           <li className="flex gap-3">
-            <input
-              type="checkbox"
-              className="mt-1 w-4 h-4 bg-surface-800 border-surface-600 rounded"
-            />
+            <input type="checkbox" className="mt-1 w-4 h-4 bg-white border-surface-300 rounded" />
             <span>Test disaster recovery procedures</span>
           </li>
         </ul>
       </section>
 
       <section>
-        <h3 className="text-xl font-bold text-surface-100 mb-4">Database Migration</h3>
+        <h3 className="text-xl font-bold text-surface-900 mb-4">Database Migration</h3>
         <CodeBlock
           code={`# Run database migrations
 docker-compose exec controls npx prisma migrate deploy
@@ -720,7 +699,7 @@ docker-compose exec controls npx prisma db seed`}
       </section>
 
       <section>
-        <h3 className="text-xl font-bold text-surface-100 mb-4">Health Checks</h3>
+        <h3 className="text-xl font-bold text-surface-900 mb-4">Health Checks</h3>
         <p className="text-surface-700 mb-4">Verify all services are running:</p>
         <CodeBlock
           code={`# Check service health
@@ -741,14 +720,14 @@ function DevelopmentDocs() {
   return (
     <div className="space-y-8">
       <section>
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Development Setup</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Development Setup</h2>
         <p className="text-surface-700 mb-4">
           This guide walks through setting up a local development environment for GigaChad GRC.
         </p>
       </section>
 
       <section>
-        <h3 className="text-xl font-bold text-surface-100 mb-4">Prerequisites</h3>
+        <h3 className="text-xl font-bold text-surface-900 mb-4">Prerequisites</h3>
         <ul className="space-y-2 text-surface-700">
           <li className="flex gap-3">
             <span className="text-brand-400">•</span>
@@ -766,7 +745,7 @@ function DevelopmentDocs() {
       </section>
 
       <section>
-        <h3 className="text-xl font-bold text-surface-100 mb-4">Quick Start</h3>
+        <h3 className="text-xl font-bold text-surface-900 mb-4">Quick Start</h3>
         <CodeBlock
           code={`# Clone the repository
 git clone https://github.com/grcengineering/gigachad-grc.git
@@ -790,7 +769,7 @@ npm run dev`}
       </section>
 
       <section>
-        <h3 className="text-xl font-bold text-surface-100 mb-4">Project Structure</h3>
+        <h3 className="text-xl font-bold text-surface-900 mb-4">Project Structure</h3>
         <CodeBlock
           language="text"
           code={`gigachad-grc/
@@ -816,7 +795,7 @@ npm run dev`}
       </section>
 
       <section>
-        <h3 className="text-xl font-bold text-surface-100 mb-4">Running Tests</h3>
+        <h3 className="text-xl font-bold text-surface-900 mb-4">Running Tests</h3>
         <CodeBlock
           code={`# Run all tests
 npm test
@@ -833,7 +812,7 @@ npm run test:e2e`}
       </section>
 
       <section>
-        <h3 className="text-xl font-bold text-surface-100 mb-4">Code Style</h3>
+        <h3 className="text-xl font-bold text-surface-900 mb-4">Code Style</h3>
         <p className="text-surface-700 mb-4">
           The project uses ESLint and Prettier for code formatting:
         </p>
@@ -850,36 +829,36 @@ npm run format`}
       </section>
 
       <section>
-        <h3 className="text-xl font-bold text-surface-100 mb-4">Useful Commands</h3>
-        <div className="bg-surface-800 rounded-lg overflow-hidden">
+        <h3 className="text-xl font-bold text-surface-900 mb-4">Useful Commands</h3>
+        <div className="bg-white rounded-lg overflow-hidden">
           <table className="w-full text-sm">
-            <thead className="bg-surface-700">
+            <thead className="bg-surface-200">
               <tr>
                 <th className="px-4 py-3 text-left text-surface-700 font-medium">Command</th>
                 <th className="px-4 py-3 text-left text-surface-700 font-medium">Description</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-surface-700">
+            <tbody className="divide-y divide-surface-200">
               <tr>
-                <td className="px-4 py-3 text-surface-200 font-mono text-xs">npm run dev</td>
+                <td className="px-4 py-3 text-surface-800 font-mono text-xs">npm run dev</td>
                 <td className="px-4 py-3 text-surface-600">Start all services in dev mode</td>
               </tr>
               <tr>
-                <td className="px-4 py-3 text-surface-200 font-mono text-xs">npm run build</td>
+                <td className="px-4 py-3 text-surface-800 font-mono text-xs">npm run build</td>
                 <td className="px-4 py-3 text-surface-600">Build all services for production</td>
               </tr>
               <tr>
-                <td className="px-4 py-3 text-surface-200 font-mono text-xs">npx prisma studio</td>
+                <td className="px-4 py-3 text-surface-800 font-mono text-xs">npx prisma studio</td>
                 <td className="px-4 py-3 text-surface-600">Open Prisma database GUI</td>
               </tr>
               <tr>
-                <td className="px-4 py-3 text-surface-200 font-mono text-xs">
+                <td className="px-4 py-3 text-surface-800 font-mono text-xs">
                   npx prisma migrate dev
                 </td>
                 <td className="px-4 py-3 text-surface-600">Run database migrations</td>
               </tr>
               <tr>
-                <td className="px-4 py-3 text-surface-200 font-mono text-xs">
+                <td className="px-4 py-3 text-surface-800 font-mono text-xs">
                   docker-compose logs -f
                 </td>
                 <td className="px-4 py-3 text-surface-600">View service logs</td>
@@ -920,7 +899,7 @@ export default function DeveloperDocs() {
       {/* Back Link */}
       <Link
         to="/help"
-        className="inline-flex items-center gap-2 text-surface-600 hover:text-surface-200 mb-6"
+        className="inline-flex items-center gap-2 text-surface-600 hover:text-surface-800 mb-6"
       >
         <ArrowLeftIcon className="w-4 h-4" />
         Back to Help Center
@@ -928,7 +907,7 @@ export default function DeveloperDocs() {
 
       {/* Header */}
       <header className="mb-8">
-        <h1 className="text-3xl font-bold text-surface-100">Developer Documentation</h1>
+        <h1 className="text-3xl font-bold text-surface-900">Developer Documentation</h1>
         <p className="text-surface-600 mt-2">Technical guides and API reference for developers</p>
       </header>
 
@@ -946,7 +925,7 @@ export default function DeveloperDocs() {
                   className={`w-full flex items-center gap-3 px-4 py-3 rounded-lg text-left transition-colors ${
                     isActive
                       ? 'bg-brand-600/20 text-brand-400 border border-brand-500/30'
-                      : 'text-surface-600 hover:bg-surface-800 hover:text-surface-200'
+                      : 'text-surface-600 hover:bg-white hover:text-surface-800'
                   }`}
                 >
                   <Icon className="w-5 h-5" />
@@ -962,14 +941,14 @@ export default function DeveloperDocs() {
 
         {/* Main Content */}
         <main className="flex-1 min-w-0">
-          <div className="bg-surface-800/30 border border-surface-700 rounded-xl p-6 lg:p-8">
+          <div className="bg-white/30 border border-surface-200 rounded-xl p-6 lg:p-8">
             {currentSection && (
-              <div className="flex items-center gap-3 mb-6 pb-6 border-b border-surface-700">
+              <div className="flex items-center gap-3 mb-6 pb-6 border-b border-surface-200">
                 <div className="p-2 bg-brand-600/20 rounded-lg">
                   <currentSection.icon className="w-6 h-6 text-brand-400" />
                 </div>
                 <div>
-                  <h2 className="text-xl font-semibold text-surface-100">{currentSection.name}</h2>
+                  <h2 className="text-xl font-semibold text-surface-900">{currentSection.name}</h2>
                   <p className="text-surface-600 text-sm">{currentSection.description}</p>
                 </div>
               </div>

--- a/frontend/src/pages/DisabledModulePage.tsx
+++ b/frontend/src/pages/DisabledModulePage.tsx
@@ -23,12 +23,12 @@ export default function DisabledModulePage({ moduleId }: DisabledModulePageProps
     <div className="min-h-[60vh] flex items-center justify-center p-6">
       <div className="max-w-lg w-full text-center">
         {/* Icon */}
-        <div className="mx-auto w-20 h-20 rounded-full bg-surface-800 flex items-center justify-center mb-6">
+        <div className="mx-auto w-20 h-20 rounded-full bg-white flex items-center justify-center mb-6">
           <LockClosedIcon className="w-10 h-10 text-surface-600" />
         </div>
 
         {/* Title */}
-        <h1 className="text-2xl font-bold text-surface-100 mb-2">Module Not Enabled</h1>
+        <h1 className="text-2xl font-bold text-surface-900 mb-2">Module Not Enabled</h1>
 
         {/* Module Name */}
         {moduleDefinition && <p className="text-lg text-brand-400 mb-4">{moduleDefinition.name}</p>}
@@ -41,8 +41,8 @@ export default function DisabledModulePage({ moduleId }: DisabledModulePageProps
         </p>
 
         {/* How to Enable */}
-        <div className="bg-surface-800/50 rounded-lg p-4 mb-6 text-left">
-          <h3 className="text-sm font-semibold text-surface-200 mb-2 flex items-center gap-2">
+        <div className="bg-white/50 rounded-lg p-4 mb-6 text-left">
+          <h3 className="text-sm font-semibold text-surface-800 mb-2 flex items-center gap-2">
             <Cog6ToothIcon className="w-4 h-4" />
             How to Enable This Module
           </h3>
@@ -51,7 +51,7 @@ export default function DisabledModulePage({ moduleId }: DisabledModulePageProps
               To enable this module, an administrator needs to update the environment configuration:
             </p>
             {moduleDefinition && (
-              <code className="block bg-surface-900 px-3 py-2 rounded text-xs text-green-600 font-mono">
+              <code className="block bg-white px-3 py-2 rounded text-xs text-green-600 font-mono">
                 {moduleDefinition.envVar}=true
               </code>
             )}

--- a/frontend/src/pages/EmployeeComplianceDashboard.tsx
+++ b/frontend/src/pages/EmployeeComplianceDashboard.tsx
@@ -105,11 +105,11 @@ function StatCard({
       <div className="card p-6 animate-pulse">
         <div className="flex items-center justify-between">
           <div className="space-y-2">
-            <div className="h-4 w-24 bg-surface-700 rounded" />
-            <div className="h-8 w-16 bg-surface-700 rounded" />
-            <div className="h-3 w-20 bg-surface-700 rounded" />
+            <div className="h-4 w-24 bg-surface-200 rounded" />
+            <div className="h-8 w-16 bg-surface-200 rounded" />
+            <div className="h-3 w-20 bg-surface-200 rounded" />
           </div>
-          <div className="p-3 rounded-lg bg-surface-700 h-12 w-12" />
+          <div className="p-3 rounded-lg bg-surface-200 h-12 w-12" />
         </div>
       </div>
     );
@@ -123,7 +123,7 @@ function StatCard({
           <p className={`text-3xl font-bold ${color}`}>{value}</p>
           {subtitle && <p className="text-sm text-muted-foreground mt-1">{subtitle}</p>}
         </div>
-        <div className="p-3 rounded-lg bg-surface-700">
+        <div className="p-3 rounded-lg bg-surface-200">
           <Icon className={`h-6 w-6 ${color}`} />
         </div>
       </div>
@@ -146,7 +146,7 @@ function ScoreBar({
   return (
     <div className="flex items-center gap-3">
       <span className="text-sm text-muted-foreground w-24">{range}</span>
-      <div className="flex-1 h-6 bg-surface-700 rounded-full overflow-hidden">
+      <div className="flex-1 h-6 bg-surface-200 rounded-full overflow-hidden">
         <div
           className={`h-full ${color} rounded-full transition-all duration-500`}
           style={{ width: `${percentage}%` }}
@@ -172,7 +172,7 @@ function DataCoverageBar({
     <div className="flex items-center gap-3">
       <Icon className={`h-5 w-5 ${color}`} />
       <span className="text-sm text-muted-foreground w-32">{label}</span>
-      <div className="flex-1 h-2 bg-surface-700 rounded-full overflow-hidden">
+      <div className="flex-1 h-2 bg-surface-200 rounded-full overflow-hidden">
         <div
           className={`h-full ${percentage >= 90 ? 'bg-green-500' : percentage >= 70 ? 'bg-yellow-500' : 'bg-red-500'} rounded-full transition-all duration-500`}
           style={{ width: `${percentage}%` }}
@@ -429,7 +429,7 @@ export default function EmployeeComplianceDashboard() {
               {isLoading ? (
                 <div className="space-y-3">
                   {[1, 2, 3].map((i) => (
-                    <div key={i} className="h-6 bg-surface-700 rounded animate-pulse" />
+                    <div key={i} className="h-6 bg-surface-200 rounded animate-pulse" />
                   ))}
                 </div>
               ) : !hasData ? (
@@ -464,7 +464,7 @@ export default function EmployeeComplianceDashboard() {
               {isLoading ? (
                 <div className="space-y-3">
                   {[1, 2, 3, 4, 5].map((i) => (
-                    <div key={i} className="h-12 bg-surface-700 rounded animate-pulse" />
+                    <div key={i} className="h-12 bg-surface-200 rounded animate-pulse" />
                   ))}
                 </div>
               ) : totalIssues === 0 ? (
@@ -480,7 +480,7 @@ export default function EmployeeComplianceDashboard() {
                     .map((issue) => (
                       <div
                         key={issue.type}
-                        className="flex items-center justify-between p-3 bg-surface-700/50 rounded-lg hover:bg-surface-700 transition-colors"
+                        className="flex items-center justify-between p-3 bg-surface-200/50 rounded-lg hover:bg-surface-200 transition-colors"
                       >
                         <div className="flex items-center gap-3">
                           <issue.icon className={`h-5 w-5 ${issue.color}`} />
@@ -522,7 +522,7 @@ export default function EmployeeComplianceDashboard() {
                       {metrics.departmentStats.map((dept) => (
                         <tr
                           key={dept.department}
-                          className="border-b border-border hover:bg-surface-700/30 transition-colors"
+                          className="border-b border-border hover:bg-surface-200/30 transition-colors"
                         >
                           <td className="p-2">
                             <div className="flex items-center gap-2">
@@ -557,7 +557,7 @@ export default function EmployeeComplianceDashboard() {
               {isLoading ? (
                 <div className="space-y-4">
                   {[1, 2, 3, 4, 5].map((i) => (
-                    <div key={i} className="h-5 bg-surface-700 rounded animate-pulse" />
+                    <div key={i} className="h-5 bg-surface-200 rounded animate-pulse" />
                   ))}
                 </div>
               ) : (
@@ -649,7 +649,7 @@ export default function EmployeeComplianceDashboard() {
                       {metrics.upcomingDeadlines.overdueTrainings.slice(0, 5).map((item, i) => (
                         <div
                           key={i}
-                          className="text-sm p-2 bg-surface-700/30 rounded hover:bg-surface-700/50 transition-colors"
+                          className="text-sm p-2 bg-surface-200/30 rounded hover:bg-surface-200/50 transition-colors"
                         >
                           <p className="text-foreground font-medium">
                             {item.employeeName || item.employeeEmail}
@@ -694,7 +694,7 @@ export default function EmployeeComplianceDashboard() {
                         .map((item, i) => (
                           <div
                             key={i}
-                            className="text-sm p-2 bg-surface-700/30 rounded hover:bg-surface-700/50 transition-colors"
+                            className="text-sm p-2 bg-surface-200/30 rounded hover:bg-surface-200/50 transition-colors"
                           >
                             <p className="text-foreground font-medium">
                               {item.employeeName || item.employeeEmail}
@@ -737,7 +737,7 @@ export default function EmployeeComplianceDashboard() {
                       {metrics.upcomingDeadlines.pendingAttestations.slice(0, 5).map((item, i) => (
                         <div
                           key={i}
-                          className="text-sm p-2 bg-surface-700/30 rounded hover:bg-surface-700/50 transition-colors"
+                          className="text-sm p-2 bg-surface-200/30 rounded hover:bg-surface-200/50 transition-colors"
                         >
                           <p className="text-foreground font-medium">
                             {item.employeeName || item.employeeEmail}

--- a/frontend/src/pages/EmployeeDetail.tsx
+++ b/frontend/src/pages/EmployeeDetail.tsx
@@ -94,17 +94,17 @@ function LoadingState() {
   return (
     <div className="p-6 space-y-6">
       <div className="flex items-center gap-4">
-        <div className="p-2 rounded-lg bg-surface-700 h-9 w-9 animate-pulse" />
+        <div className="p-2 rounded-lg bg-surface-200 h-9 w-9 animate-pulse" />
         <div className="flex-1 space-y-2">
-          <div className="h-8 w-48 bg-surface-700 rounded animate-pulse" />
-          <div className="h-4 w-64 bg-surface-700 rounded animate-pulse" />
+          <div className="h-8 w-48 bg-surface-200 rounded animate-pulse" />
+          <div className="h-4 w-64 bg-surface-200 rounded animate-pulse" />
         </div>
-        <div className="h-20 w-20 rounded-full bg-surface-700 animate-pulse" />
+        <div className="h-20 w-20 rounded-full bg-surface-200 animate-pulse" />
       </div>
-      <div className="h-12 bg-surface-700 rounded animate-pulse" />
+      <div className="h-12 bg-surface-200 rounded animate-pulse" />
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {[1, 2, 3].map((i) => (
-          <div key={i} className="card p-6 h-48 bg-surface-700 animate-pulse" />
+          <div key={i} className="card p-6 h-48 bg-surface-200 animate-pulse" />
         ))}
       </div>
     </div>
@@ -169,7 +169,7 @@ export default function EmployeeDetail() {
       <div className="flex items-center gap-4">
         <Link
           to="/people"
-          className="p-2 rounded-lg hover:bg-surface-700 text-muted-foreground hover:text-foreground"
+          className="p-2 rounded-lg hover:bg-surface-200 text-muted-foreground hover:text-foreground"
         >
           <ArrowLeftIcon className="h-5 w-5" />
         </Link>
@@ -260,7 +260,7 @@ export default function EmployeeDetail() {
               ) : (
                 <div className="space-y-2">
                   {complianceIssues.map((issue: any, i: number) => (
-                    <div key={i} className="flex items-start gap-2 p-2 rounded bg-surface-700/50">
+                    <div key={i} className="flex items-start gap-2 p-2 rounded bg-surface-200/50">
                       <ExclamationTriangleIcon
                         className={`h-4 w-4 mt-0.5 ${issue.severity === 'critical' ? 'text-red-600' : issue.severity === 'high' ? 'text-orange-600' : 'text-yellow-600'}`}
                       />
@@ -286,7 +286,7 @@ export default function EmployeeDetail() {
                   {dataSources.map((source: any, i: number) => (
                     <div
                       key={i}
-                      className="flex items-center justify-between p-2 rounded bg-surface-700/50"
+                      className="flex items-center justify-between p-2 rounded bg-surface-200/50"
                     >
                       <div>
                         <p className="text-sm font-medium text-foreground">{source.integration}</p>
@@ -461,7 +461,7 @@ export default function EmployeeDetail() {
             ) : (
               accessRecords.map((record: any) => (
                 <div key={record.id} className="space-y-4">
-                  <div className="flex items-center gap-4 p-3 bg-surface-700/50 rounded-lg">
+                  <div className="flex items-center gap-4 p-3 bg-surface-200/50 rounded-lg">
                     <div className="flex items-center gap-2">
                       <KeyIcon className="h-5 w-5 text-muted-foreground" />
                       <span className="text-foreground">MFA Status:</span>

--- a/frontend/src/pages/Employees.tsx
+++ b/frontend/src/pages/Employees.tsx
@@ -314,19 +314,19 @@ export default function Employees() {
           <span>Sort by:</span>
           <button
             onClick={() => handleSort('lastName')}
-            className={`px-2 py-1 rounded ${sortBy === 'lastName' ? 'bg-surface-700 text-foreground' : ''}`}
+            className={`px-2 py-1 rounded ${sortBy === 'lastName' ? 'bg-surface-200 text-foreground' : ''}`}
           >
             Name {sortBy === 'lastName' && (sortOrder === 'asc' ? '↑' : '↓')}
           </button>
           <button
             onClick={() => handleSort('complianceScore')}
-            className={`px-2 py-1 rounded ${sortBy === 'complianceScore' ? 'bg-surface-700 text-foreground' : ''}`}
+            className={`px-2 py-1 rounded ${sortBy === 'complianceScore' ? 'bg-surface-200 text-foreground' : ''}`}
           >
             Score {sortBy === 'complianceScore' && (sortOrder === 'asc' ? '↑' : '↓')}
           </button>
           <button
             onClick={() => handleSort('department')}
-            className={`px-2 py-1 rounded ${sortBy === 'department' ? 'bg-surface-700 text-foreground' : ''}`}
+            className={`px-2 py-1 rounded ${sortBy === 'department' ? 'bg-surface-200 text-foreground' : ''}`}
           >
             Dept {sortBy === 'department' && (sortOrder === 'asc' ? '↑' : '↓')}
           </button>
@@ -336,7 +336,7 @@ export default function Employees() {
         <div className="overflow-x-auto">
           <table className="w-full">
             <thead>
-              <tr className="border-b border-border bg-surface-800/50">
+              <tr className="border-b border-border bg-white/50">
                 <th className="text-left p-4 font-medium text-muted-foreground">Employee</th>
                 <th className="text-left p-4 font-medium text-muted-foreground">Department</th>
                 <th className="text-center p-4 font-medium text-muted-foreground">Score</th>
@@ -364,10 +364,10 @@ export default function Employees() {
                 </tr>
               ) : (
                 employees.map((employee) => (
-                  <tr key={employee.id} className="border-b border-border hover:bg-surface-800/30">
+                  <tr key={employee.id} className="border-b border-border hover:bg-white/30">
                     <td className="p-4">
                       <div className="flex items-center gap-3">
-                        <div className="h-10 w-10 rounded-full bg-surface-700 flex items-center justify-center">
+                        <div className="h-10 w-10 rounded-full bg-surface-200 flex items-center justify-center">
                           <UserIcon className="h-5 w-5 text-muted-foreground" />
                         </div>
                         <div>

--- a/frontend/src/pages/Evidence.tsx
+++ b/frontend/src/pages/Evidence.tsx
@@ -125,7 +125,7 @@ export default function Evidence() {
             <div className="flex items-center gap-3">
               <LinkIcon className="w-5 h-5 text-brand-400" />
               <div>
-                <p className="text-sm font-medium text-surface-100">Linking evidence to control</p>
+                <p className="text-sm font-medium text-surface-900">Linking evidence to control</p>
                 <p className="text-xs text-surface-600">
                   <span className="font-mono text-brand-400">{linkControl.controlId}</span>
                   {' - '}
@@ -143,7 +143,7 @@ export default function Evidence() {
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-bold text-surface-100">Evidence Library</h1>
+          <h1 className="text-2xl font-bold text-surface-900">Evidence Library</h1>
           <p className="text-surface-600 mt-1">
             {linkToControlId
               ? 'Select evidence to link to the control, or upload new evidence'
@@ -215,15 +215,15 @@ export default function Evidence() {
                 to={`/evidence/${item.id}`}
                 className={clsx(
                   'card p-4 transition-colors block',
-                  isLinked ? 'border-green-500/50 bg-green-500/5' : 'hover:border-surface-700'
+                  isLinked ? 'border-green-500/50 bg-green-500/5' : 'hover:border-surface-200'
                 )}
               >
                 <div className="flex items-start gap-3">
-                  <div className="p-2 bg-surface-800 rounded-lg">
+                  <div className="p-2 bg-white rounded-lg">
                     <Icon className="w-6 h-6 text-surface-600" />
                   </div>
                   <div className="flex-1 min-w-0">
-                    <h3 className="text-sm font-medium text-surface-100 truncate">{item.title}</h3>
+                    <h3 className="text-sm font-medium text-surface-900 truncate">{item.title}</h3>
                     <p className="text-xs text-surface-500 mt-1">{item.filename}</p>
                     <div className="flex items-center gap-2 mt-2">
                       <span className={clsx('text-xs', STATUS_STYLES[item.status])}>
@@ -238,7 +238,7 @@ export default function Evidence() {
                     )}
                   </div>
                 </div>
-                <div className="flex items-center gap-2 mt-4 pt-3 border-t border-surface-800">
+                <div className="flex items-center gap-2 mt-4 pt-3 border-t border-surface-200">
                   <span className="text-xs text-surface-500 flex-1">
                     {new Date(item.createdAt).toLocaleDateString()}
                   </span>
@@ -298,7 +298,7 @@ export default function Evidence() {
                         toast.error('Failed to download file');
                       }
                     }}
-                    className="p-1 text-surface-600 hover:text-surface-100"
+                    className="p-1 text-surface-600 hover:text-surface-900"
                     title="Download"
                   >
                     <ArrowDownTrayIcon className="w-4 h-4" />
@@ -327,7 +327,7 @@ function StatCard({
   color?: 'surface' | 'yellow' | 'orange' | 'red';
 }) {
   const colorClasses = {
-    surface: 'text-surface-100',
+    surface: 'text-surface-900',
     yellow: 'text-yellow-600',
     orange: 'text-orange-600',
     red: 'text-red-600',
@@ -419,10 +419,10 @@ function UploadModal({
       <div className="fixed inset-0 bg-black/60" onClick={onClose} />
       {/* Modal content - positioned on top */}
       <div className="relative min-h-screen flex items-center justify-center p-4">
-        <div className="relative bg-surface-900 border border-surface-800 rounded-xl w-full max-w-lg p-6 shadow-2xl">
+        <div className="relative bg-white border border-surface-200 rounded-xl w-full max-w-lg p-6 shadow-2xl">
           <div className="flex items-center justify-between mb-6">
-            <h2 className="text-lg font-semibold text-surface-100">Upload Evidence</h2>
-            <button onClick={onClose} className="text-surface-600 hover:text-surface-100">
+            <h2 className="text-lg font-semibold text-surface-900">Upload Evidence</h2>
+            <button onClick={onClose} className="text-surface-600 hover:text-surface-900">
               <XMarkIcon className="w-5 h-5" />
             </button>
           </div>
@@ -446,7 +446,7 @@ function UploadModal({
                   ? 'border-brand-500 bg-brand-500/10 scale-[1.02]'
                   : file
                     ? 'border-green-500 bg-green-500/10'
-                    : 'border-surface-700 hover:border-surface-600'
+                    : 'border-surface-200 hover:border-surface-300'
               )}
             >
               <input {...getInputProps()} />
@@ -461,7 +461,7 @@ function UploadModal({
                       setFile(null);
                       setTitle('');
                     }}
-                    className="ml-2 p-1 hover:bg-surface-700 rounded"
+                    className="ml-2 p-1 hover:bg-surface-200 rounded"
                   >
                     <XMarkIcon className="w-4 h-4 text-surface-600" />
                   </button>

--- a/frontend/src/pages/EvidenceDetail.tsx
+++ b/frontend/src/pages/EvidenceDetail.tsx
@@ -220,18 +220,18 @@ export default function EvidenceDetail() {
       <div>
         <Link
           to="/evidence"
-          className="inline-flex items-center text-sm text-surface-600 hover:text-surface-100 mb-4"
+          className="inline-flex items-center text-sm text-surface-600 hover:text-surface-900 mb-4"
         >
           <ArrowLeftIcon className="w-4 h-4 mr-1" />
           Back to Evidence
         </Link>
         <div className="flex items-start justify-between">
           <div className="flex items-start gap-4">
-            <div className="p-3 bg-surface-800 rounded-lg">
+            <div className="p-3 bg-white rounded-lg">
               <Icon className="w-8 h-8 text-surface-600" />
             </div>
             <div>
-              <h1 className="text-2xl font-bold text-surface-100">{evidence.title}</h1>
+              <h1 className="text-2xl font-bold text-surface-900">{evidence.title}</h1>
               <p className="text-surface-600 mt-1">{evidence.filename}</p>
               <div className="flex items-center gap-3 mt-2">
                 <span className={clsx('', statusConfig.color)}>
@@ -263,9 +263,9 @@ export default function EvidenceDetail() {
         <div className="lg:col-span-2 space-y-6">
           {/* Preview */}
           <div className="card p-6">
-            <h2 className="text-lg font-semibold text-surface-100 mb-4">Preview</h2>
+            <h2 className="text-lg font-semibold text-surface-900 mb-4">Preview</h2>
             {isPreviewable ? (
-              <div className="border border-surface-800 rounded-lg overflow-hidden bg-surface-950">
+              <div className="border border-surface-200 rounded-lg overflow-hidden bg-surface-50">
                 {isImage && (
                   <div className="relative group">
                     <img
@@ -310,7 +310,7 @@ export default function EvidenceDetail() {
           {/* Description */}
           {evidence.description && (
             <div className="card p-6">
-              <h2 className="text-lg font-semibold text-surface-100 mb-4">Description</h2>
+              <h2 className="text-lg font-semibold text-surface-900 mb-4">Description</h2>
               <p className="text-surface-700">{evidence.description}</p>
             </div>
           )}
@@ -318,7 +318,7 @@ export default function EvidenceDetail() {
           {/* Linked Controls */}
           <div className="card p-6">
             <div className="flex items-center justify-between mb-4">
-              <h2 className="text-lg font-semibold text-surface-100">Linked Controls</h2>
+              <h2 className="text-lg font-semibold text-surface-900">Linked Controls</h2>
               <Badge variant="neutral">{evidence.controlLinks?.length || 0} control(s)</Badge>
             </div>
             {(evidence?.controlLinks?.length ?? 0) > 0 ? (
@@ -326,11 +326,11 @@ export default function EvidenceDetail() {
                 {evidence?.controlLinks?.map((link: any) => (
                   <div
                     key={link.id}
-                    className="flex items-center gap-3 p-3 bg-surface-800 rounded-lg group"
+                    className="flex items-center gap-3 p-3 bg-white rounded-lg group"
                   >
                     <Link
                       to={`/controls/${link.control?.id}`}
-                      className="flex items-center gap-3 flex-1 hover:bg-surface-700 -m-3 p-3 rounded-lg transition-colors"
+                      className="flex items-center gap-3 flex-1 hover:bg-surface-200 -m-3 p-3 rounded-lg transition-colors"
                     >
                       <LinkIcon className="w-5 h-5 text-brand-400" />
                       <div className="flex-1">
@@ -363,22 +363,22 @@ export default function EvidenceDetail() {
           {/* Review History */}
           {evidence.reviewedAt && (
             <div className="card p-6">
-              <h2 className="text-lg font-semibold text-surface-100 mb-4">Review</h2>
+              <h2 className="text-lg font-semibold text-surface-900 mb-4">Review</h2>
               <div className="space-y-2">
                 <div className="flex items-center gap-2 text-sm">
                   <UserIcon className="w-4 h-4 text-surface-500" />
                   <span className="text-surface-600">Reviewed by:</span>
-                  <span className="text-surface-200">{evidence.reviewedBy || 'Unknown'}</span>
+                  <span className="text-surface-800">{evidence.reviewedBy || 'Unknown'}</span>
                 </div>
                 <div className="flex items-center gap-2 text-sm">
                   <CalendarIcon className="w-4 h-4 text-surface-500" />
                   <span className="text-surface-600">Reviewed on:</span>
-                  <span className="text-surface-200">
+                  <span className="text-surface-800">
                     {new Date(evidence.reviewedAt).toLocaleDateString()}
                   </span>
                 </div>
                 {evidence.reviewNotes && (
-                  <div className="mt-3 p-3 bg-surface-800 rounded-lg">
+                  <div className="mt-3 p-3 bg-white rounded-lg">
                     <p className="text-sm text-surface-500 mb-1">Notes:</p>
                     <p className="text-sm text-surface-700">{evidence.reviewNotes}</p>
                   </div>
@@ -392,43 +392,43 @@ export default function EvidenceDetail() {
         <div className="space-y-6">
           {/* Details Card */}
           <div className="card p-6">
-            <h3 className="text-sm font-semibold text-surface-100 mb-4">Details</h3>
+            <h3 className="text-sm font-semibold text-surface-900 mb-4">Details</h3>
             <dl className="space-y-3">
               <div>
                 <dt className="text-xs text-surface-500">File Size</dt>
-                <dd className="text-sm text-surface-200 mt-1">{formatFileSize(evidence.size)}</dd>
+                <dd className="text-sm text-surface-800 mt-1">{formatFileSize(evidence.size)}</dd>
               </div>
               <div>
                 <dt className="text-xs text-surface-500">File Type</dt>
-                <dd className="text-sm text-surface-200 mt-1">{evidence.mimeType || 'Unknown'}</dd>
+                <dd className="text-sm text-surface-800 mt-1">{evidence.mimeType || 'Unknown'}</dd>
               </div>
               <div>
                 <dt className="text-xs text-surface-500">Source</dt>
-                <dd className="text-sm text-surface-200 mt-1 capitalize">{evidence.source}</dd>
+                <dd className="text-sm text-surface-800 mt-1 capitalize">{evidence.source}</dd>
               </div>
               <div>
                 <dt className="text-xs text-surface-500">Collected</dt>
-                <dd className="text-sm text-surface-200 mt-1">
+                <dd className="text-sm text-surface-800 mt-1">
                   {evidence.collectedAt ? new Date(evidence.collectedAt).toLocaleDateString() : '—'}
                 </dd>
               </div>
               <div>
                 <dt className="text-xs text-surface-500">Valid From</dt>
-                <dd className="text-sm text-surface-200 mt-1">
+                <dd className="text-sm text-surface-800 mt-1">
                   {evidence.validFrom ? new Date(evidence.validFrom).toLocaleDateString() : '—'}
                 </dd>
               </div>
               {evidence.validUntil && (
                 <div>
                   <dt className="text-xs text-surface-500">Valid Until</dt>
-                  <dd className="text-sm text-surface-200 mt-1">
+                  <dd className="text-sm text-surface-800 mt-1">
                     {new Date(evidence.validUntil).toLocaleDateString()}
                   </dd>
                 </div>
               )}
               <div>
                 <dt className="text-xs text-surface-500">Version</dt>
-                <dd className="text-sm text-surface-200 mt-1">v{evidence.version}</dd>
+                <dd className="text-sm text-surface-800 mt-1">v{evidence.version}</dd>
               </div>
             </dl>
           </div>
@@ -436,7 +436,7 @@ export default function EvidenceDetail() {
           {/* Tags */}
           {(evidence?.tags?.length ?? 0) > 0 && (
             <div className="card p-6">
-              <h3 className="text-sm font-semibold text-surface-100 mb-4">Tags</h3>
+              <h3 className="text-sm font-semibold text-surface-900 mb-4">Tags</h3>
               <div className="flex flex-wrap gap-2">
                 {evidence?.tags?.map((tag: string) => (
                   <Badge key={tag} className="text-xs" variant="neutral">
@@ -450,27 +450,27 @@ export default function EvidenceDetail() {
           {/* Folder */}
           {evidence.folder && (
             <div className="card p-6">
-              <h3 className="text-sm font-semibold text-surface-100 mb-4">Folder</h3>
+              <h3 className="text-sm font-semibold text-surface-900 mb-4">Folder</h3>
               <div className="flex items-center gap-2">
                 <FolderIcon className="w-4 h-4 text-surface-600" />
-                <span className="text-sm text-surface-200">{evidence.folder.name}</span>
+                <span className="text-sm text-surface-800">{evidence.folder.name}</span>
               </div>
             </div>
           )}
 
           {/* Metadata */}
           <div className="card p-6">
-            <h3 className="text-sm font-semibold text-surface-100 mb-4">Audit</h3>
+            <h3 className="text-sm font-semibold text-surface-900 mb-4">Audit</h3>
             <dl className="space-y-3">
               <div>
                 <dt className="text-xs text-surface-500">Created</dt>
-                <dd className="text-sm text-surface-200 mt-1">
+                <dd className="text-sm text-surface-800 mt-1">
                   {new Date(evidence.createdAt).toLocaleString()}
                 </dd>
               </div>
               <div>
                 <dt className="text-xs text-surface-500">Last Updated</dt>
-                <dd className="text-sm text-surface-200 mt-1">
+                <dd className="text-sm text-surface-800 mt-1">
                   {new Date(evidence.updatedAt).toLocaleString()}
                 </dd>
               </div>
@@ -481,7 +481,7 @@ export default function EvidenceDetail() {
       {/* Tabs Section */}
       <div className="card overflow-hidden">
         {/* Tab Navigation */}
-        <div className="border-b border-surface-700 px-4">
+        <div className="border-b border-surface-200 px-4">
           <nav className="flex gap-6" aria-label="Tabs">
             <button
               onClick={() => setActiveTab('details')}
@@ -489,7 +489,7 @@ export default function EvidenceDetail() {
                 'py-3 px-1 border-b-2 font-medium text-sm transition-colors flex items-center gap-2',
                 activeTab === 'details'
                   ? 'border-brand-500 text-brand-400'
-                  : 'border-transparent text-surface-600 hover:text-surface-200 hover:border-surface-600'
+                  : 'border-transparent text-surface-600 hover:text-surface-800 hover:border-surface-300'
               )}
             >
               <DocumentTextIcon className="w-4 h-4" />
@@ -501,7 +501,7 @@ export default function EvidenceDetail() {
                 'py-3 px-1 border-b-2 font-medium text-sm transition-colors flex items-center gap-2',
                 activeTab === 'history'
                   ? 'border-brand-500 text-brand-400'
-                  : 'border-transparent text-surface-600 hover:text-surface-200 hover:border-surface-600'
+                  : 'border-transparent text-surface-600 hover:text-surface-800 hover:border-surface-300'
               )}
             >
               <ClockIcon className="w-4 h-4" />
@@ -514,25 +514,25 @@ export default function EvidenceDetail() {
         <div className="p-6">
           {activeTab === 'details' && (
             <div className="space-y-4">
-              <h3 className="text-lg font-semibold text-surface-100">File Information</h3>
+              <h3 className="text-lg font-semibold text-surface-900">File Information</h3>
               <dl className="grid grid-cols-2 md:grid-cols-4 gap-4">
                 <div>
                   <dt className="text-xs text-surface-500">File Name</dt>
-                  <dd className="text-sm text-surface-200 mt-1">{evidence.filename}</dd>
+                  <dd className="text-sm text-surface-800 mt-1">{evidence.filename}</dd>
                 </div>
                 <div>
                   <dt className="text-xs text-surface-500">File Size</dt>
-                  <dd className="text-sm text-surface-200 mt-1">{formatFileSize(evidence.size)}</dd>
+                  <dd className="text-sm text-surface-800 mt-1">{formatFileSize(evidence.size)}</dd>
                 </div>
                 <div>
                   <dt className="text-xs text-surface-500">MIME Type</dt>
-                  <dd className="text-sm text-surface-200 mt-1">
+                  <dd className="text-sm text-surface-800 mt-1">
                     {evidence.mimeType || 'Unknown'}
                   </dd>
                 </div>
                 <div>
                   <dt className="text-xs text-surface-500">Version</dt>
-                  <dd className="text-sm text-surface-200 mt-1">v{evidence.version}</dd>
+                  <dd className="text-sm text-surface-800 mt-1">v{evidence.version}</dd>
                 </div>
               </dl>
             </div>
@@ -542,7 +542,7 @@ export default function EvidenceDetail() {
       </div>
       {/* Review Modal */}
       <Dialog open={isReviewing} onClose={() => setIsReviewing(false)}>
-        <h2 className="text-lg font-semibold text-surface-100 mb-4">Review Evidence</h2>
+        <h2 className="text-lg font-semibold text-surface-900 mb-4">Review Evidence</h2>
         <div className="space-y-4">
           <div>
             <label className="label">Notes (optional)</label>
@@ -658,7 +658,7 @@ function TextPreview({ evidenceId }: { evidenceId: string }) {
   if (loading) {
     return (
       <div className="flex items-center justify-center py-8">
-        <div className="animate-spin w-6 h-6 border-2 border-surface-700 rounded-full border-t-brand-500"></div>
+        <div className="animate-spin w-6 h-6 border-2 border-surface-200 rounded-full border-t-brand-500"></div>
       </div>
     );
   }
@@ -724,7 +724,7 @@ function ExcelPreview({ evidenceId }: { evidenceId: string }) {
   if (loading) {
     return (
       <div className="flex items-center justify-center py-8">
-        <div className="animate-spin w-6 h-6 border-2 border-surface-700 rounded-full border-t-brand-500"></div>
+        <div className="animate-spin w-6 h-6 border-2 border-surface-200 rounded-full border-t-brand-500"></div>
         <span className="ml-2 text-surface-600">Loading spreadsheet...</span>
       </div>
     );
@@ -744,7 +744,7 @@ function ExcelPreview({ evidenceId }: { evidenceId: string }) {
     <div className="overflow-hidden">
       {/* Sheet tabs */}
       {sheets.length > 1 && (
-        <div className="flex gap-1 p-2 bg-surface-800 border-b border-surface-700 overflow-x-auto">
+        <div className="flex gap-1 p-2 bg-white border-b border-surface-200 overflow-x-auto">
           {sheets.map((sheet, index) => (
             <button
               key={sheet.name}
@@ -753,7 +753,7 @@ function ExcelPreview({ evidenceId }: { evidenceId: string }) {
                 'px-3 py-1 text-sm rounded transition-colors whitespace-nowrap',
                 activeSheet === index
                   ? 'bg-brand-500 text-white'
-                  : 'text-surface-600 hover:text-surface-200 hover:bg-surface-700'
+                  : 'text-surface-600 hover:text-surface-800 hover:bg-surface-200'
               )}
             >
               {sheet.name}
@@ -767,11 +767,11 @@ function ExcelPreview({ evidenceId }: { evidenceId: string }) {
         <table className="w-full text-sm">
           <tbody>
             {currentSheet?.data.slice(0, 100).map((row, rowIndex) => (
-              <tr key={rowIndex} className={rowIndex === 0 ? 'bg-surface-800 font-semibold' : ''}>
+              <tr key={rowIndex} className={rowIndex === 0 ? 'bg-white font-semibold' : ''}>
                 {row.map((cell, cellIndex) => (
                   <td
                     key={cellIndex}
-                    className="px-3 py-2 border border-surface-700 text-surface-700 whitespace-nowrap"
+                    className="px-3 py-2 border border-surface-200 text-surface-700 whitespace-nowrap"
                   >
                     {cell?.toString() || ''}
                   </td>
@@ -851,7 +851,7 @@ function WordPreview({ evidenceId }: { evidenceId: string }) {
   if (loading) {
     return (
       <div className="flex items-center justify-center py-8">
-        <div className="animate-spin w-6 h-6 border-2 border-surface-700 rounded-full border-t-brand-500"></div>
+        <div className="animate-spin w-6 h-6 border-2 border-surface-200 rounded-full border-t-brand-500"></div>
         <span className="ml-2 text-surface-600">Loading document...</span>
       </div>
     );
@@ -868,10 +868,10 @@ function WordPreview({ evidenceId }: { evidenceId: string }) {
   return (
     <div
       className="p-6 prose prose-invert max-w-none overflow-auto max-h-[600px]
-        prose-headings:text-surface-100 prose-p:text-surface-700 
-        prose-strong:text-surface-200 prose-a:text-brand-400
+        prose-headings:text-surface-900 prose-p:text-surface-700 
+        prose-strong:text-surface-800 prose-a:text-brand-400
         prose-ul:text-surface-700 prose-ol:text-surface-700
-        prose-table:border-surface-700 prose-td:border-surface-700 prose-th:border-surface-700"
+        prose-table:border-surface-200 prose-td:border-surface-200 prose-th:border-surface-200"
       dangerouslySetInnerHTML={{ __html: html || '' }}
     />
   );

--- a/frontend/src/pages/FrameworkDetail.tsx
+++ b/frontend/src/pages/FrameworkDetail.tsx
@@ -211,14 +211,14 @@ export default function FrameworkDetail() {
       <div>
         <Link
           to="/frameworks"
-          className="inline-flex items-center text-sm text-surface-600 hover:text-surface-100 mb-4"
+          className="inline-flex items-center text-sm text-surface-600 hover:text-surface-900 mb-4"
         >
           <ArrowLeftIcon className="w-4 h-4 mr-1" />
           Back to Frameworks
         </Link>
         <div className="flex items-start justify-between">
           <div>
-            <h1 className="text-2xl font-bold text-surface-100">{framework.name}</h1>
+            <h1 className="text-2xl font-bold text-surface-900">{framework.name}</h1>
             <p className="text-surface-600 mt-1">{framework.description}</p>
           </div>
           <Badge className="text-sm uppercase" variant="info">
@@ -296,7 +296,7 @@ export default function FrameworkDetail() {
             )}
           </div>
           {statusFilter !== 'all' && (
-            <div className="flex items-center gap-2 text-sm mt-4 pt-4 border-t border-surface-800">
+            <div className="flex items-center gap-2 text-sm mt-4 pt-4 border-t border-surface-200">
               <span className="text-surface-600">Filtering by:</span>
               <span
                 className={clsx(
@@ -316,7 +316,7 @@ export default function FrameworkDetail() {
               </span>
               <button
                 onClick={() => setStatusFilter('all')}
-                className="text-surface-600 hover:text-surface-100 ml-2"
+                className="text-surface-600 hover:text-surface-900 ml-2"
               >
                 <XMarkIcon className="w-4 h-4" />
               </button>
@@ -356,9 +356,9 @@ export default function FrameworkDetail() {
       {/* Requirements Tree */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <div className={clsx('card', selectedReq ? 'lg:col-span-2' : 'lg:col-span-3')}>
-          <div className="p-4 border-b border-surface-800 flex items-center justify-between">
+          <div className="p-4 border-b border-surface-200 flex items-center justify-between">
             <div>
-              <h2 className="text-lg font-semibold text-surface-100">Requirements</h2>
+              <h2 className="text-lg font-semibold text-surface-900">Requirements</h2>
               <p className="text-sm text-surface-600 mt-1">
                 {requirements && requirements.length > 0
                   ? 'Click on any requirement to view details'
@@ -384,7 +384,7 @@ export default function FrameworkDetail() {
               </Button>
             </div>
           </div>
-          <div className="divide-y divide-surface-800 max-h-[600px] overflow-y-auto">
+          <div className="divide-y divide-surface-200 max-h-[600px] overflow-y-auto">
             {requirements && requirements.length > 0 ? (
               requirements.map((req: any) => (
                 <RequirementRow
@@ -426,10 +426,10 @@ export default function FrameworkDetail() {
       {/* Create Requirement Modal */}
       <Dialog open={isCreateModalOpen} onClose={() => setIsCreateModalOpen(false)}>
         <div className="flex items-center justify-between mb-4">
-          <h2 className="text-xl font-bold text-surface-100">Add Requirement</h2>
+          <h2 className="text-xl font-bold text-surface-900">Add Requirement</h2>
           <button
             onClick={() => setIsCreateModalOpen(false)}
-            className="text-surface-600 hover:text-surface-200"
+            className="text-surface-600 hover:text-surface-800"
           >
             <XMarkIcon className="w-6 h-6" />
           </button>
@@ -525,13 +525,13 @@ export default function FrameworkDetail() {
       {/* Bulk Upload Modal */}
       <Dialog open={isUploadModalOpen} onClose={() => setIsUploadModalOpen(false)}>
         <div className="flex items-center justify-between mb-4">
-          <h2 className="text-xl font-bold text-surface-100">Bulk Upload Requirements</h2>
+          <h2 className="text-xl font-bold text-surface-900">Bulk Upload Requirements</h2>
           <button
             onClick={() => {
               setIsUploadModalOpen(false);
               setSelectedFile(null);
             }}
-            className="text-surface-600 hover:text-surface-200"
+            className="text-surface-600 hover:text-surface-800"
           >
             <XMarkIcon className="w-6 h-6" />
           </button>
@@ -539,7 +539,7 @@ export default function FrameworkDetail() {
 
         <div className="space-y-4">
           {/* Instructions */}
-          <div className="p-4 bg-surface-800/50 rounded-lg border border-surface-700">
+          <div className="p-4 bg-white/50 rounded-lg border border-surface-200">
             <p className="text-sm text-surface-700 mb-2">
               Upload a CSV, Excel (.xlsx, .xls), or JSON file with the following columns:
             </p>
@@ -679,7 +679,7 @@ function StatusCard({
         'p-3 rounded-lg text-left transition-all w-full',
         config.bg,
         isActive
-          ? 'ring-2 ring-offset-1 ring-offset-surface-900'
+          ? 'ring-2 ring-offset-1 ring-offset-surface-50'
           : 'hover:opacity-80 cursor-pointer',
         isActive && status === 'compliant' && 'ring-green-400',
         isActive && status === 'partial' && 'ring-yellow-400',
@@ -762,8 +762,8 @@ function RequirementRow({
       <div
         className={clsx(
           'flex items-center gap-3 p-4 transition-colors cursor-pointer',
-          isSelected ? 'bg-brand-500/20 border-l-2 border-brand-500' : 'hover:bg-surface-800/50',
-          directlyMatchesFilter && !isSelected && 'bg-surface-700/30'
+          isSelected ? 'bg-brand-500/20 border-l-2 border-brand-500' : 'hover:bg-white/50',
+          directlyMatchesFilter && !isSelected && 'bg-surface-200/30'
         )}
         style={{ paddingLeft: `${level * 24 + 16}px` }}
         onClick={handleClick}
@@ -793,7 +793,7 @@ function RequirementRow({
         </span>
 
         <div className="flex-1 min-w-0">
-          <p className="text-sm text-surface-100 truncate">{requirement.title}</p>
+          <p className="text-sm text-surface-900 truncate">{requirement.title}</p>
           {!requirement.isCategory && requirement.mappings?.length > 0 && (
             <p className="text-xs text-surface-500 mt-1">
               {requirement.mappings.length} control(s) mapped
@@ -1000,9 +1000,9 @@ function RequirementDetailPanel({
 
   return (
     <div className="card lg:col-span-1 h-fit sticky top-4">
-      <div className="p-4 border-b border-surface-800 flex items-center justify-between">
-        <h3 className="font-semibold text-surface-100">Requirement Details</h3>
-        <button onClick={onClose} className="p-1 hover:bg-surface-700 rounded transition-colors">
+      <div className="p-4 border-b border-surface-200 flex items-center justify-between">
+        <h3 className="font-semibold text-surface-900">Requirement Details</h3>
+        <button onClick={onClose} className="p-1 hover:bg-surface-200 rounded transition-colors">
           <XMarkIcon className="w-5 h-5 text-surface-600" />
         </button>
       </div>
@@ -1012,7 +1012,7 @@ function RequirementDetailPanel({
           <span className="font-mono text-sm text-brand-400 bg-brand-500/10 px-2 py-1 rounded">
             {requirement.reference}
           </span>
-          <h4 className="text-lg font-medium text-surface-100 mt-2">{requirement.title}</h4>
+          <h4 className="text-lg font-medium text-surface-900 mt-2">{requirement.title}</h4>
         </div>
 
         {/* Description */}
@@ -1027,7 +1027,7 @@ function RequirementDetailPanel({
 
         {/* Owner Assignment Section */}
         {!requirement.isCategory && (
-          <div className="border-t border-surface-800 pt-4">
+          <div className="border-t border-surface-200 pt-4">
             <div className="flex items-center justify-between mb-3">
               <p className="text-xs text-surface-500 uppercase tracking-wide">Assignment</p>
               {!isEditing ? (
@@ -1070,7 +1070,7 @@ function RequirementDetailPanel({
                   <SelectNative
                     value={selectedOwner}
                     onChange={(e) => setSelectedOwner(e.target.value)}
-                    className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-sm text-surface-100 focus:outline-none focus:border-brand-500"
+                    className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-sm text-surface-900 focus:outline-none focus:border-brand-500"
                   >
                     <option value="">Unassigned</option>
                     {users?.map((user: any) => (
@@ -1087,7 +1087,7 @@ function RequirementDetailPanel({
                   <SelectNative
                     value={priority}
                     onChange={(e) => setPriority(e.target.value)}
-                    className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-sm text-surface-100 focus:outline-none focus:border-brand-500"
+                    className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-sm text-surface-900 focus:outline-none focus:border-brand-500"
                   >
                     <option value="">Not Set</option>
                     <option value="high">High</option>
@@ -1103,7 +1103,7 @@ function RequirementDetailPanel({
                     type="date"
                     value={dueDate}
                     onChange={(e) => setDueDate(e.target.value)}
-                    className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-sm text-surface-100 focus:outline-none focus:border-brand-500"
+                    className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-sm text-surface-900 focus:outline-none focus:border-brand-500"
                   />
                 </div>
 
@@ -1115,14 +1115,14 @@ function RequirementDetailPanel({
                     onChange={(e) => setOwnerNotes(e.target.value)}
                     rows={3}
                     placeholder="Add notes about this requirement..."
-                    className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-sm text-surface-100 focus:outline-none focus:border-brand-500 resize-none"
+                    className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-sm text-surface-900 focus:outline-none focus:border-brand-500 resize-none"
                   />
                 </div>
               </div>
             ) : (
               <div className="space-y-2">
                 {/* Current Owner */}
-                <div className="flex items-center gap-2 p-2 bg-surface-800/50 rounded-lg">
+                <div className="flex items-center gap-2 p-2 bg-white/50 rounded-lg">
                   <UserIcon className="w-4 h-4 text-surface-500" />
                   <span className="text-sm text-surface-700">
                     {currentOwner?.displayName || 'Unassigned'}
@@ -1131,7 +1131,7 @@ function RequirementDetailPanel({
 
                 {/* Priority */}
                 {currentPriority && (
-                  <div className="flex items-center gap-2 p-2 bg-surface-800/50 rounded-lg">
+                  <div className="flex items-center gap-2 p-2 bg-white/50 rounded-lg">
                     <FlagIcon
                       className={clsx(
                         'w-4 h-4',
@@ -1150,7 +1150,7 @@ function RequirementDetailPanel({
 
                 {/* Due Date */}
                 {currentDueDate && (
-                  <div className="flex items-center gap-2 p-2 bg-surface-800/50 rounded-lg">
+                  <div className="flex items-center gap-2 p-2 bg-white/50 rounded-lg">
                     <CalendarIcon className="w-4 h-4 text-surface-500" />
                     <span className="text-sm text-surface-700">
                       Due: {new Date(currentDueDate).toLocaleDateString()}
@@ -1160,7 +1160,7 @@ function RequirementDetailPanel({
 
                 {/* Notes */}
                 {currentNotes && (
-                  <div className="p-2 bg-surface-800/50 rounded-lg">
+                  <div className="p-2 bg-white/50 rounded-lg">
                     <p className="text-xs text-surface-500 mb-1">Notes</p>
                     <p className="text-sm text-surface-700">{currentNotes}</p>
                   </div>
@@ -1172,7 +1172,7 @@ function RequirementDetailPanel({
 
         {/* Mapped Controls */}
         {!requirement.isCategory && (
-          <div className="border-t border-surface-800 pt-4">
+          <div className="border-t border-surface-200 pt-4">
             <div className="flex items-center justify-between mb-2">
               <p className="text-xs text-surface-500 uppercase tracking-wide">
                 Mapped Controls ({mappings?.length || 0})
@@ -1190,7 +1190,7 @@ function RequirementDetailPanel({
             </div>
             {isLoading ? (
               <div className="flex items-center justify-center py-4">
-                <div className="animate-spin w-5 h-5 border-2 border-surface-700 rounded-full border-t-brand-500"></div>
+                <div className="animate-spin w-5 h-5 border-2 border-surface-200 rounded-full border-t-brand-500"></div>
               </div>
             ) : mappings && mappings.length > 0 ? (
               <div
@@ -1207,7 +1207,7 @@ function RequirementDetailPanel({
                     <div
                       key={mapping.id}
                       role="listitem"
-                      className="group relative bg-surface-800/50 rounded-lg hover:bg-surface-800 transition-colors"
+                      className="group relative bg-white/50 rounded-lg hover:bg-white transition-colors"
                     >
                       <div className="flex items-start gap-2 p-3">
                         <Link
@@ -1219,7 +1219,7 @@ function RequirementDetailPanel({
                             <p className="text-sm font-mono text-brand-400">
                               {mapping.control?.controlId}
                             </p>
-                            <p className="text-sm text-surface-200 truncate">
+                            <p className="text-sm text-surface-800 truncate">
                               {mapping.control?.title}
                             </p>
                             <span
@@ -1249,14 +1249,14 @@ function RequirementDetailPanel({
                                 setOpenMenuId(isMenuOpen ? null : mapping.id);
                                 setPendingDeleteId(null);
                               }}
-                              className="p-1 rounded hover:bg-surface-700 text-surface-600 hover:text-surface-200 opacity-60 group-hover:opacity-100 focus:opacity-100 focus:outline-none focus:ring-1 focus:ring-brand-500 transition-opacity"
+                              className="p-1 rounded hover:bg-surface-200 text-surface-600 hover:text-surface-800 opacity-60 group-hover:opacity-100 focus:opacity-100 focus:outline-none focus:ring-1 focus:ring-brand-500 transition-opacity"
                             >
                               <EllipsisVerticalIcon className="w-4 h-4" />
                             </button>
                             {isMenuOpen && (
                               <div
                                 role="menu"
-                                className="absolute right-0 top-7 z-10 min-w-[10rem] bg-surface-800 border border-surface-700 rounded-lg shadow-lg py-1"
+                                className="absolute right-0 top-7 z-10 min-w-[10rem] bg-white border border-surface-200 rounded-lg shadow-lg py-1"
                               >
                                 {canEditMappings && (
                                   <button
@@ -1268,7 +1268,7 @@ function RequirementDetailPanel({
                                       setOpenMenuId(null);
                                       handleOpenEditMapping(mapping.id);
                                     }}
-                                    className="block w-full text-left px-3 py-1.5 text-sm text-surface-200 hover:bg-surface-700"
+                                    className="block w-full text-left px-3 py-1.5 text-sm text-surface-800 hover:bg-surface-200"
                                   >
                                     Edit
                                   </button>
@@ -1283,7 +1283,7 @@ function RequirementDetailPanel({
                                       setOpenMenuId(null);
                                       handleOpenCopyMapping(mapping);
                                     }}
-                                    className="block w-full text-left px-3 py-1.5 text-sm text-surface-200 hover:bg-surface-700"
+                                    className="block w-full text-left px-3 py-1.5 text-sm text-surface-800 hover:bg-surface-200"
                                   >
                                     Copy to framework…
                                   </button>
@@ -1297,7 +1297,7 @@ function RequirementDetailPanel({
                                     setHistoryDrawerMappingId(mapping.id);
                                     setOpenMenuId(null);
                                   }}
-                                  className="flex items-center gap-2 w-full text-left px-3 py-1.5 text-sm text-surface-200 hover:bg-surface-700"
+                                  className="flex items-center gap-2 w-full text-left px-3 py-1.5 text-sm text-surface-800 hover:bg-surface-200"
                                 >
                                   <ClockIcon className="w-4 h-4" aria-hidden="true" />
                                   History
@@ -1312,7 +1312,7 @@ function RequirementDetailPanel({
                                       setOpenMenuId(null);
                                       setPendingDeleteId(mapping.id);
                                     }}
-                                    className="block w-full text-left px-3 py-1.5 text-sm text-red-600 hover:bg-surface-700"
+                                    className="block w-full text-left px-3 py-1.5 text-sm text-red-600 hover:bg-surface-200"
                                   >
                                     Delete
                                   </button>
@@ -1327,7 +1327,7 @@ function RequirementDetailPanel({
                           <div
                             role="alertdialog"
                             aria-label="Confirm mapping deletion"
-                            className="bg-surface-900/60 border border-red-500/30 rounded-md p-2 text-xs text-surface-200"
+                            className="bg-white/60 border border-red-500/30 rounded-md p-2 text-xs text-surface-800"
                           >
                             <p className="mb-2">Remove this mapping?</p>
                             <div className="flex justify-end gap-2">
@@ -1338,7 +1338,7 @@ function RequirementDetailPanel({
                                   e.stopPropagation();
                                   setPendingDeleteId(null);
                                 }}
-                                className="px-2 py-1 text-surface-700 hover:text-surface-100"
+                                className="px-2 py-1 text-surface-700 hover:text-surface-900"
                                 disabled={deleteMutation.isPending}
                               >
                                 Cancel
@@ -1443,10 +1443,10 @@ function RequirementDetailPanel({
         {/* Comments & Tasks for non-category requirements */}
         {!requirement.isCategory && (
           <>
-            <div className="border-t border-surface-800 pt-4">
+            <div className="border-t border-surface-200 pt-4">
               <CommentsPanel entityType="requirement" entityId={requirement.id} />
             </div>
-            <div className="border-t border-surface-800 pt-4">
+            <div className="border-t border-surface-200 pt-4">
               <TasksPanel entityType="requirement" entityId={requirement.id} />
             </div>
           </>

--- a/frontend/src/pages/FrameworkLibrary.tsx
+++ b/frontend/src/pages/FrameworkLibrary.tsx
@@ -89,7 +89,7 @@ function RequirementTree({
   };
 
   return (
-    <div className={clsx('space-y-1', level > 0 && 'ml-4 border-l border-surface-700 pl-3')}>
+    <div className={clsx('space-y-1', level > 0 && 'ml-4 border-l border-surface-200 pl-3')}>
       {requirements.map((req) => {
         const hasChildren = req.children && req.children.length > 0;
         const isExpanded = expanded.has(req.reference);
@@ -99,15 +99,13 @@ function RequirementTree({
             <div
               className={clsx(
                 'flex items-start gap-2 py-2 px-3 rounded-lg transition-colors',
-                req.isCategory
-                  ? 'bg-surface-800/50 hover:bg-surface-800'
-                  : 'hover:bg-surface-800/30'
+                req.isCategory ? 'bg-white/50 hover:bg-white' : 'hover:bg-white/30'
               )}
             >
               {hasChildren ? (
                 <button
                   onClick={() => toggleExpand(req.reference)}
-                  className="mt-0.5 text-surface-600 hover:text-surface-200"
+                  className="mt-0.5 text-surface-600 hover:text-surface-800"
                 >
                   {isExpanded ? (
                     <ChevronDownIcon className="w-4 h-4" />
@@ -125,7 +123,7 @@ function RequirementTree({
                       'text-xs font-mono px-1.5 py-0.5 rounded',
                       req.isCategory
                         ? 'bg-brand-500/20 text-brand-400'
-                        : 'bg-surface-700 text-surface-700'
+                        : 'bg-surface-200 text-surface-700'
                     )}
                   >
                     {req.reference}
@@ -133,7 +131,7 @@ function RequirementTree({
                   <span
                     className={clsx(
                       'font-medium truncate',
-                      req.isCategory ? 'text-surface-100' : 'text-surface-200'
+                      req.isCategory ? 'text-surface-900' : 'text-surface-800'
                     )}
                   >
                     {req.title}
@@ -166,7 +164,7 @@ function FrameworkPreviewModal({
   return (
     <Dialog open onClose={onClose}>
       {/* Header */}
-      <div className="flex items-center justify-between p-6 border-b border-surface-700">
+      <div className="flex items-center justify-between p-6 border-b border-surface-200">
         <div className="flex items-center gap-4">
           <div
             className={clsx(
@@ -177,7 +175,7 @@ function FrameworkPreviewModal({
             {categoryIcons[framework.category] || categoryIcons.security}
           </div>
           <div>
-            <h2 className="text-xl font-semibold text-surface-100">{framework.name}</h2>
+            <h2 className="text-xl font-semibold text-surface-900">{framework.name}</h2>
             <p className="text-sm text-surface-600">
               {framework.source} • Version {framework.version}
             </p>
@@ -185,7 +183,7 @@ function FrameworkPreviewModal({
         </div>
         <button
           onClick={onClose}
-          className="p-2 text-surface-600 hover:text-surface-200 hover:bg-surface-800 rounded-lg transition-colors"
+          className="p-2 text-surface-600 hover:text-surface-800 hover:bg-white rounded-lg transition-colors"
         >
           <XCircleIcon className="w-6 h-6" />
         </button>
@@ -196,29 +194,29 @@ function FrameworkPreviewModal({
         <div className="mb-6">
           <p className="text-surface-700">{framework.description}</p>
           <div className="flex items-center gap-4 mt-4">
-            <div className="px-3 py-1.5 bg-surface-800 rounded-lg">
+            <div className="px-3 py-1.5 bg-white rounded-lg">
               <span className="text-sm text-surface-600">Requirements:</span>
-              <span className="ml-2 font-semibold text-surface-100">
+              <span className="ml-2 font-semibold text-surface-900">
                 {framework.requirementCount}
               </span>
             </div>
-            <div className="px-3 py-1.5 bg-surface-800 rounded-lg">
+            <div className="px-3 py-1.5 bg-white rounded-lg">
               <span className="text-sm text-surface-600">Categories:</span>
-              <span className="ml-2 font-semibold text-surface-100">{framework.categoryCount}</span>
+              <span className="ml-2 font-semibold text-surface-900">{framework.categoryCount}</span>
             </div>
           </div>
         </div>
 
         <div>
-          <h3 className="text-lg font-medium text-surface-100 mb-4">Requirements Structure</h3>
-          <div className="bg-surface-800/30 rounded-lg p-4 max-h-[400px] overflow-y-auto">
+          <h3 className="text-lg font-medium text-surface-900 mb-4">Requirements Structure</h3>
+          <div className="bg-white/30 rounded-lg p-4 max-h-[400px] overflow-y-auto">
             <RequirementTree requirements={framework.requirements} />
           </div>
         </div>
       </div>
 
       {/* Footer */}
-      <div className="flex items-center justify-end gap-3 p-6 border-t border-surface-700">
+      <div className="flex items-center justify-end gap-3 p-6 border-t border-surface-200">
         <Button variant="secondary" onClick={onClose}>
           Cancel
         </Button>
@@ -250,10 +248,10 @@ function FrameworkCard({
   return (
     <div
       className={clsx(
-        'group bg-surface-800/50 border rounded-xl p-5 transition-all duration-200',
+        'group bg-white/50 border rounded-xl p-5 transition-all duration-200',
         framework.isActivated
           ? 'border-green-500/30 bg-green-500/5'
-          : 'border-surface-700 hover:border-surface-600 hover:bg-surface-800/70'
+          : 'border-surface-200 hover:border-surface-300 hover:bg-white/70'
       )}
     >
       <div className="flex items-start justify-between mb-4">
@@ -273,7 +271,7 @@ function FrameworkCard({
         )}
       </div>
 
-      <h3 className="text-lg font-semibold text-surface-100 mb-1">{framework.name}</h3>
+      <h3 className="text-lg font-semibold text-surface-900 mb-1">{framework.name}</h3>
       <p className="text-sm text-surface-600 mb-4 line-clamp-2">{framework.description}</p>
 
       <div className="flex items-center gap-3 text-sm text-surface-600 mb-4">
@@ -313,7 +311,7 @@ function FrameworkCard({
       </div>
 
       {framework.isActivated && framework.activatedFrameworkId && (
-        <div className="mt-4 pt-4 border-t border-surface-700">
+        <div className="mt-4 pt-4 border-t border-surface-200">
           <Link
             to={`/frameworks/${framework.activatedFrameworkId}`}
             className="text-sm text-brand-400 hover:text-brand-300 transition-colors"
@@ -429,7 +427,7 @@ export default function FrameworkLibrary() {
       <div className="space-y-6 animate-fade-in">
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-2xl font-bold text-surface-100">Framework Library</h1>
+            <h1 className="text-2xl font-bold text-surface-900">Framework Library</h1>
             <p className="text-surface-600 mt-1">
               Browse and activate compliance frameworks for your organization
             </p>
@@ -445,7 +443,7 @@ export default function FrameworkLibrary() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-surface-100">Framework Library</h1>
+          <h1 className="text-2xl font-bold text-surface-900">Framework Library</h1>
           <p className="text-surface-600 mt-1">
             Browse and activate compliance frameworks for your organization
           </p>
@@ -470,7 +468,7 @@ export default function FrameworkLibrary() {
             placeholder="Search frameworks..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full pl-10 pr-4 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 placeholder-surface-500 focus:outline-none focus:ring-2 focus:ring-brand-500/50 focus:border-brand-500"
+            className="w-full pl-10 pr-4 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 placeholder-surface-500 focus:outline-none focus:ring-2 focus:ring-brand-500/50 focus:border-brand-500"
           />
         </div>
 
@@ -479,7 +477,7 @@ export default function FrameworkLibrary() {
           <SelectNative
             value={categoryFilter}
             onChange={(e) => setCategoryFilter(e.target.value)}
-            className="px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:ring-2 focus:ring-brand-500/50"
+            className="px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:ring-2 focus:ring-brand-500/50"
           >
             <option value="all">All Categories</option>
             {categories.map((cat) => (
@@ -495,7 +493,7 @@ export default function FrameworkLibrary() {
             type="checkbox"
             checked={showActivatedOnly}
             onChange={(e) => setShowActivatedOnly(e.target.checked)}
-            className="w-4 h-4 rounded border-surface-600 bg-surface-800 text-brand-500 focus:ring-brand-500/50"
+            className="w-4 h-4 rounded border-surface-300 bg-white text-brand-500 focus:ring-brand-500/50"
           />
           <span className="text-sm text-surface-700">Show activated only</span>
         </label>
@@ -517,9 +515,9 @@ export default function FrameworkLibrary() {
           ))}
         </div>
       ) : (
-        <div className="text-center py-16 bg-surface-800/30 rounded-xl border border-surface-700">
+        <div className="text-center py-16 bg-white/30 rounded-xl border border-surface-200">
           <BookOpenIcon className="w-12 h-12 text-surface-500 mx-auto mb-4" />
-          <h3 className="text-lg font-medium text-surface-200 mb-2">No frameworks found</h3>
+          <h3 className="text-lg font-medium text-surface-800 mb-2">No frameworks found</h3>
           <p className="text-surface-600">
             {searchQuery || categoryFilter !== 'all'
               ? 'Try adjusting your search or filter criteria'

--- a/frontend/src/pages/Frameworks.tsx
+++ b/frontend/src/pages/Frameworks.tsx
@@ -69,7 +69,7 @@ export default function Frameworks() {
       <div className="space-y-6 animate-fade-in">
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-2xl font-bold text-surface-100">Frameworks</h1>
+            <h1 className="text-2xl font-bold text-surface-900">Frameworks</h1>
             <p className="text-surface-600 mt-1">
               Track your compliance readiness across regulatory frameworks
             </p>
@@ -85,7 +85,7 @@ export default function Frameworks() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-surface-100">Frameworks</h1>
+          <h1 className="text-2xl font-bold text-surface-900">Frameworks</h1>
           <p className="text-surface-600 mt-1">
             Track your compliance readiness across regulatory frameworks
           </p>
@@ -111,7 +111,7 @@ export default function Frameworks() {
       ) : (
         <div className="card flex flex-col items-center justify-center py-16">
           <CubeIcon className="w-16 h-16 mb-4 text-surface-500" />
-          <h3 className="text-lg font-medium text-surface-200 mb-2">No frameworks yet</h3>
+          <h3 className="text-lg font-medium text-surface-800 mb-2">No frameworks yet</h3>
           <p className="text-surface-600 text-center mb-6 max-w-md">
             Get started by creating your first compliance framework.
           </p>
@@ -127,10 +127,10 @@ export default function Frameworks() {
       {/* Create Framework Modal */}
       <Dialog open={isCreateModalOpen} onClose={() => setIsCreateModalOpen(false)}>
         <div className="flex items-center justify-between mb-4">
-          <h2 className="text-xl font-bold text-surface-100">Create Framework</h2>
+          <h2 className="text-xl font-bold text-surface-900">Create Framework</h2>
           <button
             onClick={() => setIsCreateModalOpen(false)}
-            className="text-surface-600 hover:text-surface-200"
+            className="text-surface-600 hover:text-surface-800"
           >
             <XMarkIcon className="w-6 h-6" />
           </button>
@@ -203,7 +203,7 @@ export default function Frameworks() {
       {/* Delete Confirmation Modal */}
       {deleteConfirm && (
         <Dialog open onClose={() => setDeleteConfirm(null)}>
-          <h3 className="text-lg font-semibold text-surface-100 mb-2">Delete Framework</h3>
+          <h3 className="text-lg font-semibold text-surface-900 mb-2">Delete Framework</h3>
           <p className="text-surface-600 mb-6">
             Are you sure you want to delete "{deleteConfirm.name}"? This will also delete all
             requirements and mappings associated with this framework. This action cannot be undone.
@@ -247,7 +247,7 @@ function FrameworkCard({
   return (
     <Link
       to={`/frameworks/${framework.id}`}
-      className="card p-6 hover:border-surface-700 transition-colors group relative"
+      className="card p-6 hover:border-surface-200 transition-colors group relative"
     >
       {/* Delete Button */}
       <button
@@ -264,7 +264,7 @@ function FrameworkCard({
             <CubeIcon className="w-6 h-6 text-brand-400" />
           </div>
           <div>
-            <h3 className="font-semibold text-surface-100 group-hover:text-brand-400 transition-colors">
+            <h3 className="font-semibold text-surface-900 group-hover:text-brand-400 transition-colors">
               {framework.name}
             </h3>
             <p className="text-xs text-surface-500">Version {framework.version}</p>
@@ -286,21 +286,21 @@ function FrameworkCard({
         </div>
       </div>
       {/* Stats */}
-      <div className="grid grid-cols-2 gap-4 pt-4 border-t border-surface-800">
+      <div className="grid grid-cols-2 gap-4 pt-4 border-t border-surface-200">
         <div>
           <p className="text-xs text-surface-500">Requirements</p>
-          <p className="text-sm font-medium text-surface-200">{framework.requirementCount || 0}</p>
+          <p className="text-sm font-medium text-surface-800">{framework.requirementCount || 0}</p>
         </div>
         <div>
           <p className="text-xs text-surface-500">Mapped Controls</p>
-          <p className="text-sm font-medium text-surface-200">
+          <p className="text-sm font-medium text-surface-800">
             {framework.mappedControlCount || 0}
           </p>
         </div>
       </div>
       {/* Last Assessment */}
       {framework.lastAssessment && (
-        <div className="mt-4 pt-4 border-t border-surface-800">
+        <div className="mt-4 pt-4 border-t border-surface-200">
           <p className="text-xs text-surface-500">
             Last assessed: {new Date(framework.lastAssessment.createdAt).toLocaleDateString()}
           </p>

--- a/frontend/src/pages/HelpArticle.tsx
+++ b/frontend/src/pages/HelpArticle.tsx
@@ -27,7 +27,7 @@ function TrustCenterCustomDomainArticle() {
   const CopyButton = ({ text, section }: { text: string; section: string }) => (
     <button
       onClick={() => copyToClipboard(text, section)}
-      className="p-1.5 text-surface-600 hover:text-surface-200 hover:bg-surface-700 rounded transition-colors"
+      className="p-1.5 text-surface-600 hover:text-surface-800 hover:bg-surface-200 rounded transition-colors"
       title="Copy to clipboard"
     >
       {copiedSection === section ? (
@@ -42,18 +42,18 @@ function TrustCenterCustomDomainArticle() {
     <article className="prose prose-invert max-w-none">
       {/* Summary */}
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Summary</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Summary</h2>
         <p className="text-surface-700">
           Custom domain URLs allow you to use your own branded domain (like{' '}
-          <code className="bg-surface-800 px-1.5 py-0.5 rounded text-brand-400">
+          <code className="bg-white px-1.5 py-0.5 rounded text-brand-400">
             trust.yourcompany.com
           </code>
           ) instead of the default GigaChad GRC URL when sharing your Trust Center with prospects,
           customers, and partners.
         </p>
 
-        <div className="bg-surface-800/50 border border-surface-700 rounded-lg p-4 mt-4">
-          <h4 className="font-semibold text-surface-200 mb-2">
+        <div className="bg-white/50 border border-surface-200 rounded-lg p-4 mt-4">
+          <h4 className="font-semibold text-surface-800 mb-2">
             Benefits of using a custom domain:
           </h4>
           <ul className="text-surface-600 space-y-1 text-sm list-disc list-inside">
@@ -77,7 +77,7 @@ function TrustCenterCustomDomainArticle() {
 
       {/* Prerequisites */}
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Prerequisites</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Prerequisites</h2>
         <p className="text-surface-700 mb-4">Before setting up a custom domain, ensure you have:</p>
         <ul className="space-y-2">
           {[
@@ -90,10 +90,7 @@ function TrustCenterCustomDomainArticle() {
             { text: 'Trust Center content - Your Trust Center has been configured', done: false },
           ].map((item, i) => (
             <li key={i} className="flex items-start gap-3 text-surface-700">
-              <input
-                type="checkbox"
-                className="mt-1 w-4 h-4 bg-surface-800 border-surface-600 rounded"
-              />
+              <input type="checkbox" className="mt-1 w-4 h-4 bg-white border-surface-300 rounded" />
               <span>{item.text}</span>
             </li>
           ))}
@@ -108,7 +105,7 @@ function TrustCenterCustomDomainArticle() {
 
       {/* Step 1 */}
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">
           Step 1: Enable Your Custom Domain in GigaChad GRC
         </h2>
         <ol className="space-y-3 text-surface-700">
@@ -141,7 +138,7 @@ function TrustCenterCustomDomainArticle() {
             </span>
             <span>
               Enter your desired custom domain (e.g.,{' '}
-              <code className="bg-surface-800 px-1.5 py-0.5 rounded text-brand-400">
+              <code className="bg-white px-1.5 py-0.5 rounded text-brand-400">
                 trust.yourcompany.com
               </code>
               )
@@ -159,16 +156,15 @@ function TrustCenterCustomDomainArticle() {
         <div className="bg-blue-500/10 border border-blue-500/30 rounded-lg p-4 mt-4">
           <p className="text-blue-600 text-sm">
             <strong>Tip:</strong> We recommend using a subdomain like{' '}
-            <code className="bg-surface-800 px-1 rounded">trust</code> or{' '}
-            <code className="bg-surface-800 px-1 rounded">security</code> rather than your root
-            domain.
+            <code className="bg-white px-1 rounded">trust</code> or{' '}
+            <code className="bg-white px-1 rounded">security</code> rather than your root domain.
           </p>
         </div>
       </section>
 
       {/* Step 2 */}
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">
           Step 2: Update Your DNS Records
         </h2>
         <p className="text-surface-700 mb-4">
@@ -176,15 +172,15 @@ function TrustCenterCustomDomainArticle() {
         </p>
 
         {/* DNS Record Table */}
-        <div className="bg-surface-800 rounded-lg overflow-hidden mb-6">
+        <div className="bg-white rounded-lg overflow-hidden mb-6">
           <table className="w-full text-sm">
-            <thead className="bg-surface-700">
+            <thead className="bg-surface-200">
               <tr>
                 <th className="px-4 py-3 text-left text-surface-700 font-medium">Field</th>
                 <th className="px-4 py-3 text-left text-surface-700 font-medium">Value</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-surface-700">
+            <tbody className="divide-y divide-surface-200">
               <tr>
                 <td className="px-4 py-3 text-surface-600">Type</td>
                 <td className="px-4 py-3">
@@ -218,11 +214,11 @@ function TrustCenterCustomDomainArticle() {
 
         {/* DNS Provider Instructions */}
         <div className="space-y-4">
-          <h3 className="text-lg font-semibold text-surface-200">Provider-Specific Instructions</h3>
+          <h3 className="text-lg font-semibold text-surface-800">Provider-Specific Instructions</h3>
 
           {/* Cloudflare */}
-          <details className="bg-surface-800/50 border border-surface-700 rounded-lg">
-            <summary className="px-4 py-3 cursor-pointer text-surface-200 font-medium hover:bg-surface-800 rounded-lg">
+          <details className="bg-white/50 border border-surface-200 rounded-lg">
+            <summary className="px-4 py-3 cursor-pointer text-surface-800 font-medium hover:bg-white rounded-lg">
               Cloudflare
             </summary>
             <div className="px-4 pb-4 text-sm text-surface-600 space-y-2">
@@ -237,7 +233,7 @@ function TrustCenterCustomDomainArticle() {
                 </li>
                 <li>
                   Set Type to CNAME, Name to your subdomain, Target to{' '}
-                  <code className="bg-surface-800 px-1 rounded text-brand-400">
+                  <code className="bg-white px-1 rounded text-brand-400">
                     trust.gigachad-grc.com
                   </code>
                 </li>
@@ -258,8 +254,8 @@ function TrustCenterCustomDomainArticle() {
           </details>
 
           {/* GoDaddy */}
-          <details className="bg-surface-800/50 border border-surface-700 rounded-lg">
-            <summary className="px-4 py-3 cursor-pointer text-surface-200 font-medium hover:bg-surface-800 rounded-lg">
+          <details className="bg-white/50 border border-surface-200 rounded-lg">
+            <summary className="px-4 py-3 cursor-pointer text-surface-800 font-medium hover:bg-white rounded-lg">
               GoDaddy
             </summary>
             <div className="px-4 pb-4 text-sm text-surface-600 space-y-2">
@@ -276,7 +272,7 @@ function TrustCenterCustomDomainArticle() {
                 </li>
                 <li>
                   Set Type to CNAME, Name to your subdomain, Value to{' '}
-                  <code className="bg-surface-800 px-1 rounded text-brand-400">
+                  <code className="bg-white px-1 rounded text-brand-400">
                     trust.gigachad-grc.com
                   </code>
                 </li>
@@ -289,8 +285,8 @@ function TrustCenterCustomDomainArticle() {
           </details>
 
           {/* Route 53 */}
-          <details className="bg-surface-800/50 border border-surface-700 rounded-lg">
-            <summary className="px-4 py-3 cursor-pointer text-surface-200 font-medium hover:bg-surface-800 rounded-lg">
+          <details className="bg-white/50 border border-surface-200 rounded-lg">
+            <summary className="px-4 py-3 cursor-pointer text-surface-800 font-medium hover:bg-white rounded-lg">
               Amazon Route 53
             </summary>
             <div className="px-4 pb-4 text-sm text-surface-600 space-y-2">
@@ -305,7 +301,7 @@ function TrustCenterCustomDomainArticle() {
                 </li>
                 <li>
                   Enter your subdomain, select CNAME, enter{' '}
-                  <code className="bg-surface-800 px-1 rounded text-brand-400">
+                  <code className="bg-white px-1 rounded text-brand-400">
                     trust.gigachad-grc.com
                   </code>
                 </li>
@@ -318,8 +314,8 @@ function TrustCenterCustomDomainArticle() {
           </details>
 
           {/* Namecheap */}
-          <details className="bg-surface-800/50 border border-surface-700 rounded-lg">
-            <summary className="px-4 py-3 cursor-pointer text-surface-200 font-medium hover:bg-surface-800 rounded-lg">
+          <details className="bg-white/50 border border-surface-200 rounded-lg">
+            <summary className="px-4 py-3 cursor-pointer text-surface-800 font-medium hover:bg-white rounded-lg">
               Namecheap
             </summary>
             <div className="px-4 pb-4 text-sm text-surface-600 space-y-2">
@@ -336,7 +332,7 @@ function TrustCenterCustomDomainArticle() {
                 </li>
                 <li>
                   Select CNAME, enter your subdomain, value{' '}
-                  <code className="bg-surface-800 px-1 rounded text-brand-400">
+                  <code className="bg-white px-1 rounded text-brand-400">
                     trust.gigachad-grc.com
                   </code>
                 </li>
@@ -346,8 +342,8 @@ function TrustCenterCustomDomainArticle() {
           </details>
 
           {/* Google Domains */}
-          <details className="bg-surface-800/50 border border-surface-700 rounded-lg">
-            <summary className="px-4 py-3 cursor-pointer text-surface-200 font-medium hover:bg-surface-800 rounded-lg">
+          <details className="bg-white/50 border border-surface-200 rounded-lg">
+            <summary className="px-4 py-3 cursor-pointer text-surface-800 font-medium hover:bg-white rounded-lg">
               Google Domains / Squarespace
             </summary>
             <div className="px-4 pb-4 text-sm text-surface-600 space-y-2">
@@ -362,7 +358,7 @@ function TrustCenterCustomDomainArticle() {
                 </li>
                 <li>
                   Add CNAME record with your subdomain pointing to{' '}
-                  <code className="bg-surface-800 px-1 rounded text-brand-400">
+                  <code className="bg-white px-1 rounded text-brand-400">
                     trust.gigachad-grc.com
                   </code>
                 </li>
@@ -377,7 +373,7 @@ function TrustCenterCustomDomainArticle() {
 
       {/* Step 3 */}
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">
           Step 3: Verify Your Configuration
         </h2>
         <p className="text-surface-700 mb-4">
@@ -385,7 +381,7 @@ function TrustCenterCustomDomainArticle() {
           30 minutes).
         </p>
 
-        <h3 className="text-lg font-semibold text-surface-200 mb-3">
+        <h3 className="text-lg font-semibold text-surface-800 mb-3">
           How to Check DNS Propagation
         </h3>
         <ul className="space-y-3 text-surface-700 mb-4">
@@ -408,7 +404,7 @@ function TrustCenterCustomDomainArticle() {
             <span className="text-brand-400">•</span>
             <span>
               Or run from terminal:{' '}
-              <code className="bg-surface-800 px-2 py-0.5 rounded text-brand-400">
+              <code className="bg-white px-2 py-0.5 rounded text-brand-400">
                 dig trust.yourcompany.com CNAME
               </code>
             </span>
@@ -418,7 +414,7 @@ function TrustCenterCustomDomainArticle() {
 
       {/* SSL */}
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">SSL Certificate</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">SSL Certificate</h2>
         <p className="text-surface-700 mb-4">
           GigaChad GRC automatically provisions a free SSL/TLS certificate for your custom domain
           using Let's Encrypt.
@@ -441,7 +437,7 @@ function TrustCenterCustomDomainArticle() {
 
       {/* FAQ */}
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">FAQ</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">FAQ</h2>
         <div className="space-y-4">
           {[
             {
@@ -461,8 +457,8 @@ function TrustCenterCustomDomainArticle() {
               a: 'Contact your IT administrator with the CNAME record details: Type=CNAME, Host=trust, Value=trust.gigachad-grc.com',
             },
           ].map((faq, i) => (
-            <details key={i} className="bg-surface-800/50 border border-surface-700 rounded-lg">
-              <summary className="px-4 py-3 cursor-pointer text-surface-200 font-medium hover:bg-surface-800 rounded-lg">
+            <details key={i} className="bg-white/50 border border-surface-200 rounded-lg">
+              <summary className="px-4 py-3 cursor-pointer text-surface-800 font-medium hover:bg-white rounded-lg">
                 {faq.q}
               </summary>
               <div className="px-4 pb-4 text-sm text-surface-600">{faq.a}</div>
@@ -472,23 +468,23 @@ function TrustCenterCustomDomainArticle() {
       </section>
 
       {/* Related */}
-      <section className="border-t border-surface-800 pt-8">
-        <h3 className="text-lg font-semibold text-surface-200 mb-4">Related Articles</h3>
+      <section className="border-t border-surface-200 pt-8">
+        <h3 className="text-lg font-semibold text-surface-800 mb-4">Related Articles</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <Link
             to="/trust-center/settings"
-            className="flex items-center gap-3 p-4 bg-surface-800/50 border border-surface-700 rounded-lg hover:bg-surface-800 transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
           >
             <GlobeAltIcon className="w-5 h-5 text-surface-600" />
-            <span className="text-surface-200">Trust Center Settings</span>
+            <span className="text-surface-800">Trust Center Settings</span>
             <ChevronRightIcon className="w-4 h-4 text-surface-500 ml-auto" />
           </Link>
           <Link
             to="/trust-center"
-            className="flex items-center gap-3 p-4 bg-surface-800/50 border border-surface-700 rounded-lg hover:bg-surface-800 transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
           >
             <GlobeAltIcon className="w-5 h-5 text-surface-600" />
-            <span className="text-surface-200">Manage Trust Center Content</span>
+            <span className="text-surface-800">Manage Trust Center Content</span>
             <ChevronRightIcon className="w-4 h-4 text-surface-500 ml-auto" />
           </Link>
         </div>
@@ -502,7 +498,7 @@ function TrustCenterGettingStartedArticle() {
   return (
     <article className="prose prose-invert max-w-none">
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Overview</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Overview</h2>
         <p className="text-surface-700">
           Your Trust Center is a public-facing security portal that showcases your organization's
           security posture, compliance certifications, and security documentation to prospects,
@@ -510,8 +506,8 @@ function TrustCenterGettingStartedArticle() {
           need for repetitive security questionnaires.
         </p>
 
-        <div className="bg-surface-800/50 border border-surface-700 rounded-lg p-4 mt-4">
-          <h4 className="font-semibold text-surface-200 mb-2">What you can showcase:</h4>
+        <div className="bg-white/50 border border-surface-200 rounded-lg p-4 mt-4">
+          <h4 className="font-semibold text-surface-800 mb-2">What you can showcase:</h4>
           <ul className="text-surface-600 space-y-1 text-sm list-disc list-inside">
             <li>
               <strong>Compliance certifications</strong> - SOC 2, ISO 27001, HIPAA, GDPR badges
@@ -533,7 +529,7 @@ function TrustCenterGettingStartedArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">
           Step 1: Enable Your Trust Center
         </h2>
         <ol className="space-y-3 text-surface-700">
@@ -574,7 +570,7 @@ function TrustCenterGettingStartedArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Step 2: Configure Branding</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Step 2: Configure Branding</h2>
         <p className="text-surface-700 mb-4">Make your Trust Center match your brand identity:</p>
         <ol className="space-y-3 text-surface-700">
           <li className="flex gap-3">
@@ -621,47 +617,47 @@ function TrustCenterGettingStartedArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">
           Step 3: Choose Content Sections
         </h2>
         <p className="text-surface-700 mb-4">
           Select which sections to display on your Trust Center:
         </p>
-        <div className="bg-surface-800 rounded-lg overflow-hidden mb-4">
+        <div className="bg-white rounded-lg overflow-hidden mb-4">
           <table className="w-full text-sm">
-            <thead className="bg-surface-700">
+            <thead className="bg-surface-200">
               <tr>
                 <th className="px-4 py-3 text-left text-surface-700 font-medium">Section</th>
                 <th className="px-4 py-3 text-left text-surface-700 font-medium">Description</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-surface-700">
+            <tbody className="divide-y divide-surface-200">
               <tr>
-                <td className="px-4 py-3 text-surface-200 font-medium">Certifications</td>
+                <td className="px-4 py-3 text-surface-800 font-medium">Certifications</td>
                 <td className="px-4 py-3 text-surface-600">
                   Display compliance badges (SOC 2, ISO 27001, etc.)
                 </td>
               </tr>
               <tr>
-                <td className="px-4 py-3 text-surface-200 font-medium">Policies</td>
+                <td className="px-4 py-3 text-surface-800 font-medium">Policies</td>
                 <td className="px-4 py-3 text-surface-600">
                   Share security and privacy policy documents
                 </td>
               </tr>
               <tr>
-                <td className="px-4 py-3 text-surface-200 font-medium">Security Features</td>
+                <td className="px-4 py-3 text-surface-800 font-medium">Security Features</td>
                 <td className="px-4 py-3 text-surface-600">
                   Highlight encryption, access controls, monitoring
                 </td>
               </tr>
               <tr>
-                <td className="px-4 py-3 text-surface-200 font-medium">Privacy</td>
+                <td className="px-4 py-3 text-surface-800 font-medium">Privacy</td>
                 <td className="px-4 py-3 text-surface-600">
                   Data handling, retention, and privacy practices
                 </td>
               </tr>
               <tr>
-                <td className="px-4 py-3 text-surface-200 font-medium">Incident Response</td>
+                <td className="px-4 py-3 text-surface-800 font-medium">Incident Response</td>
                 <td className="px-4 py-3 text-surface-600">
                   Your incident response procedures and contacts
                 </td>
@@ -672,7 +668,7 @@ function TrustCenterGettingStartedArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Step 4: Add Content</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Step 4: Add Content</h2>
         <ol className="space-y-3 text-surface-700">
           <li className="flex gap-3">
             <span className="flex-shrink-0 w-6 h-6 bg-brand-600 text-white rounded-full flex items-center justify-center text-sm font-bold">
@@ -714,7 +710,7 @@ function TrustCenterGettingStartedArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">
           Step 5: Share Your Trust Center
         </h2>
         <p className="text-surface-700 mb-4">
@@ -748,23 +744,23 @@ function TrustCenterGettingStartedArticle() {
         </ul>
       </section>
 
-      <section className="border-t border-surface-800 pt-8">
-        <h3 className="text-lg font-semibold text-surface-200 mb-4">Related Articles</h3>
+      <section className="border-t border-surface-200 pt-8">
+        <h3 className="text-lg font-semibold text-surface-800 mb-4">Related Articles</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <Link
             to="/help/trust-center/custom-domain"
-            className="flex items-center gap-3 p-4 bg-surface-800/50 border border-surface-700 rounded-lg hover:bg-surface-800 transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
           >
             <GlobeAltIcon className="w-5 h-5 text-surface-600" />
-            <span className="text-surface-200">Set Up a Custom URL</span>
+            <span className="text-surface-800">Set Up a Custom URL</span>
             <ChevronRightIcon className="w-4 h-4 text-surface-500 ml-auto" />
           </Link>
           <Link
             to="/trust-center/settings"
-            className="flex items-center gap-3 p-4 bg-surface-800/50 border border-surface-700 rounded-lg hover:bg-surface-800 transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
           >
             <GlobeAltIcon className="w-5 h-5 text-surface-600" />
-            <span className="text-surface-200">Trust Center Settings</span>
+            <span className="text-surface-800">Trust Center Settings</span>
             <ChevronRightIcon className="w-4 h-4 text-surface-500 ml-auto" />
           </Link>
         </div>
@@ -778,7 +774,7 @@ function IntegrationsOverviewArticle() {
   return (
     <article className="prose prose-invert max-w-none">
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Overview</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Overview</h2>
         <p className="text-surface-700">
           Integrations connect GigaChad GRC to your existing tools and systems to automate evidence
           collection, sync compliance data, and streamline your security workflows. Instead of
@@ -786,8 +782,8 @@ function IntegrationsOverviewArticle() {
           systems.
         </p>
 
-        <div className="bg-surface-800/50 border border-surface-700 rounded-lg p-4 mt-4">
-          <h4 className="font-semibold text-surface-200 mb-2">Integration categories:</h4>
+        <div className="bg-white/50 border border-surface-200 rounded-lg p-4 mt-4">
+          <h4 className="font-semibold text-surface-800 mb-2">Integration categories:</h4>
           <ul className="text-surface-600 space-y-1 text-sm list-disc list-inside">
             <li>
               <strong>Cloud Providers</strong> - AWS, Azure, GCP configuration evidence
@@ -812,7 +808,7 @@ function IntegrationsOverviewArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">
           Step 1: Browse Available Integrations
         </h2>
         <ol className="space-y-3 text-surface-700">
@@ -840,7 +836,7 @@ function IntegrationsOverviewArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">
           Step 2: Configure an Integration
         </h2>
         <p className="text-surface-700 mb-4">
@@ -848,8 +844,8 @@ function IntegrationsOverviewArticle() {
         </p>
 
         <div className="space-y-4">
-          <div className="bg-surface-800/50 border border-surface-700 rounded-lg p-4">
-            <h4 className="font-semibold text-surface-200 mb-2">Quick Setup (No-Code)</h4>
+          <div className="bg-white/50 border border-surface-200 rounded-lg p-4">
+            <h4 className="font-semibold text-surface-800 mb-2">Quick Setup (No-Code)</h4>
             <p className="text-surface-600 text-sm mb-2">
               Best for standard integrations. Enter your credentials and select what data to
               collect.
@@ -862,8 +858,8 @@ function IntegrationsOverviewArticle() {
             </ul>
           </div>
 
-          <div className="bg-surface-800/50 border border-surface-700 rounded-lg p-4">
-            <h4 className="font-semibold text-surface-200 mb-2">Advanced Builder (Low-Code)</h4>
+          <div className="bg-white/50 border border-surface-200 rounded-lg p-4">
+            <h4 className="font-semibold text-surface-800 mb-2">Advanced Builder (Low-Code)</h4>
             <p className="text-surface-600 text-sm mb-2">
               For custom configurations. Build API calls visually with response mapping.
             </p>
@@ -875,8 +871,8 @@ function IntegrationsOverviewArticle() {
             </ul>
           </div>
 
-          <div className="bg-surface-800/50 border border-surface-700 rounded-lg p-4">
-            <h4 className="font-semibold text-surface-200 mb-2">Raw API (Code)</h4>
+          <div className="bg-white/50 border border-surface-200 rounded-lg p-4">
+            <h4 className="font-semibold text-surface-800 mb-2">Raw API (Code)</h4>
             <p className="text-surface-600 text-sm mb-2">
               For engineers. Write custom API calls or JavaScript code directly.
             </p>
@@ -890,45 +886,45 @@ function IntegrationsOverviewArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">
           Step 3: Select Evidence to Collect
         </h2>
         <p className="text-surface-700 mb-4">
           Each integration can collect different types of evidence. Common evidence types include:
         </p>
-        <div className="bg-surface-800 rounded-lg overflow-hidden mb-4">
+        <div className="bg-white rounded-lg overflow-hidden mb-4">
           <table className="w-full text-sm">
-            <thead className="bg-surface-700">
+            <thead className="bg-surface-200">
               <tr>
                 <th className="px-4 py-3 text-left text-surface-700 font-medium">Evidence Type</th>
                 <th className="px-4 py-3 text-left text-surface-700 font-medium">Example</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-surface-700">
+            <tbody className="divide-y divide-surface-200">
               <tr>
-                <td className="px-4 py-3 text-surface-200">User Lists</td>
+                <td className="px-4 py-3 text-surface-800">User Lists</td>
                 <td className="px-4 py-3 text-surface-600">
                   Active users, roles, last login dates
                 </td>
               </tr>
               <tr>
-                <td className="px-4 py-3 text-surface-200">Access Reviews</td>
+                <td className="px-4 py-3 text-surface-800">Access Reviews</td>
                 <td className="px-4 py-3 text-surface-600">
                   Permission assignments, group memberships
                 </td>
               </tr>
               <tr>
-                <td className="px-4 py-3 text-surface-200">Security Configs</td>
+                <td className="px-4 py-3 text-surface-800">Security Configs</td>
                 <td className="px-4 py-3 text-surface-600">
                   MFA settings, password policies, encryption
                 </td>
               </tr>
               <tr>
-                <td className="px-4 py-3 text-surface-200">Audit Logs</td>
+                <td className="px-4 py-3 text-surface-800">Audit Logs</td>
                 <td className="px-4 py-3 text-surface-600">Login events, configuration changes</td>
               </tr>
               <tr>
-                <td className="px-4 py-3 text-surface-200">Vulnerability Scans</td>
+                <td className="px-4 py-3 text-surface-800">Vulnerability Scans</td>
                 <td className="px-4 py-3 text-surface-600">Scan results, remediation status</td>
               </tr>
             </tbody>
@@ -943,7 +939,7 @@ function IntegrationsOverviewArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Step 4: Test and Monitor</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Step 4: Test and Monitor</h2>
         <ol className="space-y-3 text-surface-700">
           <li className="flex gap-3">
             <span className="flex-shrink-0 w-6 h-6 bg-brand-600 text-white rounded-full flex items-center justify-center text-sm font-bold">
@@ -979,7 +975,7 @@ function IntegrationsOverviewArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Security & Credentials</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Security & Credentials</h2>
         <p className="text-surface-700 mb-4">Your integration credentials are protected:</p>
         <ul className="space-y-2 text-surface-700">
           <li className="flex gap-3">
@@ -1001,23 +997,23 @@ function IntegrationsOverviewArticle() {
         </ul>
       </section>
 
-      <section className="border-t border-surface-800 pt-8">
-        <h3 className="text-lg font-semibold text-surface-200 mb-4">Related Articles</h3>
+      <section className="border-t border-surface-200 pt-8">
+        <h3 className="text-lg font-semibold text-surface-800 mb-4">Related Articles</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <Link
             to="/integrations"
-            className="flex items-center gap-3 p-4 bg-surface-800/50 border border-surface-700 rounded-lg hover:bg-surface-800 transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
           >
             <LinkIcon className="w-5 h-5 text-surface-600" />
-            <span className="text-surface-200">Browse Integrations</span>
+            <span className="text-surface-800">Browse Integrations</span>
             <ChevronRightIcon className="w-4 h-4 text-surface-500 ml-auto" />
           </Link>
           <Link
             to="/evidence"
-            className="flex items-center gap-3 p-4 bg-surface-800/50 border border-surface-700 rounded-lg hover:bg-surface-800 transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
           >
             <ClipboardDocumentIcon className="w-5 h-5 text-surface-600" />
-            <span className="text-surface-200">View Evidence</span>
+            <span className="text-surface-800">View Evidence</span>
             <ChevronRightIcon className="w-4 h-4 text-surface-500 ml-auto" />
           </Link>
         </div>
@@ -1031,7 +1027,7 @@ function ComplianceFrameworksArticle() {
   return (
     <article className="prose prose-invert max-w-none">
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Overview</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Overview</h2>
         <p className="text-surface-700">
           Compliance frameworks in GigaChad GRC help you track and manage your organization's
           adherence to security standards and regulations. Whether you're pursuing SOC 2, ISO 27001,
@@ -1039,8 +1035,8 @@ function ComplianceFrameworksArticle() {
           requirements.
         </p>
 
-        <div className="bg-surface-800/50 border border-surface-700 rounded-lg p-4 mt-4">
-          <h4 className="font-semibold text-surface-200 mb-2">Supported frameworks include:</h4>
+        <div className="bg-white/50 border border-surface-200 rounded-lg p-4 mt-4">
+          <h4 className="font-semibold text-surface-800 mb-2">Supported frameworks include:</h4>
           <div className="grid grid-cols-2 md:grid-cols-3 gap-2 text-surface-600 text-sm">
             <span>• SOC 2 Type I & II</span>
             <span>• ISO 27001:2022</span>
@@ -1059,7 +1055,7 @@ function ComplianceFrameworksArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Step 1: Add a Framework</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Step 1: Add a Framework</h2>
         <ol className="space-y-3 text-surface-700">
           <li className="flex gap-3">
             <span className="flex-shrink-0 w-6 h-6 bg-brand-600 text-white rounded-full flex items-center justify-center text-sm font-bold">
@@ -1100,7 +1096,7 @@ function ComplianceFrameworksArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">
           Step 2: Map Controls to Requirements
         </h2>
         <p className="text-surface-700 mb-4">
@@ -1130,8 +1126,8 @@ function ComplianceFrameworksArticle() {
           </li>
         </ol>
 
-        <div className="bg-surface-800/50 border border-surface-700 rounded-lg p-4 mt-4">
-          <h4 className="font-semibold text-surface-200 mb-2">Control mapping example:</h4>
+        <div className="bg-white/50 border border-surface-200 rounded-lg p-4 mt-4">
+          <h4 className="font-semibold text-surface-800 mb-2">Control mapping example:</h4>
           <p className="text-surface-600 text-sm">
             A "Multi-Factor Authentication" control might satisfy:
           </p>
@@ -1144,21 +1140,21 @@ function ComplianceFrameworksArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">
           Step 3: Track Compliance Status
         </h2>
         <p className="text-surface-700 mb-4">
           Monitor your compliance posture with real-time dashboards:
         </p>
-        <div className="bg-surface-800 rounded-lg overflow-hidden mb-4">
+        <div className="bg-white rounded-lg overflow-hidden mb-4">
           <table className="w-full text-sm">
-            <thead className="bg-surface-700">
+            <thead className="bg-surface-200">
               <tr>
                 <th className="px-4 py-3 text-left text-surface-700 font-medium">Status</th>
                 <th className="px-4 py-3 text-left text-surface-700 font-medium">Meaning</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-surface-700">
+            <tbody className="divide-y divide-surface-200">
               <tr>
                 <td className="px-4 py-3">
                   <span className="px-2 py-1 bg-green-500/20 text-green-600 rounded text-xs">
@@ -1205,7 +1201,7 @@ function ComplianceFrameworksArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Step 4: Prepare for Audits</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Step 4: Prepare for Audits</h2>
         <p className="text-surface-700 mb-4">When audit time comes, GigaChad GRC helps you:</p>
         <ul className="space-y-3 text-surface-700">
           <li className="flex gap-3">
@@ -1235,23 +1231,23 @@ function ComplianceFrameworksArticle() {
         </ul>
       </section>
 
-      <section className="border-t border-surface-800 pt-8">
-        <h3 className="text-lg font-semibold text-surface-200 mb-4">Related Articles</h3>
+      <section className="border-t border-surface-200 pt-8">
+        <h3 className="text-lg font-semibold text-surface-800 mb-4">Related Articles</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <Link
             to="/frameworks"
-            className="flex items-center gap-3 p-4 bg-surface-800/50 border border-surface-700 rounded-lg hover:bg-surface-800 transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
           >
             <ShieldCheckIcon className="w-5 h-5 text-surface-600" />
-            <span className="text-surface-200">View Frameworks</span>
+            <span className="text-surface-800">View Frameworks</span>
             <ChevronRightIcon className="w-4 h-4 text-surface-500 ml-auto" />
           </Link>
           <Link
             to="/controls"
-            className="flex items-center gap-3 p-4 bg-surface-800/50 border border-surface-700 rounded-lg hover:bg-surface-800 transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
           >
             <ShieldCheckIcon className="w-5 h-5 text-surface-600" />
-            <span className="text-surface-200">Manage Controls</span>
+            <span className="text-surface-800">Manage Controls</span>
             <ChevronRightIcon className="w-4 h-4 text-surface-500 ml-auto" />
           </Link>
         </div>
@@ -1265,7 +1261,7 @@ function VendorManagementArticle() {
   return (
     <article className="prose prose-invert max-w-none">
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Overview</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Overview</h2>
         <p className="text-surface-700">
           Third-Party Risk Management (TPRM) helps you assess, monitor, and manage the security
           risks introduced by your vendors, suppliers, and service providers. A single vendor breach
@@ -1273,8 +1269,8 @@ function VendorManagementArticle() {
           security program.
         </p>
 
-        <div className="bg-surface-800/50 border border-surface-700 rounded-lg p-4 mt-4">
-          <h4 className="font-semibold text-surface-200 mb-2">Key TPRM capabilities:</h4>
+        <div className="bg-white/50 border border-surface-200 rounded-lg p-4 mt-4">
+          <h4 className="font-semibold text-surface-800 mb-2">Key TPRM capabilities:</h4>
           <ul className="text-surface-600 space-y-1 text-sm list-disc list-inside">
             <li>
               <strong>Vendor inventory</strong> - Centralized database of all third parties
@@ -1296,7 +1292,7 @@ function VendorManagementArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">
           Step 1: Add Vendors to Your Inventory
         </h2>
         <ol className="space-y-3 text-surface-700">
@@ -1338,13 +1334,13 @@ function VendorManagementArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Step 2: Classify Vendor Risk</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Step 2: Classify Vendor Risk</h2>
         <p className="text-surface-700 mb-4">
           Determine the appropriate level of due diligence based on data access and business impact:
         </p>
-        <div className="bg-surface-800 rounded-lg overflow-hidden mb-4">
+        <div className="bg-white rounded-lg overflow-hidden mb-4">
           <table className="w-full text-sm">
-            <thead className="bg-surface-700">
+            <thead className="bg-surface-200">
               <tr>
                 <th className="px-4 py-3 text-left text-surface-700 font-medium">Risk Tier</th>
                 <th className="px-4 py-3 text-left text-surface-700 font-medium">Criteria</th>
@@ -1353,7 +1349,7 @@ function VendorManagementArticle() {
                 </th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-surface-700">
+            <tbody className="divide-y divide-surface-200">
               <tr>
                 <td className="px-4 py-3">
                   <span className="px-2 py-1 bg-red-500/20 text-red-600 rounded text-xs">
@@ -1402,7 +1398,7 @@ function VendorManagementArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">
           Step 3: Conduct Risk Assessments
         </h2>
         <ol className="space-y-3 text-surface-700">
@@ -1448,7 +1444,7 @@ function VendorManagementArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">
           Step 4: Track Contracts and Renewals
         </h2>
         <p className="text-surface-700 mb-4">Link contracts to vendors for complete visibility:</p>
@@ -1473,7 +1469,7 @@ function VendorManagementArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Step 5: Monitor Ongoing Risk</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Step 5: Monitor Ongoing Risk</h2>
         <p className="text-surface-700 mb-4">Vendor risk doesn't stop after initial assessment:</p>
         <ul className="space-y-2 text-surface-700">
           <li className="flex gap-3">
@@ -1495,23 +1491,23 @@ function VendorManagementArticle() {
         </ul>
       </section>
 
-      <section className="border-t border-surface-800 pt-8">
-        <h3 className="text-lg font-semibold text-surface-200 mb-4">Related Articles</h3>
+      <section className="border-t border-surface-200 pt-8">
+        <h3 className="text-lg font-semibold text-surface-800 mb-4">Related Articles</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <Link
             to="/vendors"
-            className="flex items-center gap-3 p-4 bg-surface-800/50 border border-surface-700 rounded-lg hover:bg-surface-800 transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
           >
             <BuildingOfficeIcon className="w-5 h-5 text-surface-600" />
-            <span className="text-surface-200">Manage Vendors</span>
+            <span className="text-surface-800">Manage Vendors</span>
             <ChevronRightIcon className="w-4 h-4 text-surface-500 ml-auto" />
           </Link>
           <Link
             to="/contracts"
-            className="flex items-center gap-3 p-4 bg-surface-800/50 border border-surface-700 rounded-lg hover:bg-surface-800 transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
           >
             <ClipboardDocumentIcon className="w-5 h-5 text-surface-600" />
-            <span className="text-surface-200">View Contracts</span>
+            <span className="text-surface-800">View Contracts</span>
             <ChevronRightIcon className="w-4 h-4 text-surface-500 ml-auto" />
           </Link>
         </div>
@@ -1525,15 +1521,15 @@ function AuditManagementArticle() {
   return (
     <article className="prose prose-invert max-w-none">
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Overview</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Overview</h2>
         <p className="text-surface-700">
           The Audit module helps you manage internal and external audits from planning through
           remediation. Track evidence requests, coordinate with auditors, document findings, and
           ensure timely remediation of identified issues.
         </p>
 
-        <div className="bg-surface-800/50 border border-surface-700 rounded-lg p-4 mt-4">
-          <h4 className="font-semibold text-surface-200 mb-2">Audit management features:</h4>
+        <div className="bg-white/50 border border-surface-200 rounded-lg p-4 mt-4">
+          <h4 className="font-semibold text-surface-800 mb-2">Audit management features:</h4>
           <ul className="text-surface-600 space-y-1 text-sm list-disc list-inside">
             <li>
               <strong>Audit planning</strong> - Schedule and scope audits
@@ -1555,7 +1551,7 @@ function AuditManagementArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Step 1: Create an Audit</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Step 1: Create an Audit</h2>
         <ol className="space-y-3 text-surface-700">
           <li className="flex gap-3">
             <span className="flex-shrink-0 w-6 h-6 bg-brand-600 text-white rounded-full flex items-center justify-center text-sm font-bold">
@@ -1595,7 +1591,7 @@ function AuditManagementArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">
           Step 2: Manage Evidence Requests
         </h2>
         <p className="text-surface-700 mb-4">
@@ -1645,17 +1641,17 @@ function AuditManagementArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Step 3: Track Audit Progress</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Step 3: Track Audit Progress</h2>
         <p className="text-surface-700 mb-4">Monitor your audit status with the dashboard:</p>
-        <div className="bg-surface-800 rounded-lg overflow-hidden mb-4">
+        <div className="bg-white rounded-lg overflow-hidden mb-4">
           <table className="w-full text-sm">
-            <thead className="bg-surface-700">
+            <thead className="bg-surface-200">
               <tr>
                 <th className="px-4 py-3 text-left text-surface-700 font-medium">Status</th>
                 <th className="px-4 py-3 text-left text-surface-700 font-medium">Description</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-surface-700">
+            <tbody className="divide-y divide-surface-200">
               <tr>
                 <td className="px-4 py-3">
                   <span className="px-2 py-1 bg-blue-500/20 text-blue-600 rounded text-xs">
@@ -1700,7 +1696,7 @@ function AuditManagementArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">
           Step 4: Document and Remediate Findings
         </h2>
         <p className="text-surface-700 mb-4">
@@ -1751,7 +1747,7 @@ function AuditManagementArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Step 5: Review Audit History</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Step 5: Review Audit History</h2>
         <p className="text-surface-700 mb-4">
           The Audit Log provides a complete history of compliance activities:
         </p>
@@ -1775,23 +1771,23 @@ function AuditManagementArticle() {
         </ul>
       </section>
 
-      <section className="border-t border-surface-800 pt-8">
-        <h3 className="text-lg font-semibold text-surface-200 mb-4">Related Articles</h3>
+      <section className="border-t border-surface-200 pt-8">
+        <h3 className="text-lg font-semibold text-surface-800 mb-4">Related Articles</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <Link
             to="/audits"
-            className="flex items-center gap-3 p-4 bg-surface-800/50 border border-surface-700 rounded-lg hover:bg-surface-800 transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
           >
             <ClipboardDocumentListIcon className="w-5 h-5 text-surface-600" />
-            <span className="text-surface-200">View Audits</span>
+            <span className="text-surface-800">View Audits</span>
             <ChevronRightIcon className="w-4 h-4 text-surface-500 ml-auto" />
           </Link>
           <Link
             to="/audit"
-            className="flex items-center gap-3 p-4 bg-surface-800/50 border border-surface-700 rounded-lg hover:bg-surface-800 transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
           >
             <ClipboardDocumentListIcon className="w-5 h-5 text-surface-600" />
-            <span className="text-surface-200">Audit Log</span>
+            <span className="text-surface-800">Audit Log</span>
             <ChevronRightIcon className="w-4 h-4 text-surface-500 ml-auto" />
           </Link>
         </div>
@@ -1805,7 +1801,7 @@ function CloudDeploymentArticle() {
   return (
     <article className="prose prose-invert max-w-none">
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Overview</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Overview</h2>
         <p className="text-surface-700">
           GigaChad GRC can be deployed to the cloud using Supabase for database/storage and Vercel
           for hosting. This guide covers the deployment process and configuration options.
@@ -1819,7 +1815,7 @@ function CloudDeploymentArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Prerequisites</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Prerequisites</h2>
         <ul className="space-y-2">
           {[
             'Okta Account - For enterprise SSO authentication',
@@ -1836,12 +1832,12 @@ function CloudDeploymentArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">
           Step 1: Create Supabase Project
         </h2>
         <ol className="space-y-4 text-surface-700">
           <li className="flex gap-3">
-            <span className="bg-surface-700 text-surface-200 w-6 h-6 rounded-full flex items-center justify-center text-sm flex-shrink-0">
+            <span className="bg-surface-200 text-surface-800 w-6 h-6 rounded-full flex items-center justify-center text-sm flex-shrink-0">
               1
             </span>
             <span>
@@ -1857,13 +1853,13 @@ function CloudDeploymentArticle() {
             </span>
           </li>
           <li className="flex gap-3">
-            <span className="bg-surface-700 text-surface-200 w-6 h-6 rounded-full flex items-center justify-center text-sm flex-shrink-0">
+            <span className="bg-surface-200 text-surface-800 w-6 h-6 rounded-full flex items-center justify-center text-sm flex-shrink-0">
               2
             </span>
             <span>Click "New Project"</span>
           </li>
           <li className="flex gap-3">
-            <span className="bg-surface-700 text-surface-200 w-6 h-6 rounded-full flex items-center justify-center text-sm flex-shrink-0">
+            <span className="bg-surface-200 text-surface-800 w-6 h-6 rounded-full flex items-center justify-center text-sm flex-shrink-0">
               3
             </span>
             <div>
@@ -1882,7 +1878,7 @@ function CloudDeploymentArticle() {
             </div>
           </li>
           <li className="flex gap-3">
-            <span className="bg-surface-700 text-surface-200 w-6 h-6 rounded-full flex items-center justify-center text-sm flex-shrink-0">
+            <span className="bg-surface-200 text-surface-800 w-6 h-6 rounded-full flex items-center justify-center text-sm flex-shrink-0">
               4
             </span>
             <span>Save your database password securely</span>
@@ -1891,10 +1887,10 @@ function CloudDeploymentArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Step 2: Configure Okta</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Step 2: Configure Okta</h2>
         <ol className="space-y-4 text-surface-700">
           <li className="flex gap-3">
-            <span className="bg-surface-700 text-surface-200 w-6 h-6 rounded-full flex items-center justify-center text-sm flex-shrink-0">
+            <span className="bg-surface-200 text-surface-800 w-6 h-6 rounded-full flex items-center justify-center text-sm flex-shrink-0">
               1
             </span>
             <span>
@@ -1902,7 +1898,7 @@ function CloudDeploymentArticle() {
             </span>
           </li>
           <li className="flex gap-3">
-            <span className="bg-surface-700 text-surface-200 w-6 h-6 rounded-full flex items-center justify-center text-sm flex-shrink-0">
+            <span className="bg-surface-200 text-surface-800 w-6 h-6 rounded-full flex items-center justify-center text-sm flex-shrink-0">
               2
             </span>
             <span>
@@ -1911,18 +1907,18 @@ function CloudDeploymentArticle() {
             </span>
           </li>
           <li className="flex gap-3">
-            <span className="bg-surface-700 text-surface-200 w-6 h-6 rounded-full flex items-center justify-center text-sm flex-shrink-0">
+            <span className="bg-surface-200 text-surface-800 w-6 h-6 rounded-full flex items-center justify-center text-sm flex-shrink-0">
               3
             </span>
             <div>
               <span>Configure redirect URIs:</span>
-              <div className="bg-surface-800 rounded p-3 mt-2 text-sm font-mono text-surface-700">
+              <div className="bg-white rounded p-3 mt-2 text-sm font-mono text-surface-700">
                 https://your-app.vercel.app/login/callback
               </div>
             </div>
           </li>
           <li className="flex gap-3">
-            <span className="bg-surface-700 text-surface-200 w-6 h-6 rounded-full flex items-center justify-center text-sm flex-shrink-0">
+            <span className="bg-surface-200 text-surface-800 w-6 h-6 rounded-full flex items-center justify-center text-sm flex-shrink-0">
               4
             </span>
             <span>
@@ -1933,22 +1929,22 @@ function CloudDeploymentArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Step 3: Deploy to Vercel</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Step 3: Deploy to Vercel</h2>
         <ol className="space-y-4 text-surface-700">
           <li className="flex gap-3">
-            <span className="bg-surface-700 text-surface-200 w-6 h-6 rounded-full flex items-center justify-center text-sm flex-shrink-0">
+            <span className="bg-surface-200 text-surface-800 w-6 h-6 rounded-full flex items-center justify-center text-sm flex-shrink-0">
               1
             </span>
             <span>Import your Git repository in Vercel</span>
           </li>
           <li className="flex gap-3">
-            <span className="bg-surface-700 text-surface-200 w-6 h-6 rounded-full flex items-center justify-center text-sm flex-shrink-0">
+            <span className="bg-surface-200 text-surface-800 w-6 h-6 rounded-full flex items-center justify-center text-sm flex-shrink-0">
               2
             </span>
             <span>Set environment variables (see table below)</span>
           </li>
           <li className="flex gap-3">
-            <span className="bg-surface-700 text-surface-200 w-6 h-6 rounded-full flex items-center justify-center text-sm flex-shrink-0">
+            <span className="bg-surface-200 text-surface-800 w-6 h-6 rounded-full flex items-center justify-center text-sm flex-shrink-0">
               3
             </span>
             <span>Deploy!</span>
@@ -1957,41 +1953,41 @@ function CloudDeploymentArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Environment Variables</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Environment Variables</h2>
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
-              <tr className="border-b border-surface-700">
-                <th className="text-left py-2 text-surface-200">Variable</th>
-                <th className="text-left py-2 text-surface-200">Description</th>
+              <tr className="border-b border-surface-200">
+                <th className="text-left py-2 text-surface-800">Variable</th>
+                <th className="text-left py-2 text-surface-800">Description</th>
               </tr>
             </thead>
             <tbody className="text-surface-600">
-              <tr className="border-b border-surface-800">
+              <tr className="border-b border-surface-200">
                 <td className="py-2 font-mono text-brand-400">VITE_OKTA_ISSUER</td>
                 <td className="py-2">Your Okta authorization server URL</td>
               </tr>
-              <tr className="border-b border-surface-800">
+              <tr className="border-b border-surface-200">
                 <td className="py-2 font-mono text-brand-400">VITE_OKTA_CLIENT_ID</td>
                 <td className="py-2">Okta application client ID</td>
               </tr>
-              <tr className="border-b border-surface-800">
+              <tr className="border-b border-surface-200">
                 <td className="py-2 font-mono text-brand-400">DATABASE_URL</td>
                 <td className="py-2">Supabase pooled connection string</td>
               </tr>
-              <tr className="border-b border-surface-800">
+              <tr className="border-b border-surface-200">
                 <td className="py-2 font-mono text-brand-400">DIRECT_URL</td>
                 <td className="py-2">Supabase direct connection string</td>
               </tr>
-              <tr className="border-b border-surface-800">
+              <tr className="border-b border-surface-200">
                 <td className="py-2 font-mono text-brand-400">SUPABASE_URL</td>
                 <td className="py-2">Supabase project URL</td>
               </tr>
-              <tr className="border-b border-surface-800">
+              <tr className="border-b border-surface-200">
                 <td className="py-2 font-mono text-brand-400">SUPABASE_ANON_KEY</td>
                 <td className="py-2">Supabase anonymous key</td>
               </tr>
-              <tr className="border-b border-surface-800">
+              <tr className="border-b border-surface-200">
                 <td className="py-2 font-mono text-brand-400">SUPABASE_SERVICE_KEY</td>
                 <td className="py-2">Supabase service role key</td>
               </tr>
@@ -2005,32 +2001,32 @@ function CloudDeploymentArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">
           Step 4: Run Database Migrations
         </h2>
         <p className="text-surface-700 mb-4">After first deployment, run:</p>
-        <div className="bg-surface-800 rounded p-4 font-mono text-sm text-surface-700">
+        <div className="bg-white rounded p-4 font-mono text-sm text-surface-700">
           npx prisma migrate deploy
         </div>
       </section>
 
-      <section className="border-t border-surface-800 pt-8">
-        <h3 className="text-lg font-semibold text-surface-200 mb-4">Related Articles</h3>
+      <section className="border-t border-surface-200 pt-8">
+        <h3 className="text-lg font-semibold text-surface-800 mb-4">Related Articles</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <Link
             to="/help/deployment/supabase-vercel-migration"
-            className="flex items-center gap-3 p-4 bg-surface-800/50 border border-surface-700 rounded-lg hover:bg-surface-800 transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
           >
             <BookOpenIcon className="w-5 h-5 text-surface-600" />
-            <span className="text-surface-200">Full Migration Guide</span>
+            <span className="text-surface-800">Full Migration Guide</span>
             <ChevronRightIcon className="w-4 h-4 text-surface-500 ml-auto" />
           </Link>
           <Link
             to="/settings"
-            className="flex items-center gap-3 p-4 bg-surface-800/50 border border-surface-700 rounded-lg hover:bg-surface-800 transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
           >
             <Cog6ToothIcon className="w-5 h-5 text-surface-600" />
-            <span className="text-surface-200">Settings</span>
+            <span className="text-surface-800">Settings</span>
             <ChevronRightIcon className="w-4 h-4 text-surface-500 ml-auto" />
           </Link>
         </div>
@@ -2044,7 +2040,7 @@ function SupabaseVercelMigrationArticle() {
   return (
     <article className="prose prose-invert max-w-none">
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Overview</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Overview</h2>
         <p className="text-surface-700">
           This guide covers migrating GigaChad GRC from the Docker-based microservices architecture
           to Supabase (database/storage) + Vercel (frontend/serverless API) with Okta SSO
@@ -2052,8 +2048,8 @@ function SupabaseVercelMigrationArticle() {
         </p>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-6">
-          <div className="bg-surface-800/50 border border-surface-700 rounded-lg p-4">
-            <h4 className="font-semibold text-surface-200 mb-2">Previous Architecture</h4>
+          <div className="bg-white/50 border border-surface-200 rounded-lg p-4">
+            <h4 className="font-semibold text-surface-800 mb-2">Previous Architecture</h4>
             <ul className="text-surface-600 text-sm space-y-1">
               <li>• 6 NestJS microservices</li>
               <li>• PostgreSQL + Redis + RustFS</li>
@@ -2074,7 +2070,7 @@ function SupabaseVercelMigrationArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Migration Phases</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Migration Phases</h2>
         <div className="space-y-4">
           {[
             {
@@ -2105,13 +2101,13 @@ function SupabaseVercelMigrationArticle() {
           ].map((item) => (
             <div
               key={item.phase}
-              className="flex items-start gap-4 p-4 bg-surface-800/50 border border-surface-700 rounded-lg"
+              className="flex items-start gap-4 p-4 bg-white/50 border border-surface-200 rounded-lg"
             >
               <span className="bg-brand-600 text-white w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold flex-shrink-0">
                 {item.phase}
               </span>
               <div className="flex-1">
-                <h4 className="font-semibold text-surface-200">{item.title}</h4>
+                <h4 className="font-semibold text-surface-800">{item.title}</h4>
                 <p className="text-surface-600 text-sm">{item.desc}</p>
               </div>
               <span className="text-surface-500 text-sm">{item.time}</span>
@@ -2124,12 +2120,12 @@ function SupabaseVercelMigrationArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Supabase Connection Strings</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Supabase Connection Strings</h2>
         <p className="text-surface-700 mb-4">
           Supabase uses two connection strings - pooled for queries and direct for migrations:
         </p>
         <div className="space-y-4">
-          <div className="bg-surface-800 rounded-lg p-4">
+          <div className="bg-white rounded-lg p-4">
             <h4 className="font-mono text-brand-400 text-sm mb-2">
               DATABASE_URL (Pooled - Port 6543)
             </h4>
@@ -2140,7 +2136,7 @@ function SupabaseVercelMigrationArticle() {
               postgres://postgres.[ref]:[password]@aws-0-region.pooler.supabase.com:6543/postgres
             </code>
           </div>
-          <div className="bg-surface-800 rounded-lg p-4">
+          <div className="bg-white rounded-lg p-4">
             <h4 className="font-mono text-brand-400 text-sm mb-2">
               DIRECT_URL (Direct - Port 5432)
             </h4>
@@ -2155,34 +2151,34 @@ function SupabaseVercelMigrationArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Storage Buckets</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Storage Buckets</h2>
         <p className="text-surface-700 mb-4">Create these buckets in Supabase Storage:</p>
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
-              <tr className="border-b border-surface-700">
-                <th className="text-left py-2 text-surface-200">Bucket</th>
-                <th className="text-left py-2 text-surface-200">Access</th>
-                <th className="text-left py-2 text-surface-200">Purpose</th>
+              <tr className="border-b border-surface-200">
+                <th className="text-left py-2 text-surface-800">Bucket</th>
+                <th className="text-left py-2 text-surface-800">Access</th>
+                <th className="text-left py-2 text-surface-800">Purpose</th>
               </tr>
             </thead>
             <tbody className="text-surface-600">
-              <tr className="border-b border-surface-800">
+              <tr className="border-b border-surface-200">
                 <td className="py-2 font-mono">evidence</td>
                 <td className="py-2">Private</td>
                 <td className="py-2">Evidence files and documents</td>
               </tr>
-              <tr className="border-b border-surface-800">
+              <tr className="border-b border-surface-200">
                 <td className="py-2 font-mono">policies</td>
                 <td className="py-2">Private</td>
                 <td className="py-2">Policy document storage</td>
               </tr>
-              <tr className="border-b border-surface-800">
+              <tr className="border-b border-surface-200">
                 <td className="py-2 font-mono">integrations</td>
                 <td className="py-2">Private</td>
                 <td className="py-2">Integration configuration</td>
               </tr>
-              <tr className="border-b border-surface-800">
+              <tr className="border-b border-surface-200">
                 <td className="py-2 font-mono">questionnaires</td>
                 <td className="py-2">Private</td>
                 <td className="py-2">Questionnaire attachments</td>
@@ -2198,10 +2194,10 @@ function SupabaseVercelMigrationArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Okta Configuration</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Okta Configuration</h2>
         <div className="space-y-4">
-          <div className="bg-surface-800 rounded-lg p-4">
-            <h4 className="font-semibold text-surface-200 mb-2">Application Settings</h4>
+          <div className="bg-white rounded-lg p-4">
+            <h4 className="font-semibold text-surface-800 mb-2">Application Settings</h4>
             <ul className="text-surface-600 text-sm space-y-1">
               <li>
                 • <strong>Type:</strong> OIDC - Single-Page Application
@@ -2217,8 +2213,8 @@ function SupabaseVercelMigrationArticle() {
               </li>
             </ul>
           </div>
-          <div className="bg-surface-800 rounded-lg p-4">
-            <h4 className="font-semibold text-surface-200 mb-2">Groups Claim (for roles)</h4>
+          <div className="bg-white rounded-lg p-4">
+            <h4 className="font-semibold text-surface-800 mb-2">Groups Claim (for roles)</h4>
             <p className="text-surface-600 text-sm mb-2">
               Add a groups claim to include user roles in tokens:
             </p>
@@ -2241,34 +2237,34 @@ function SupabaseVercelMigrationArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Rollback Procedure</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Rollback Procedure</h2>
         <p className="text-surface-700 mb-4">If you need to rollback to the Docker architecture:</p>
         <ol className="space-y-2 text-surface-700">
           <li className="flex gap-3">
-            <span className="bg-surface-700 text-surface-200 w-6 h-6 rounded-full flex items-center justify-center text-sm flex-shrink-0">
+            <span className="bg-surface-200 text-surface-800 w-6 h-6 rounded-full flex items-center justify-center text-sm flex-shrink-0">
               1
             </span>
             <span>Update DNS to point to your Docker host</span>
           </li>
           <li className="flex gap-3">
-            <span className="bg-surface-700 text-surface-200 w-6 h-6 rounded-full flex items-center justify-center text-sm flex-shrink-0">
+            <span className="bg-surface-200 text-surface-800 w-6 h-6 rounded-full flex items-center justify-center text-sm flex-shrink-0">
               2
             </span>
             <span>Restore database from backup</span>
           </li>
           <li className="flex gap-3">
-            <span className="bg-surface-700 text-surface-200 w-6 h-6 rounded-full flex items-center justify-center text-sm flex-shrink-0">
+            <span className="bg-surface-200 text-surface-800 w-6 h-6 rounded-full flex items-center justify-center text-sm flex-shrink-0">
               3
             </span>
             <span>
               Start Docker services:{' '}
-              <code className="bg-surface-800 px-1.5 py-0.5 rounded text-brand-400">
+              <code className="bg-white px-1.5 py-0.5 rounded text-brand-400">
                 docker-compose up -d
               </code>
             </span>
           </li>
           <li className="flex gap-3">
-            <span className="bg-surface-700 text-surface-200 w-6 h-6 rounded-full flex items-center justify-center text-sm flex-shrink-0">
+            <span className="bg-surface-200 text-surface-800 w-6 h-6 rounded-full flex items-center justify-center text-sm flex-shrink-0">
               4
             </span>
             <span>Update frontend .env to use legacy API endpoints</span>
@@ -2276,23 +2272,23 @@ function SupabaseVercelMigrationArticle() {
         </ol>
       </section>
 
-      <section className="border-t border-surface-800 pt-8">
-        <h3 className="text-lg font-semibold text-surface-200 mb-4">Related Articles</h3>
+      <section className="border-t border-surface-200 pt-8">
+        <h3 className="text-lg font-semibold text-surface-800 mb-4">Related Articles</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <Link
             to="/help/deployment/cloud-deployment"
-            className="flex items-center gap-3 p-4 bg-surface-800/50 border border-surface-700 rounded-lg hover:bg-surface-800 transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
           >
             <BookOpenIcon className="w-5 h-5 text-surface-600" />
-            <span className="text-surface-200">Cloud Deployment Guide</span>
+            <span className="text-surface-800">Cloud Deployment Guide</span>
             <ChevronRightIcon className="w-4 h-4 text-surface-500 ml-auto" />
           </Link>
           <Link
             to="/integrations"
-            className="flex items-center gap-3 p-4 bg-surface-800/50 border border-surface-700 rounded-lg hover:bg-surface-800 transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
           >
             <LinkIcon className="w-5 h-5 text-surface-600" />
-            <span className="text-surface-200">Integrations</span>
+            <span className="text-surface-800">Integrations</span>
             <ChevronRightIcon className="w-4 h-4 text-surface-500 ml-auto" />
           </Link>
         </div>
@@ -2306,15 +2302,15 @@ function MCPQuickStartArticle() {
   return (
     <article className="prose prose-invert max-w-none">
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Overview</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Overview</h2>
         <p className="text-surface-700">
           Model Context Protocol (MCP) servers automate GRC workflows by connecting to external
           services to collect compliance evidence, run automated compliance checks, and provide
           AI-powered analysis. This guide walks you through setting up your first MCP server.
         </p>
 
-        <div className="bg-surface-800/50 border border-surface-700 rounded-lg p-4 mt-4">
-          <h4 className="font-semibold text-surface-200 mb-2">Available MCP Server Types:</h4>
+        <div className="bg-white/50 border border-surface-200 rounded-lg p-4 mt-4">
+          <h4 className="font-semibold text-surface-800 mb-2">Available MCP Server Types:</h4>
           <ul className="text-surface-600 space-y-1 text-sm list-disc list-inside">
             <li>
               <strong>GRC Evidence Collection</strong> - Automated evidence from AWS, Azure, GitHub,
@@ -2336,7 +2332,7 @@ function MCPQuickStartArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Step 1: Access MCP Settings</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Step 1: Access MCP Settings</h2>
         <ol className="space-y-3 text-surface-700">
           <li className="flex gap-3">
             <span className="flex-shrink-0 w-6 h-6 bg-brand-600 text-white rounded-full flex items-center justify-center text-sm font-bold">
@@ -2358,11 +2354,11 @@ function MCPQuickStartArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Step 2: Select a Template</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Step 2: Select a Template</h2>
         <p className="text-surface-700 mb-4">Choose the server type that matches your needs:</p>
         <div className="space-y-4">
-          <div className="bg-surface-800/50 border border-surface-700 rounded-lg p-4">
-            <h4 className="font-semibold text-surface-200 mb-2">GRC Evidence Collection Server</h4>
+          <div className="bg-white/50 border border-surface-200 rounded-lg p-4">
+            <h4 className="font-semibold text-surface-800 mb-2">GRC Evidence Collection Server</h4>
             <p className="text-surface-600 text-sm mb-2">
               Best for automated evidence gathering from cloud providers and identity systems.
             </p>
@@ -2370,8 +2366,8 @@ function MCPQuickStartArticle() {
               Integrations: AWS, Azure, GitHub, Okta, Google Workspace, Jamf
             </p>
           </div>
-          <div className="bg-surface-800/50 border border-surface-700 rounded-lg p-4">
-            <h4 className="font-semibold text-surface-200 mb-2">
+          <div className="bg-white/50 border border-surface-200 rounded-lg p-4">
+            <h4 className="font-semibold text-surface-800 mb-2">
               GRC Compliance Automation Server
             </h4>
             <p className="text-surface-600 text-sm mb-2">
@@ -2381,8 +2377,8 @@ function MCPQuickStartArticle() {
               Capabilities: Control testing, gap analysis, policy validation
             </p>
           </div>
-          <div className="bg-surface-800/50 border border-surface-700 rounded-lg p-4">
-            <h4 className="font-semibold text-surface-200 mb-2">GRC AI Assistant Server</h4>
+          <div className="bg-white/50 border border-surface-200 rounded-lg p-4">
+            <h4 className="font-semibold text-surface-800 mb-2">GRC AI Assistant Server</h4>
             <p className="text-surface-600 text-sm mb-2">
               Best for AI-powered analysis and recommendations.
             </p>
@@ -2392,14 +2388,14 @@ function MCPQuickStartArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Step 3: Configure Credentials</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Step 3: Configure Credentials</h2>
         <p className="text-surface-700 mb-4">
           After selecting a template, configure the integrations you want to use. Expand each
           section and enter your API credentials:
         </p>
-        <div className="bg-surface-800 rounded-lg overflow-hidden mb-4">
+        <div className="bg-white rounded-lg overflow-hidden mb-4">
           <table className="w-full text-sm">
-            <thead className="bg-surface-700">
+            <thead className="bg-surface-200">
               <tr>
                 <th className="px-4 py-3 text-left text-surface-700 font-medium">Integration</th>
                 <th className="px-4 py-3 text-left text-surface-700 font-medium">
@@ -2407,35 +2403,35 @@ function MCPQuickStartArticle() {
                 </th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-surface-700">
+            <tbody className="divide-y divide-surface-200">
               <tr>
-                <td className="px-4 py-3 text-surface-200">AWS</td>
+                <td className="px-4 py-3 text-surface-800">AWS</td>
                 <td className="px-4 py-3 text-surface-600 font-mono text-xs">
                   AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
                 </td>
               </tr>
               <tr>
-                <td className="px-4 py-3 text-surface-200">Azure</td>
+                <td className="px-4 py-3 text-surface-800">Azure</td>
                 <td className="px-4 py-3 text-surface-600 font-mono text-xs">
                   AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET
                 </td>
               </tr>
               <tr>
-                <td className="px-4 py-3 text-surface-200">GitHub</td>
+                <td className="px-4 py-3 text-surface-800">GitHub</td>
                 <td className="px-4 py-3 text-surface-600 font-mono text-xs">GITHUB_TOKEN</td>
               </tr>
               <tr>
-                <td className="px-4 py-3 text-surface-200">Okta</td>
+                <td className="px-4 py-3 text-surface-800">Okta</td>
                 <td className="px-4 py-3 text-surface-600 font-mono text-xs">
                   OKTA_DOMAIN, OKTA_API_TOKEN
                 </td>
               </tr>
               <tr>
-                <td className="px-4 py-3 text-surface-200">OpenAI</td>
+                <td className="px-4 py-3 text-surface-800">OpenAI</td>
                 <td className="px-4 py-3 text-surface-600 font-mono text-xs">OPENAI_API_KEY</td>
               </tr>
               <tr>
-                <td className="px-4 py-3 text-surface-200">Anthropic</td>
+                <td className="px-4 py-3 text-surface-800">Anthropic</td>
                 <td className="px-4 py-3 text-surface-600 font-mono text-xs">ANTHROPIC_API_KEY</td>
               </tr>
             </tbody>
@@ -2450,7 +2446,7 @@ function MCPQuickStartArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Step 4: Deploy and Connect</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Step 4: Deploy and Connect</h2>
         <ol className="space-y-3 text-surface-700">
           <li className="flex gap-3">
             <span className="flex-shrink-0 w-6 h-6 bg-brand-600 text-white rounded-full flex items-center justify-center text-sm font-bold">
@@ -2478,7 +2474,7 @@ function MCPQuickStartArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Step 5: View Server Details</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Step 5: View Server Details</h2>
         <p className="text-surface-700 mb-4">
           Click on any registered server to view detailed information:
         </p>
@@ -2512,7 +2508,7 @@ function MCPQuickStartArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Security</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Security</h2>
         <p className="text-surface-700 mb-4">
           All MCP server credentials are protected with enterprise-grade security:
         </p>
@@ -2536,23 +2532,23 @@ function MCPQuickStartArticle() {
         </ul>
       </section>
 
-      <section className="border-t border-surface-800 pt-8">
-        <h3 className="text-lg font-semibold text-surface-200 mb-4">Related Articles</h3>
+      <section className="border-t border-surface-200 pt-8">
+        <h3 className="text-lg font-semibold text-surface-800 mb-4">Related Articles</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <Link
             to="/help/mcp/credential-security"
-            className="flex items-center gap-3 p-4 bg-surface-800/50 border border-surface-700 rounded-lg hover:bg-surface-800 transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
           >
             <ShieldCheckIcon className="w-5 h-5 text-surface-600" />
-            <span className="text-surface-200">MCP Credential Security</span>
+            <span className="text-surface-800">MCP Credential Security</span>
             <ChevronRightIcon className="w-4 h-4 text-surface-500 ml-auto" />
           </Link>
           <Link
             to="/settings/mcp"
-            className="flex items-center gap-3 p-4 bg-surface-800/50 border border-surface-700 rounded-lg hover:bg-surface-800 transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
           >
             <Cog6ToothIcon className="w-5 h-5 text-surface-600" />
-            <span className="text-surface-200">MCP Settings</span>
+            <span className="text-surface-800">MCP Settings</span>
             <ChevronRightIcon className="w-4 h-4 text-surface-500 ml-auto" />
           </Link>
         </div>
@@ -2566,7 +2562,7 @@ function MCPCredentialSecurityArticle() {
   return (
     <article className="prose prose-invert max-w-none">
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Overview</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Overview</h2>
         <p className="text-surface-700">
           MCP server credentials (API keys, tokens, secrets) are protected using industry-standard
           encryption. This document explains the security architecture and provides recommendations
@@ -2585,36 +2581,36 @@ function MCPCredentialSecurityArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Encryption Details</h2>
-        <div className="bg-surface-800 rounded-lg overflow-hidden mb-4">
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Encryption Details</h2>
+        <div className="bg-white rounded-lg overflow-hidden mb-4">
           <table className="w-full text-sm">
-            <thead className="bg-surface-700">
+            <thead className="bg-surface-200">
               <tr>
                 <th className="px-4 py-3 text-left text-surface-700 font-medium">Component</th>
                 <th className="px-4 py-3 text-left text-surface-700 font-medium">Specification</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-surface-700">
+            <tbody className="divide-y divide-surface-200">
               <tr>
-                <td className="px-4 py-3 text-surface-200">Algorithm</td>
+                <td className="px-4 py-3 text-surface-800">Algorithm</td>
                 <td className="px-4 py-3 text-surface-600">AES-256-GCM</td>
               </tr>
               <tr>
-                <td className="px-4 py-3 text-surface-200">Key Derivation</td>
+                <td className="px-4 py-3 text-surface-800">Key Derivation</td>
                 <td className="px-4 py-3 text-surface-600">SCRYPT with salt</td>
               </tr>
               <tr>
-                <td className="px-4 py-3 text-surface-200">IV Size</td>
+                <td className="px-4 py-3 text-surface-800">IV Size</td>
                 <td className="px-4 py-3 text-surface-600">
                   128 bits (16 bytes), random per operation
                 </td>
               </tr>
               <tr>
-                <td className="px-4 py-3 text-surface-200">Auth Tag Size</td>
+                <td className="px-4 py-3 text-surface-800">Auth Tag Size</td>
                 <td className="px-4 py-3 text-surface-600">128 bits (16 bytes)</td>
               </tr>
               <tr>
-                <td className="px-4 py-3 text-surface-200">Storage</td>
+                <td className="px-4 py-3 text-surface-800">Storage</td>
                 <td className="px-4 py-3 text-surface-600">PostgreSQL (encrypted JSON)</td>
               </tr>
             </tbody>
@@ -2623,14 +2619,14 @@ function MCPCredentialSecurityArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Configuration</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Configuration</h2>
         <p className="text-surface-700 mb-4">Set the encryption key via environment variable:</p>
-        <div className="bg-surface-900 rounded-lg p-4 font-mono text-sm text-green-600 mb-4">
+        <div className="bg-white rounded-lg p-4 font-mono text-sm text-green-600 mb-4">
           MCP_ENCRYPTION_KEY=your-64-character-random-string
         </div>
-        <div className="bg-surface-800/50 border border-surface-700 rounded-lg p-4">
-          <h4 className="font-semibold text-surface-200 mb-2">Generate a Secure Key:</h4>
-          <div className="bg-surface-900 rounded-lg p-3 font-mono text-sm text-surface-700 mt-2">
+        <div className="bg-white/50 border border-surface-200 rounded-lg p-4">
+          <h4 className="font-semibold text-surface-800 mb-2">Generate a Secure Key:</h4>
+          <div className="bg-white rounded-lg p-3 font-mono text-sm text-surface-700 mt-2">
             openssl rand -hex 32
           </div>
         </div>
@@ -2643,7 +2639,7 @@ function MCPCredentialSecurityArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">What's Protected</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">What's Protected</h2>
         <ul className="space-y-2 text-surface-700">
           <li className="flex gap-3">
             <span className="text-green-600">✓</span>
@@ -2665,7 +2661,7 @@ function MCPCredentialSecurityArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">What's NOT Exposed</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">What's NOT Exposed</h2>
         <ul className="space-y-2 text-surface-700">
           <li className="flex gap-3">
             <span className="text-red-600">✗</span>
@@ -2683,31 +2679,31 @@ function MCPCredentialSecurityArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Audit Trail</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Audit Trail</h2>
         <p className="text-surface-700 mb-4">Every MCP server configuration records:</p>
-        <div className="bg-surface-800 rounded-lg overflow-hidden mb-4">
+        <div className="bg-white rounded-lg overflow-hidden mb-4">
           <table className="w-full text-sm">
-            <thead className="bg-surface-700">
+            <thead className="bg-surface-200">
               <tr>
                 <th className="px-4 py-3 text-left text-surface-700 font-medium">Field</th>
                 <th className="px-4 py-3 text-left text-surface-700 font-medium">Purpose</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-surface-700">
+            <tbody className="divide-y divide-surface-200">
               <tr>
-                <td className="px-4 py-3 text-surface-200 font-mono">created_by</td>
+                <td className="px-4 py-3 text-surface-800 font-mono">created_by</td>
                 <td className="px-4 py-3 text-surface-600">User who created the configuration</td>
               </tr>
               <tr>
-                <td className="px-4 py-3 text-surface-200 font-mono">created_at</td>
+                <td className="px-4 py-3 text-surface-800 font-mono">created_at</td>
                 <td className="px-4 py-3 text-surface-600">Timestamp of creation</td>
               </tr>
               <tr>
-                <td className="px-4 py-3 text-surface-200 font-mono">last_updated</td>
+                <td className="px-4 py-3 text-surface-800 font-mono">last_updated</td>
                 <td className="px-4 py-3 text-surface-600">Last modification timestamp</td>
               </tr>
               <tr>
-                <td className="px-4 py-3 text-surface-200 font-mono">configured_integrations</td>
+                <td className="px-4 py-3 text-surface-800 font-mono">configured_integrations</td>
                 <td className="px-4 py-3 text-surface-600">Which integrations have credentials</td>
               </tr>
             </tbody>
@@ -2716,7 +2712,7 @@ function MCPCredentialSecurityArticle() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-2xl font-bold text-surface-100 mb-4">Recommendations</h2>
+        <h2 className="text-2xl font-bold text-surface-900 mb-4">Recommendations</h2>
         <div className="space-y-4">
           <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-4">
             <h4 className="font-semibold text-red-700 mb-2">🔴 Critical</h4>
@@ -2746,23 +2742,23 @@ function MCPCredentialSecurityArticle() {
         </div>
       </section>
 
-      <section className="border-t border-surface-800 pt-8">
-        <h3 className="text-lg font-semibold text-surface-200 mb-4">Related Articles</h3>
+      <section className="border-t border-surface-200 pt-8">
+        <h3 className="text-lg font-semibold text-surface-800 mb-4">Related Articles</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <Link
             to="/help/mcp/quick-start"
-            className="flex items-center gap-3 p-4 bg-surface-800/50 border border-surface-700 rounded-lg hover:bg-surface-800 transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
           >
             <BookOpenIcon className="w-5 h-5 text-surface-600" />
-            <span className="text-surface-200">MCP Quick Start Guide</span>
+            <span className="text-surface-800">MCP Quick Start Guide</span>
             <ChevronRightIcon className="w-4 h-4 text-surface-500 ml-auto" />
           </Link>
           <Link
             to="/settings/mcp"
-            className="flex items-center gap-3 p-4 bg-surface-800/50 border border-surface-700 rounded-lg hover:bg-surface-800 transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
           >
             <Cog6ToothIcon className="w-5 h-5 text-surface-600" />
-            <span className="text-surface-200">MCP Settings</span>
+            <span className="text-surface-800">MCP Settings</span>
             <ChevronRightIcon className="w-4 h-4 text-surface-500 ml-auto" />
           </Link>
         </div>
@@ -2881,7 +2877,7 @@ export default function HelpArticle() {
       component: (
         <div className="text-center py-16">
           <GlobeAltIcon className="w-16 h-16 text-surface-600 mx-auto mb-4" />
-          <h2 className="text-2xl font-semibold text-surface-200 mb-2">Article Not Found</h2>
+          <h2 className="text-2xl font-semibold text-surface-800 mb-2">Article Not Found</h2>
           <p className="text-surface-600 mb-6">
             The help article you're looking for doesn't exist.
           </p>
@@ -2903,19 +2899,19 @@ export default function HelpArticle() {
     <div className="max-w-4xl mx-auto">
       {/* Breadcrumb */}
       <nav className="flex items-center gap-2 text-sm text-surface-600 mb-6">
-        <Link to="/help" className="hover:text-surface-200">
+        <Link to="/help" className="hover:text-surface-800">
           Help Center
         </Link>
         <ChevronRightIcon className="w-4 h-4" />
         <span className="capitalize">{articleData.breadcrumb}</span>
         <ChevronRightIcon className="w-4 h-4" />
-        <span className="text-surface-200">{articleData.title}</span>
+        <span className="text-surface-800">{articleData.title}</span>
       </nav>
 
       {/* Back Link */}
       <Link
         to="/help"
-        className="inline-flex items-center gap-2 text-surface-600 hover:text-surface-200 mb-6"
+        className="inline-flex items-center gap-2 text-surface-600 hover:text-surface-800 mb-6"
       >
         <ArrowLeftIcon className="w-4 h-4" />
         Back to Help Center
@@ -2923,7 +2919,7 @@ export default function HelpArticle() {
 
       {/* Article Header */}
       <header className="mb-8">
-        <h1 className="text-3xl font-bold text-surface-100">{articleData.title}</h1>
+        <h1 className="text-3xl font-bold text-surface-900">{articleData.title}</h1>
         <p className="text-surface-500 text-sm mt-2">Last updated: December 2025</p>
       </header>
 

--- a/frontend/src/pages/HelpCenter.tsx
+++ b/frontend/src/pages/HelpCenter.tsx
@@ -164,7 +164,7 @@ export default function HelpCenter() {
     <div className="space-y-8">
       {/* Header */}
       <div className="text-center">
-        <h1 className="text-4xl font-bold text-surface-100">Help Center</h1>
+        <h1 className="text-4xl font-bold text-surface-900">Help Center</h1>
         <p className="mt-2 text-lg text-surface-600">
           Find guides, tutorials, and answers to common questions
         </p>
@@ -178,7 +178,7 @@ export default function HelpCenter() {
             placeholder="Search help articles..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full pl-12 pr-4 py-3 bg-surface-800 border border-surface-700 rounded-xl text-surface-100 placeholder-surface-500 focus:outline-none focus:border-brand-500 focus:ring-1 focus:ring-brand-500"
+            className="w-full pl-12 pr-4 py-3 bg-white border border-surface-200 rounded-xl text-surface-900 placeholder-surface-500 focus:outline-none focus:border-brand-500 focus:ring-1 focus:ring-brand-500"
           />
         </div>
       </div>
@@ -194,7 +194,7 @@ export default function HelpCenter() {
               className={`flex flex-col items-center gap-2 p-4 rounded-lg border transition-colors ${
                 isSelected
                   ? 'bg-brand-600/20 border-brand-500 text-brand-400'
-                  : 'bg-surface-800/50 border-surface-700 text-surface-600 hover:bg-surface-800 hover:text-surface-200'
+                  : 'bg-white/50 border-surface-200 text-surface-600 hover:bg-white hover:text-surface-800'
               }`}
             >
               <Icon className={`w-6 h-6 ${isSelected ? 'text-brand-400' : category.color}`} />
@@ -215,7 +215,7 @@ export default function HelpCenter() {
                 Featured
               </span>
             </div>
-            <h3 className="text-xl font-semibold text-surface-100 mb-2">
+            <h3 className="text-xl font-semibold text-surface-900 mb-2">
               Set Up a Custom URL for Your Trust Center
             </h3>
             <p className="text-surface-600 mb-4">
@@ -235,7 +235,7 @@ export default function HelpCenter() {
       </div>
       {/* Articles Grid */}
       <div>
-        <h2 className="text-xl font-semibold text-surface-100 mb-4">
+        <h2 className="text-xl font-semibold text-surface-900 mb-4">
           {selectedCategory ? `${selectedCategory} Articles` : 'All Articles'}
           <span className="ml-2 text-sm font-normal text-surface-500">
             ({filteredArticles.length})
@@ -243,7 +243,7 @@ export default function HelpCenter() {
         </h2>
 
         {filteredArticles.length === 0 ? (
-          <div className="text-center py-12 bg-surface-800/30 rounded-lg border border-surface-700">
+          <div className="text-center py-12 bg-white/30 rounded-lg border border-surface-200">
             <BookOpenIcon className="w-12 h-12 text-surface-600 mx-auto mb-3" />
             <p className="text-surface-600">No articles found matching your search</p>
             <button
@@ -262,17 +262,17 @@ export default function HelpCenter() {
               <Link
                 key={article.id}
                 to={article.href}
-                className="group bg-surface-800/50 border border-surface-700 rounded-lg p-5 hover:bg-surface-800 hover:border-surface-600 transition-colors"
+                className="group bg-white/50 border border-surface-200 rounded-lg p-5 hover:bg-white hover:border-surface-300 transition-colors"
               >
                 <div className="flex items-start justify-between mb-2">
-                  <span className="px-2 py-0.5 text-xs bg-surface-700 text-surface-600 rounded">
+                  <span className="px-2 py-0.5 text-xs bg-surface-200 text-surface-600 rounded">
                     {article.category}
                   </span>
                   {article.external && (
                     <ArrowTopRightOnSquareIcon className="w-4 h-4 text-surface-500" />
                   )}
                 </div>
-                <h3 className="text-surface-100 font-medium mb-2 group-hover:text-brand-400 transition-colors">
+                <h3 className="text-surface-900 font-medium mb-2 group-hover:text-brand-400 transition-colors">
                   {article.title}
                 </h3>
                 <p className="text-sm text-surface-500 line-clamp-2">{article.description}</p>
@@ -282,44 +282,44 @@ export default function HelpCenter() {
         )}
       </div>
       {/* Quick Links */}
-      <div className="border-t border-surface-800 pt-8">
-        <h2 className="text-lg font-semibold text-surface-100 mb-4">Developer Resources</h2>
+      <div className="border-t border-surface-200 pt-8">
+        <h2 className="text-lg font-semibold text-surface-900 mb-4">Developer Resources</h2>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <Link
             to="/docs?section=api"
-            className="flex items-center gap-3 p-4 bg-surface-800/50 border border-surface-700 rounded-lg hover:bg-surface-800 transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
           >
             <BookOpenIcon className="w-5 h-5 text-surface-600" />
-            <span className="text-surface-200">API Documentation</span>
+            <span className="text-surface-800">API Documentation</span>
             <ChevronRightIcon className="w-4 h-4 text-surface-500 ml-auto" />
           </Link>
           <Link
             to="/docs?section=architecture"
-            className="flex items-center gap-3 p-4 bg-surface-800/50 border border-surface-700 rounded-lg hover:bg-surface-800 transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
           >
             <BookOpenIcon className="w-5 h-5 text-surface-600" />
-            <span className="text-surface-200">Architecture Guide</span>
+            <span className="text-surface-800">Architecture Guide</span>
             <ChevronRightIcon className="w-4 h-4 text-surface-500 ml-auto" />
           </Link>
           <Link
             to="/docs?section=configuration"
-            className="flex items-center gap-3 p-4 bg-surface-800/50 border border-surface-700 rounded-lg hover:bg-surface-800 transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
           >
             <BookOpenIcon className="w-5 h-5 text-surface-600" />
-            <span className="text-surface-200">Configuration Guide</span>
+            <span className="text-surface-800">Configuration Guide</span>
             <ChevronRightIcon className="w-4 h-4 text-surface-500 ml-auto" />
           </Link>
         </div>
       </div>
       {/* Contact Support */}
-      <div className="bg-surface-800/30 border border-surface-700 rounded-xl p-6 text-center">
-        <h3 className="text-lg font-semibold text-surface-100 mb-2">Still need help?</h3>
+      <div className="bg-white/30 border border-surface-200 rounded-xl p-6 text-center">
+        <h3 className="text-lg font-semibold text-surface-900 mb-2">Still need help?</h3>
         <p className="text-surface-600 mb-4">
           Can't find what you're looking for? Our support team is here to help.
         </p>
         <a
           href="mailto:support@example.com"
-          className="inline-flex items-center gap-2 px-4 py-2 bg-surface-700 text-surface-200 rounded-lg hover:bg-surface-600 transition-colors"
+          className="inline-flex items-center gap-2 px-4 py-2 bg-surface-200 text-surface-800 rounded-lg hover:bg-surface-600 transition-colors"
         >
           Contact Support
         </a>

--- a/frontend/src/pages/Integrations.tsx
+++ b/frontend/src/pages/Integrations.tsx
@@ -231,7 +231,7 @@ export default function Integrations() {
     <div className="space-y-6 animate-fade-in">
       {/* Header */}
       <div>
-        <h1 className="text-2xl font-bold text-surface-100">Integrations</h1>
+        <h1 className="text-2xl font-bold text-surface-900">Integrations</h1>
         <p className="text-surface-600 mt-1">
           Connect external services for automated evidence collection
         </p>
@@ -250,7 +250,7 @@ export default function Integrations() {
           {searchQuery && (
             <button
               onClick={() => handleSearchChange('')}
-              className="absolute right-3 top-1/2 -translate-y-1/2 text-surface-600 hover:text-surface-100"
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-surface-600 hover:text-surface-900"
             >
               <XMarkIcon className="w-5 h-5" />
             </button>
@@ -263,11 +263,11 @@ export default function Integrations() {
           onClick={() => setStatusFilter(statusFilter === 'all' ? 'all' : 'all')}
           className={clsx(
             'card p-4 text-left transition-all',
-            statusFilter === 'all' ? 'ring-2 ring-surface-500' : 'hover:bg-surface-800/50'
+            statusFilter === 'all' ? 'ring-2 ring-surface-500' : 'hover:bg-white/50'
           )}
         >
           <p className="text-sm text-surface-600">Available Integrations</p>
-          <p className="text-2xl font-bold text-surface-100 mt-1">
+          <p className="text-2xl font-bold text-surface-900 mt-1">
             {integrationTypes ? Object.keys(integrationTypes).length : 0}
           </p>
         </button>
@@ -277,7 +277,7 @@ export default function Integrations() {
             'card p-4 text-left transition-all',
             statusFilter === 'configured'
               ? 'ring-2 ring-green-500'
-              : 'hover:bg-surface-800/50 cursor-pointer'
+              : 'hover:bg-white/50 cursor-pointer'
           )}
         >
           <p className="text-sm text-surface-600">Configured</p>
@@ -290,9 +290,7 @@ export default function Integrations() {
           onClick={() => setStatusFilter(statusFilter === 'active' ? 'all' : 'active')}
           className={clsx(
             'card p-4 text-left transition-all',
-            statusFilter === 'active'
-              ? 'ring-2 ring-brand-500'
-              : 'hover:bg-surface-800/50 cursor-pointer'
+            statusFilter === 'active' ? 'ring-2 ring-brand-500' : 'hover:bg-white/50 cursor-pointer'
           )}
         >
           <p className="text-sm text-surface-600">Active</p>
@@ -309,7 +307,7 @@ export default function Integrations() {
             'card p-4 text-left transition-all',
             statusFilter === 'with_evidence'
               ? 'ring-2 ring-purple-500'
-              : 'hover:bg-surface-800/50 cursor-pointer'
+              : 'hover:bg-white/50 cursor-pointer'
           )}
         >
           <p className="text-sm text-surface-600">Evidence Collected</p>
@@ -340,7 +338,7 @@ export default function Integrations() {
           <span className="text-surface-500">({visibleCount} results)</span>
           <button
             onClick={() => setStatusFilter('all')}
-            className="text-surface-600 hover:text-surface-100 ml-2"
+            className="text-surface-600 hover:text-surface-900 ml-2"
           >
             <XMarkIcon className="w-4 h-4" />
           </button>
@@ -349,7 +347,7 @@ export default function Integrations() {
       {/* Integrations by Category */}
       {isLoading ? (
         <div className="flex items-center justify-center py-12">
-          <div className="animate-spin w-8 h-8 border-4 border-surface-700 rounded-full border-t-brand-500"></div>
+          <div className="animate-spin w-8 h-8 border-4 border-surface-200 rounded-full border-t-brand-500"></div>
         </div>
       ) : (
         <div className="space-y-8">
@@ -357,7 +355,7 @@ export default function Integrations() {
             .sort(([catA], [catB]) => catA.localeCompare(catB))
             .map(([category, items]) => (
               <div key={category}>
-                <h2 className="text-lg font-semibold text-surface-200 mb-4 flex items-center gap-2">
+                <h2 className="text-lg font-semibold text-surface-800 mb-4 flex items-center gap-2">
                   {category}
                   <span className="text-sm font-normal text-surface-500">({items.length})</span>
                 </h2>
@@ -379,22 +377,22 @@ export default function Integrations() {
                         className={clsx(
                           'card p-6 transition-colors cursor-pointer',
                           isConfigured
-                            ? 'hover:border-surface-700'
+                            ? 'hover:border-surface-200'
                             : 'hover:border-brand-500/50 opacity-75'
                         )}
                         onClick={() => handleConfigureIntegration(type, integration)}
                       >
                         <div className="flex items-start justify-between mb-4">
                           <div className="flex items-center gap-3">
-                            <div className="p-2 bg-surface-800 rounded-lg flex items-center justify-center">
+                            <div className="p-2 bg-white rounded-lg flex items-center justify-center">
                               <IntegrationIcon
                                 iconSlug={meta.iconSlug || type}
                                 integrationName={meta.name}
-                                className="w-6 h-6 text-surface-100"
+                                className="w-6 h-6 text-surface-900"
                               />
                             </div>
                             <div>
-                              <h3 className="font-semibold text-surface-100">{meta.name}</h3>
+                              <h3 className="font-semibold text-surface-900">{meta.name}</h3>
                               <span className={clsx('text-xs', statusConfig.badge)}>
                                 {statusConfig.label}
                               </span>
@@ -431,7 +429,7 @@ export default function Integrations() {
                         )}
                         {isConfigured ? (
                           <>
-                            <div className="flex items-center justify-between text-xs text-surface-500 pt-4 border-t border-surface-800">
+                            <div className="flex items-center justify-between text-xs text-surface-500 pt-4 border-t border-surface-200">
                               <span>
                                 {integration.lastSyncAt
                                   ? `Last sync: ${new Date(integration.lastSyncAt).toLocaleDateString()}`
@@ -441,7 +439,7 @@ export default function Integrations() {
                             </div>
 
                             {/* Action buttons */}
-                            <div className="flex items-center gap-2 mt-4 pt-4 border-t border-surface-800">
+                            <div className="flex items-center gap-2 mt-4 pt-4 border-t border-surface-200">
                               <Button
                                 onClick={(e) => {
                                   e.stopPropagation();
@@ -459,7 +457,7 @@ export default function Integrations() {
                                   testMutation.mutate(integration.id);
                                 }}
                                 disabled={testMutation.isPending}
-                                className="p-1.5 text-surface-600 hover:text-surface-100 hover:bg-surface-800 rounded transition-colors"
+                                className="p-1.5 text-surface-600 hover:text-surface-900 hover:bg-white rounded transition-colors"
                                 title="Test Connection"
                               >
                                 <ArrowPathIcon
@@ -476,7 +474,7 @@ export default function Integrations() {
                                     syncMutation.mutate(integration.id);
                                   }}
                                   disabled={syncMutation.isPending}
-                                  className="p-1.5 text-surface-600 hover:text-green-600 hover:bg-surface-800 rounded transition-colors"
+                                  className="p-1.5 text-surface-600 hover:text-green-600 hover:bg-white rounded transition-colors"
                                   title="Trigger Sync"
                                 >
                                   <PlayIcon className="w-4 h-4" />
@@ -492,7 +490,7 @@ export default function Integrations() {
                                   }
                                 }}
                                 disabled={deleteMutation.isPending}
-                                className="p-1.5 text-surface-600 hover:text-red-600 hover:bg-surface-800 rounded transition-colors"
+                                className="p-1.5 text-surface-600 hover:text-red-600 hover:bg-white rounded transition-colors"
                                 title="Delete"
                               >
                                 <TrashIcon className="w-4 h-4" />
@@ -500,7 +498,7 @@ export default function Integrations() {
                             </div>
                           </>
                         ) : (
-                          <div className="pt-4 border-t border-surface-800 text-center">
+                          <div className="pt-4 border-t border-surface-200 text-center">
                             <button
                               onClick={(e) => {
                                 e.stopPropagation();

--- a/frontend/src/pages/KnowledgeBase.tsx
+++ b/frontend/src/pages/KnowledgeBase.tsx
@@ -156,7 +156,7 @@ privacy,GDPR Compliance,Are you GDPR compliant?,"We are fully GDPR compliant and
       <div className="space-y-6">
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-3xl font-bold text-surface-100">Knowledge Base</h1>
+            <h1 className="text-3xl font-bold text-surface-900">Knowledge Base</h1>
             <p className="mt-1 text-surface-600">
               Pre-approved answers to common security questions
             </p>
@@ -171,7 +171,7 @@ privacy,GDPR Compliance,Are you GDPR compliant?,"We are fully GDPR compliant and
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold text-surface-100">Knowledge Base</h1>
+          <h1 className="text-3xl font-bold text-surface-900">Knowledge Base</h1>
           <p className="mt-1 text-surface-600">Pre-approved answers to common security questions</p>
         </div>
         <div className="flex gap-2">
@@ -199,13 +199,13 @@ privacy,GDPR Compliance,Are you GDPR compliant?,"We are fully GDPR compliant and
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder="Search knowledge base..."
-            className="w-full pl-10 pr-4 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+            className="w-full pl-10 pr-4 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
           />
         </div>
         <SelectNative
           value={category}
           onChange={(e) => setCategory(e.target.value)}
-          className="px-4 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+          className="px-4 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
         >
           {categories.map((cat) => (
             <option key={cat} value={cat}>
@@ -236,10 +236,10 @@ privacy,GDPR Compliance,Are you GDPR compliant?,"We are fully GDPR compliant and
             <div
               key={entry.id}
               onClick={() => navigate(`/knowledge-base/${entry.id}`)}
-              className="bg-surface-900 border border-surface-800 rounded-lg p-6 hover:bg-surface-800 cursor-pointer transition-colors"
+              className="bg-white border border-surface-200 rounded-lg p-6 hover:bg-white cursor-pointer transition-colors"
             >
               <div className="flex items-start justify-between mb-3">
-                <h3 className="text-lg font-semibold text-surface-100 flex-1">{entry.title}</h3>
+                <h3 className="text-lg font-semibold text-surface-900 flex-1">{entry.title}</h3>
                 <div className="flex gap-2">
                   <span
                     className={`px-2 py-1 text-xs rounded capitalize ${
@@ -258,11 +258,11 @@ privacy,GDPR Compliance,Are you GDPR compliant?,"We are fully GDPR compliant and
                 </div>
               </div>
               <div className="flex items-center gap-2 mb-3">
-                <span className="px-2 py-1 text-xs bg-surface-700 text-surface-700 rounded capitalize">
+                <span className="px-2 py-1 text-xs bg-surface-200 text-surface-700 rounded capitalize">
                   {entry.category}
                 </span>
                 {entry.framework && (
-                  <span className="px-2 py-1 text-xs bg-surface-700 text-surface-700 rounded">
+                  <span className="px-2 py-1 text-xs bg-surface-200 text-surface-700 rounded">
                     {entry.framework}
                   </span>
                 )}
@@ -276,12 +276,12 @@ privacy,GDPR Compliance,Are you GDPR compliant?,"We are fully GDPR compliant and
       {/* Bulk Upload Modal */}
       <Dialog open={showBulkUpload} onClose={() => setShowBulkUpload(false)}>
         <div className="flex items-center justify-between mb-4">
-          <h2 className="text-2xl font-bold text-surface-100">
+          <h2 className="text-2xl font-bold text-surface-900">
             Bulk Upload Knowledge Base Entries
           </h2>
           <button
             onClick={downloadTemplate}
-            className="flex items-center gap-2 px-3 py-1.5 text-sm bg-surface-700 text-surface-200 rounded-lg hover:bg-surface-600 transition-colors"
+            className="flex items-center gap-2 px-3 py-1.5 text-sm bg-surface-200 text-surface-800 rounded-lg hover:bg-surface-600 transition-colors"
           >
             <ArrowDownTrayIcon className="w-4 h-4" />
             Download Template
@@ -294,7 +294,7 @@ privacy,GDPR Compliance,Are you GDPR compliant?,"We are fully GDPR compliant and
 
         <div className="mb-4">
           <label className="block text-sm font-medium text-surface-600 mb-2">CSV File</label>
-          <div className="border-2 border-dashed border-surface-700 rounded-lg p-8 text-center">
+          <div className="border-2 border-dashed border-surface-200 rounded-lg p-8 text-center">
             <input
               type="file"
               accept=".csv"
@@ -315,7 +315,7 @@ privacy,GDPR Compliance,Are you GDPR compliant?,"We are fully GDPR compliant and
           </div>
         </div>
 
-        <div className="mb-4 bg-surface-800 rounded-lg p-4">
+        <div className="mb-4 bg-white rounded-lg p-4">
           <h3 className="text-sm font-medium text-surface-700 mb-2">Example CSV Format:</h3>
           <pre className="text-xs text-surface-600 font-mono overflow-x-auto">
             {`category,title,question,answer,tags,framework,status,isPublic

--- a/frontend/src/pages/KnowledgeBaseDetail.tsx
+++ b/frontend/src/pages/KnowledgeBaseDetail.tsx
@@ -162,11 +162,11 @@ export default function KnowledgeBaseDetail() {
         <div className="flex items-center gap-4">
           <button
             onClick={() => navigate('/knowledge-base')}
-            className="p-2 text-surface-600 hover:text-surface-100 hover:bg-surface-800 rounded-lg transition-colors"
+            className="p-2 text-surface-600 hover:text-surface-900 hover:bg-white rounded-lg transition-colors"
           >
             <ArrowLeftIcon className="w-5 h-5" />
           </button>
-          <h1 className="text-3xl font-bold text-surface-100">
+          <h1 className="text-3xl font-bold text-surface-900">
             {id === 'new'
               ? 'New Knowledge Base Entry'
               : editing
@@ -194,7 +194,7 @@ export default function KnowledgeBaseDetail() {
         )}
       </div>
       {editing ? (
-        <div className="bg-surface-900 border border-surface-800 rounded-lg p-6 space-y-6">
+        <div className="bg-white border border-surface-200 rounded-lg p-6 space-y-6">
           <div>
             <label className="block text-sm font-medium text-surface-600 mb-1">
               Title <span className="text-red-600">*</span>
@@ -203,7 +203,7 @@ export default function KnowledgeBaseDetail() {
               type="text"
               value={formData.title}
               onChange={(e) => setFormData((prev) => ({ ...prev, title: e.target.value }))}
-              className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               placeholder="e.g., Data Encryption at Rest"
             />
           </div>
@@ -215,7 +215,7 @@ export default function KnowledgeBaseDetail() {
               <SelectNative
                 value={formData.category}
                 onChange={(e) => setFormData((prev) => ({ ...prev, category: e.target.value }))}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               >
                 {CATEGORIES.map((cat) => (
                   <option key={cat} value={cat}>
@@ -230,7 +230,7 @@ export default function KnowledgeBaseDetail() {
                 type="text"
                 value={formData.framework || ''}
                 onChange={(e) => setFormData((prev) => ({ ...prev, framework: e.target.value }))}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
                 placeholder="e.g., SOC2, ISO 27001"
               />
             </div>
@@ -241,7 +241,7 @@ export default function KnowledgeBaseDetail() {
               type="text"
               value={formData.question || ''}
               onChange={(e) => setFormData((prev) => ({ ...prev, question: e.target.value }))}
-              className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               placeholder="e.g., Does your platform encrypt data at rest?"
             />
           </div>
@@ -253,7 +253,7 @@ export default function KnowledgeBaseDetail() {
               value={formData.answer}
               onChange={(e) => setFormData((prev) => ({ ...prev, answer: e.target.value }))}
               rows={6}
-              className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               placeholder="Provide a detailed answer..."
             />
           </div>
@@ -270,7 +270,7 @@ export default function KnowledgeBaseDetail() {
                     handleAddTag();
                   }
                 }}
-                className="flex-1 px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="flex-1 px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
                 placeholder="Add a tag and press Enter"
               />
               <button
@@ -286,7 +286,7 @@ export default function KnowledgeBaseDetail() {
                 {formData.tags.map((tag, index) => (
                   <span
                     key={index}
-                    className="inline-flex items-center gap-1 px-2 py-1 text-xs bg-surface-700 text-surface-700 rounded"
+                    className="inline-flex items-center gap-1 px-2 py-1 text-xs bg-surface-200 text-surface-700 rounded"
                   >
                     {tag}
                     <button
@@ -307,7 +307,7 @@ export default function KnowledgeBaseDetail() {
               <SelectNative
                 value={formData.status}
                 onChange={(e) => setFormData((prev) => ({ ...prev, status: e.target.value }))}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               >
                 {STATUSES.map((status) => (
                   <option key={status} value={status}>
@@ -322,13 +322,13 @@ export default function KnowledgeBaseDetail() {
                   type="checkbox"
                   checked={formData.isPublic}
                   onChange={(e) => setFormData((prev) => ({ ...prev, isPublic: e.target.checked }))}
-                  className="w-4 h-4 rounded border-surface-700 bg-surface-800 text-brand-600 focus:ring-brand-500"
+                  className="w-4 h-4 rounded border-surface-200 bg-white text-brand-600 focus:ring-brand-500"
                 />
                 <span className="text-sm text-surface-700">Make publicly visible</span>
               </label>
             </div>
           </div>
-          <div className="flex justify-end gap-2 pt-4 border-t border-surface-800">
+          <div className="flex justify-end gap-2 pt-4 border-t border-surface-200">
             <Button
               variant="secondary"
               onClick={() => {
@@ -352,13 +352,13 @@ export default function KnowledgeBaseDetail() {
           </div>
         </div>
       ) : entry ? (
-        <div className="bg-surface-900 border border-surface-800 rounded-lg p-6 space-y-6">
+        <div className="bg-white border border-surface-200 rounded-lg p-6 space-y-6">
           <div className="flex items-center gap-2">
-            <span className="px-2 py-1 text-xs bg-surface-700 text-surface-700 rounded capitalize">
+            <span className="px-2 py-1 text-xs bg-surface-200 text-surface-700 rounded capitalize">
               {entry.category}
             </span>
             {entry.framework && (
-              <span className="px-2 py-1 text-xs bg-surface-700 text-surface-700 rounded">
+              <span className="px-2 py-1 text-xs bg-surface-200 text-surface-700 rounded">
                 {typeof entry.framework === 'string' ? entry.framework : entry.framework.name}
               </span>
             )}
@@ -371,7 +371,7 @@ export default function KnowledgeBaseDetail() {
               <span className="px-2 py-1 text-xs bg-blue-500/20 text-blue-600 rounded">Public</span>
             )}
             {entry.usageCount !== undefined && (
-              <span className="px-2 py-1 text-xs bg-surface-700 text-surface-600 rounded">
+              <span className="px-2 py-1 text-xs bg-surface-200 text-surface-600 rounded">
                 Used {entry.usageCount} times
               </span>
             )}
@@ -379,12 +379,12 @@ export default function KnowledgeBaseDetail() {
           {entry.question && (
             <div>
               <h3 className="text-sm font-medium text-surface-600 mb-2">Question</h3>
-              <p className="text-surface-100">{entry.question}</p>
+              <p className="text-surface-900">{entry.question}</p>
             </div>
           )}
           <div>
             <h3 className="text-sm font-medium text-surface-600 mb-2">Answer</h3>
-            <div className="text-surface-100 whitespace-pre-wrap">{entry.answer}</div>
+            <div className="text-surface-900 whitespace-pre-wrap">{entry.answer}</div>
           </div>
           {entry.tags && entry.tags.length > 0 && (
             <div>
@@ -393,7 +393,7 @@ export default function KnowledgeBaseDetail() {
                 {entry.tags.map((tag: string, index: number) => (
                   <span
                     key={index}
-                    className="px-2 py-1 text-xs bg-surface-700 text-surface-700 rounded"
+                    className="px-2 py-1 text-xs bg-surface-200 text-surface-700 rounded"
                   >
                     {tag}
                   </span>
@@ -404,7 +404,7 @@ export default function KnowledgeBaseDetail() {
         </div>
       ) : null}
       <Dialog open={showDeleteConfirm} onClose={() => setShowDeleteConfirm(false)}>
-        <h3 className="text-lg font-semibold text-surface-100 mb-2">Delete Knowledge Base Entry</h3>
+        <h3 className="text-lg font-semibold text-surface-900 mb-2">Delete Knowledge Base Entry</h3>
         <p className="text-surface-600 mb-6">
           Are you sure you want to delete "{entry?.title}"? This action cannot be undone.
         </p>

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -42,8 +42,8 @@ export default function Login() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-surface-950">
-        <div className="animate-spin w-8 h-8 border-4 border-surface-700 rounded-full border-t-brand-500"></div>
+      <div className="min-h-screen flex items-center justify-center bg-surface-50">
+        <div className="animate-spin w-8 h-8 border-4 border-surface-200 rounded-full border-t-brand-500"></div>
       </div>
     );
   }
@@ -51,7 +51,7 @@ export default function Login() {
   const isDev = import.meta.env.DEV || import.meta.env.VITE_ENABLE_DEV_AUTH === 'true';
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-surface-950 px-4">
+    <div className="min-h-screen flex flex-col items-center justify-center bg-surface-50 px-4">
       {/* Background gradient */}
       <div className="absolute inset-0 overflow-hidden">
         <div className="absolute -top-40 -right-40 w-80 h-80 bg-brand-600/20 rounded-full blur-3xl"></div>
@@ -61,7 +61,7 @@ export default function Login() {
         {/* Logo */}
         <div className="flex flex-col items-center mb-8">
           <img src={branding.logoUrl} alt="Logo" className="w-16 h-16 object-contain mb-4" />
-          <h1 className="text-3xl font-bold text-surface-100">{branding.platformName}</h1>
+          <h1 className="text-3xl font-bold text-surface-900">{branding.platformName}</h1>
           <p className="text-surface-600 mt-2">Governance, Risk, and Compliance Platform</p>
         </div>
 
@@ -74,7 +74,7 @@ export default function Login() {
 
         {/* Login card */}
         <div className="card p-8">
-          <h2 className="text-xl font-semibold text-surface-100 text-center mb-2">Welcome Back</h2>
+          <h2 className="text-xl font-semibold text-surface-900 text-center mb-2">Welcome Back</h2>
           <p className="text-surface-600 text-center mb-8">
             Sign in to access your compliance dashboard
           </p>
@@ -88,10 +88,10 @@ export default function Login() {
             <>
               <div className="relative my-6">
                 <div className="absolute inset-0 flex items-center">
-                  <div className="w-full border-t border-surface-700"></div>
+                  <div className="w-full border-t border-surface-200"></div>
                 </div>
                 <div className="relative flex justify-center text-sm">
-                  <span className="px-2 bg-surface-800 text-surface-500">Development Only</span>
+                  <span className="px-2 bg-white text-surface-500">Development Only</span>
                 </div>
               </div>
               <button

--- a/frontend/src/pages/MCPSettings.tsx
+++ b/frontend/src/pages/MCPSettings.tsx
@@ -166,7 +166,7 @@ export default function MCPSettings() {
       </div>
       {/* Server Stats */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-        <div className="bg-white dark:bg-surface-800 rounded-lg p-4 border border-gray-200 dark:border-surface-700">
+        <div className="bg-white dark:bg-white rounded-lg p-4 border border-gray-200 dark:border-surface-200">
           <div className="flex items-center gap-3">
             <div className="p-2 bg-brand-100 dark:bg-brand-900/30 rounded-lg">
               <CpuChipIcon className="w-6 h-6 text-brand-600 dark:text-brand-400" />
@@ -177,7 +177,7 @@ export default function MCPSettings() {
             </div>
           </div>
         </div>
-        <div className="bg-white dark:bg-surface-800 rounded-lg p-4 border border-gray-200 dark:border-surface-700">
+        <div className="bg-white dark:bg-white rounded-lg p-4 border border-gray-200 dark:border-surface-200">
           <div className="flex items-center gap-3">
             <div className="p-2 bg-green-100 dark:bg-green-900/30 rounded-lg">
               <CheckCircleIcon className="w-6 h-6 text-green-600 dark:text-green-600" />
@@ -190,7 +190,7 @@ export default function MCPSettings() {
             </div>
           </div>
         </div>
-        <div className="bg-white dark:bg-surface-800 rounded-lg p-4 border border-gray-200 dark:border-surface-700">
+        <div className="bg-white dark:bg-white rounded-lg p-4 border border-gray-200 dark:border-surface-200">
           <div className="flex items-center gap-3">
             <div className="p-2 bg-red-100 dark:bg-red-900/30 rounded-lg">
               <ExclamationCircleIcon className="w-6 h-6 text-red-600 dark:text-red-600" />
@@ -203,7 +203,7 @@ export default function MCPSettings() {
             </div>
           </div>
         </div>
-        <div className="bg-white dark:bg-surface-800 rounded-lg p-4 border border-gray-200 dark:border-surface-700">
+        <div className="bg-white dark:bg-white rounded-lg p-4 border border-gray-200 dark:border-surface-200">
           <div className="flex items-center gap-3">
             <div className="p-2 bg-purple-100 dark:bg-purple-900/30 rounded-lg">
               <Cog6ToothIcon className="w-6 h-6 text-purple-600 dark:text-purple-600" />
@@ -218,8 +218,8 @@ export default function MCPSettings() {
         </div>
       </div>
       {/* Server List */}
-      <div className="bg-white dark:bg-surface-800 rounded-lg border border-gray-200 dark:border-surface-700">
-        <div className="p-4 border-b border-gray-200 dark:border-surface-700">
+      <div className="bg-white dark:bg-white rounded-lg border border-gray-200 dark:border-surface-200">
+        <div className="p-4 border-b border-gray-200 dark:border-surface-200">
           <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
             Registered Servers
           </h2>
@@ -239,11 +239,11 @@ export default function MCPSettings() {
             </Button>
           </div>
         ) : (
-          <div className="divide-y divide-gray-200 dark:divide-surface-700">
+          <div className="divide-y divide-gray-200 dark:divide-surface-200">
             {servers.map((server) => (
               <div
                 key={server.id}
-                className="p-4 hover:bg-gray-50 dark:hover:bg-surface-700/50 cursor-pointer"
+                className="p-4 hover:bg-gray-50 dark:hover:bg-surface-200/50 cursor-pointer"
                 onClick={() => setSelectedServer(server)}
               >
                 <div className="flex items-center justify-between">
@@ -307,7 +307,7 @@ export default function MCPSettings() {
       </div>
       {/* Add Server Modal */}
       <Dialog open={showAddModal} onClose={() => setShowAddModal(false)}>
-        <div className="p-4 border-b border-gray-200 dark:border-surface-700 flex justify-between items-center">
+        <div className="p-4 border-b border-gray-200 dark:border-surface-200 flex justify-between items-center">
           <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
             {selectedTemplate ? `Configure ${selectedTemplate.name}` : 'Add MCP Server'}
           </h2>
@@ -330,7 +330,7 @@ export default function MCPSettings() {
                 <div
                   key={template.id}
                   onClick={() => setSelectedTemplate(template)}
-                  className="p-4 border border-gray-200 dark:border-surface-700 rounded-lg hover:border-brand-500 dark:hover:border-brand-500 cursor-pointer transition-colors"
+                  className="p-4 border border-gray-200 dark:border-surface-200 rounded-lg hover:border-brand-500 dark:hover:border-brand-500 cursor-pointer transition-colors"
                 >
                   <h3 className="font-medium text-gray-900 dark:text-white">{template.name}</h3>
                   <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
@@ -340,7 +340,7 @@ export default function MCPSettings() {
                     {template.capabilities.map((cap) => (
                       <span
                         key={cap}
-                        className="px-2 py-0.5 text-xs bg-gray-100 dark:bg-surface-700 text-gray-600 dark:text-gray-400 rounded"
+                        className="px-2 py-0.5 text-xs bg-gray-100 dark:bg-surface-200 text-gray-600 dark:text-gray-400 rounded"
                       >
                         {cap}
                       </span>
@@ -376,7 +376,7 @@ export default function MCPSettings() {
                         type="password"
                         value={envVars[envVar] || ''}
                         onChange={(e) => setEnvVars({ ...envVars, [envVar]: e.target.value })}
-                        className="w-full px-3 py-2 border border-gray-300 dark:border-surface-600 rounded-lg bg-white dark:bg-surface-700 text-gray-900 dark:text-white"
+                        className="w-full px-3 py-2 border border-gray-300 dark:border-surface-300 rounded-lg bg-white dark:bg-surface-200 text-gray-900 dark:text-white"
                         placeholder={`Enter ${envVar}`}
                       />
                     </div>
@@ -401,9 +401,9 @@ export default function MCPSettings() {
                       {selectedTemplate.configGroups.map((group) => (
                         <details
                           key={group.name}
-                          className="border border-gray-200 dark:border-surface-700 rounded-lg"
+                          className="border border-gray-200 dark:border-surface-200 rounded-lg"
                         >
-                          <summary className="px-4 py-3 cursor-pointer font-medium text-gray-900 dark:text-white bg-gray-50 dark:bg-surface-700/50 rounded-t-lg">
+                          <summary className="px-4 py-3 cursor-pointer font-medium text-gray-900 dark:text-white bg-gray-50 dark:bg-surface-200/50 rounded-t-lg">
                             {group.name}
                             {group.keys.some((k) => envVars[k]) && (
                               <span className="ml-2 text-xs text-green-600 dark:text-green-600">
@@ -438,7 +438,7 @@ export default function MCPSettings() {
                                     onChange={(e) =>
                                       setEnvVars({ ...envVars, [key]: e.target.value })
                                     }
-                                    className="w-full px-3 py-2 border border-gray-300 dark:border-surface-600 rounded-lg bg-white dark:bg-surface-700 text-gray-900 dark:text-white"
+                                    className="w-full px-3 py-2 border border-gray-300 dark:border-surface-300 rounded-lg bg-white dark:bg-surface-200 text-gray-900 dark:text-white"
                                     placeholder={envDef.description}
                                   />
                                 </div>
@@ -472,7 +472,7 @@ export default function MCPSettings() {
                             onChange={(e) =>
                               setEnvVars({ ...envVars, [envDef.key]: e.target.value })
                             }
-                            className="w-full px-3 py-2 border border-gray-300 dark:border-surface-600 rounded-lg bg-white dark:bg-surface-700 text-gray-900 dark:text-white"
+                            className="w-full px-3 py-2 border border-gray-300 dark:border-surface-300 rounded-lg bg-white dark:bg-surface-200 text-gray-900 dark:text-white"
                             placeholder={envDef.description}
                           />
                         </div>
@@ -482,7 +482,7 @@ export default function MCPSettings() {
                 </div>
               )}
 
-              <div className="flex justify-end gap-2 pt-4 border-t border-gray-200 dark:border-surface-700">
+              <div className="flex justify-end gap-2 pt-4 border-t border-gray-200 dark:border-surface-200">
                 <Button onClick={() => setSelectedTemplate(null)} variant="secondary">
                   Back
                 </Button>
@@ -511,7 +511,7 @@ export default function MCPSettings() {
       {/* Server Details Modal */}
       {selectedServer && (
         <Dialog open onClose={() => setSelectedServer(null)}>
-          <div className="p-4 border-b border-gray-200 dark:border-surface-700 flex justify-between items-center">
+          <div className="p-4 border-b border-gray-200 dark:border-surface-200 flex justify-between items-center">
             <div className="flex items-center gap-3">
               {getStatusIcon(selectedServer.status)}
               <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
@@ -534,7 +534,7 @@ export default function MCPSettings() {
                 <CpuChipIcon className="w-5 h-5" />
                 Server Information
               </h3>
-              <div className="grid grid-cols-2 gap-4 p-4 bg-gray-50 dark:bg-surface-700/50 rounded-lg">
+              <div className="grid grid-cols-2 gap-4 p-4 bg-gray-50 dark:bg-surface-200/50 rounded-lg">
                 <div>
                   <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">
                     Server ID
@@ -603,7 +603,7 @@ export default function MCPSettings() {
                   (for audit purposes)
                 </span>
               </h3>
-              <div className="p-4 bg-gray-50 dark:bg-surface-700/50 rounded-lg space-y-4">
+              <div className="p-4 bg-gray-50 dark:bg-surface-200/50 rounded-lg space-y-4">
                 {/* Configured Integrations */}
                 <div>
                   <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2">
@@ -667,7 +667,7 @@ export default function MCPSettings() {
                 )}
 
                 {/* Credential Status - Masked for security */}
-                <div className="border-t border-gray-200 dark:border-surface-600 pt-4">
+                <div className="border-t border-gray-200 dark:border-surface-300 pt-4">
                   <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2">
                     Credential Configuration Status
                   </p>
@@ -695,7 +695,7 @@ export default function MCPSettings() {
                           className={`flex items-center gap-2 p-2 rounded text-sm ${
                             isConfigured
                               ? 'bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-600'
-                              : 'bg-gray-100 dark:bg-surface-700 text-gray-500 dark:text-gray-400'
+                              : 'bg-gray-100 dark:bg-surface-200 text-gray-500 dark:text-gray-400'
                           }`}
                         >
                           {isConfigured ? (
@@ -732,7 +732,7 @@ export default function MCPSettings() {
                       {selectedServer.capabilities.tools.map((tool) => (
                         <div
                           key={tool.name}
-                          className="p-3 bg-gray-50 dark:bg-surface-700 rounded-lg"
+                          className="p-3 bg-gray-50 dark:bg-surface-200 rounded-lg"
                         >
                           <p className="font-medium text-gray-900 dark:text-white">{tool.name}</p>
                           {tool.description && (
@@ -756,7 +756,7 @@ export default function MCPSettings() {
                       {selectedServer.capabilities.resources.map((resource) => (
                         <div
                           key={resource.uri}
-                          className="p-3 bg-gray-50 dark:bg-surface-700 rounded-lg"
+                          className="p-3 bg-gray-50 dark:bg-surface-200 rounded-lg"
                         >
                           <p className="font-medium text-gray-900 dark:text-white">
                             {resource.name}
@@ -780,7 +780,7 @@ export default function MCPSettings() {
                       {selectedServer.capabilities.prompts.map((prompt) => (
                         <div
                           key={prompt.name}
-                          className="p-3 bg-gray-50 dark:bg-surface-700 rounded-lg"
+                          className="p-3 bg-gray-50 dark:bg-surface-200 rounded-lg"
                         >
                           <p className="font-medium text-gray-900 dark:text-white">{prompt.name}</p>
                           {prompt.description && (
@@ -797,7 +797,7 @@ export default function MCPSettings() {
             )}
 
             {/* Audit Trail Footer */}
-            <div className="border-t border-gray-200 dark:border-surface-700 pt-4">
+            <div className="border-t border-gray-200 dark:border-surface-200 pt-4">
               <p className="text-xs text-gray-500 dark:text-gray-400">
                 This configuration information is logged for audit purposes. Changes to server
                 configuration are tracked in the Audit Log.

--- a/frontend/src/pages/MappingGaps.tsx
+++ b/frontend/src/pages/MappingGaps.tsx
@@ -224,7 +224,7 @@ export default function MappingGaps() {
   return (
     <div className="p-6 space-y-6">
       <header>
-        <h1 className="text-2xl font-semibold text-surface-100">Mapping Gap Analysis</h1>
+        <h1 className="text-2xl font-semibold text-surface-900">Mapping Gap Analysis</h1>
         <p className="text-sm text-surface-600 mt-1">
           Find requirements without coverage and controls that are not mapped to any requirement.
         </p>
@@ -275,7 +275,7 @@ export default function MappingGaps() {
         </div>
       </div>
       <div className="card overflow-hidden">
-        <div className="border-b border-surface-700 px-4">
+        <div className="border-b border-surface-200 px-4">
           <nav className="flex flex-wrap gap-6" aria-label="Tabs" role="tablist">
             {TABS.map((tab) => (
               <button
@@ -288,7 +288,7 @@ export default function MappingGaps() {
                   'py-3 px-1 border-b-2 font-medium text-sm transition-colors',
                   activeTab === tab.key
                     ? 'border-brand-500 text-brand-400'
-                    : 'border-transparent text-surface-600 hover:text-surface-200 hover:border-surface-600'
+                    : 'border-transparent text-surface-600 hover:text-surface-800 hover:border-surface-300'
                 )}
               >
                 {tab.label}
@@ -301,7 +301,7 @@ export default function MappingGaps() {
           {gapsQuery.isLoading ? (
             <div className="space-y-2" role="status" aria-label="Loading gaps">
               {Array.from({ length: 5 }).map((_, i) => (
-                <div key={i} className="h-10 bg-surface-800 rounded animate-pulse" />
+                <div key={i} className="h-10 bg-white rounded animate-pulse" />
               ))}
             </div>
           ) : gapsQuery.isError ? (
@@ -321,7 +321,7 @@ export default function MappingGaps() {
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
                 <thead>
-                  <tr className="text-left text-surface-600 border-b border-surface-700">
+                  <tr className="text-left text-surface-600 border-b border-surface-200">
                     {showTypeColumn && <th className="py-2 px-3 font-medium">Type</th>}
                     {showFrameworkColumn && <th className="py-2 px-3 font-medium">Framework</th>}
                     <th className="py-2 px-3 font-medium">
@@ -341,10 +341,7 @@ export default function MappingGaps() {
                         ? `/controls/${row.control.id}`
                         : '#';
                     return (
-                      <tr
-                        key={row.id}
-                        className="border-b border-surface-800 hover:bg-surface-800/50"
-                      >
+                      <tr key={row.id} className="border-b border-surface-200 hover:bg-white/50">
                         {showTypeColumn && (
                           <td className="py-2 px-3 text-surface-700">{TYPE_LABEL[row.type]}</td>
                         )}
@@ -363,7 +360,7 @@ export default function MappingGaps() {
                             {row.requirement ? 'Requirement' : row.control ? 'Control' : '—'}
                           </td>
                         )}
-                        <td className="py-2 px-3 text-surface-200">
+                        <td className="py-2 px-3 text-surface-800">
                           {row.requirement?.title ?? row.control?.title ?? '—'}
                         </td>
                       </tr>

--- a/frontend/src/pages/PermissionGroups.tsx
+++ b/frontend/src/pages/PermissionGroups.tsx
@@ -83,7 +83,7 @@ export default function PermissionGroups() {
         <div className="flex gap-2">
           <button
             onClick={() => seedMutation.mutate()}
-            className="px-4 py-2 bg-surface-700 text-white rounded-lg hover:bg-surface-600 transition-colors"
+            className="px-4 py-2 bg-surface-200 text-white rounded-lg hover:bg-surface-600 transition-colors"
           >
             Seed Defaults
           </button>
@@ -117,7 +117,7 @@ export default function PermissionGroups() {
       ) : (
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
           {groups?.map((group: PermissionGroup) => (
-            <div key={group.id} className="bg-surface-800 rounded-lg border border-surface-700 p-5">
+            <div key={group.id} className="bg-white rounded-lg border border-surface-200 p-5">
               <div className="flex items-start justify-between mb-4">
                 <div>
                   <div className="flex items-center gap-2">
@@ -133,14 +133,14 @@ export default function PermissionGroups() {
                 <div className="flex items-center gap-1">
                   <button
                     onClick={() => setShowMembersModal(group)}
-                    className="p-2 text-surface-600 hover:text-white hover:bg-surface-700 rounded-lg"
+                    className="p-2 text-surface-600 hover:text-white hover:bg-surface-200 rounded-lg"
                     title="View Members"
                   >
                     <UserGroupIcon className="w-5 h-5" />
                   </button>
                   <button
                     onClick={() => setEditingGroup(group)}
-                    className="p-2 text-surface-600 hover:text-white hover:bg-surface-700 rounded-lg"
+                    className="p-2 text-surface-600 hover:text-white hover:bg-surface-200 rounded-lg"
                     title="Edit Group"
                   >
                     <PencilSquareIcon className="w-5 h-5" />
@@ -152,7 +152,7 @@ export default function PermissionGroups() {
                           deleteMutation.mutate(group.id);
                         }
                       }}
-                      className="p-2 text-surface-600 hover:text-red-600 hover:bg-surface-700 rounded-lg"
+                      className="p-2 text-surface-600 hover:text-red-600 hover:bg-surface-200 rounded-lg"
                       title="Delete Group"
                     >
                       <TrashIcon className="w-5 h-5" />
@@ -168,7 +168,7 @@ export default function PermissionGroups() {
                   {group.permissions.slice(0, 6).map((perm, idx) => (
                     <span
                       key={idx}
-                      className="px-2 py-1 bg-surface-700 rounded text-xs text-surface-200"
+                      className="px-2 py-1 bg-surface-200 rounded text-xs text-surface-800"
                     >
                       {perm.resource}: {perm.actions.length} actions
                     </span>
@@ -181,7 +181,7 @@ export default function PermissionGroups() {
                 </div>
               </div>
 
-              <div className="mt-4 pt-4 border-t border-surface-700 flex items-center justify-between text-sm text-surface-600">
+              <div className="mt-4 pt-4 border-t border-surface-200 flex items-center justify-between text-sm text-surface-600">
                 <span>
                   {group.memberCount} member{group.memberCount !== 1 ? 's' : ''}
                 </span>
@@ -287,7 +287,7 @@ function PermissionGroupModal({
 
   return (
     <Dialog open onClose={onClose}>
-      <div className="p-4 border-b border-surface-700 flex items-center justify-between">
+      <div className="p-4 border-b border-surface-200 flex items-center justify-between">
         <h2 className="text-lg font-semibold text-white">
           {group ? 'Edit Permission Group' : 'Create Permission Group'}
         </h2>
@@ -305,7 +305,7 @@ function PermissionGroupModal({
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              className="w-full bg-surface-900 border border-surface-600 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+              className="w-full bg-white border border-surface-300 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
               placeholder="e.g., Compliance Manager"
             />
           </div>
@@ -315,7 +315,7 @@ function PermissionGroupModal({
               type="text"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
-              className="w-full bg-surface-900 border border-surface-600 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+              className="w-full bg-white border border-surface-300 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
               placeholder="Brief description of this role"
             />
           </div>
@@ -324,10 +324,10 @@ function PermissionGroupModal({
         {/* Permission Matrix */}
         <div>
           <label className="block text-sm text-surface-600 mb-3">Permission Matrix</label>
-          <div className="bg-surface-900 rounded-lg border border-surface-700 overflow-hidden">
+          <div className="bg-white rounded-lg border border-surface-200 overflow-hidden">
             <table className="w-full">
               <thead>
-                <tr className="bg-surface-800">
+                <tr className="bg-white">
                   <th className="text-left text-surface-600 font-medium px-4 py-3 w-48">
                     Resource
                   </th>
@@ -344,12 +344,12 @@ function PermissionGroupModal({
                   </th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-surface-700">
+              <tbody className="divide-y divide-surface-200">
                 {RESOURCES.map((resource) => {
                   const currentActions = permissions[resource.id] || [];
                   const allSelected = currentActions.length === ACTIONS.length;
                   return (
-                    <tr key={resource.id} className="hover:bg-surface-800/50">
+                    <tr key={resource.id} className="hover:bg-white/50">
                       <td className="px-4 py-3">
                         <div className="text-white text-sm font-medium">{resource.label}</div>
                         <div className="text-surface-500 text-xs">{resource.description}</div>
@@ -361,7 +361,7 @@ function PermissionGroupModal({
                             className={`w-6 h-6 rounded border-2 flex items-center justify-center transition-colors ${
                               currentActions.includes(action)
                                 ? 'bg-brand-500 border-brand-500'
-                                : 'border-surface-600 hover:border-surface-500'
+                                : 'border-surface-300 hover:border-surface-500'
                             }`}
                           >
                             {currentActions.includes(action) && (
@@ -376,7 +376,7 @@ function PermissionGroupModal({
                           className={`w-6 h-6 rounded border-2 flex items-center justify-center transition-colors ${
                             allSelected
                               ? 'bg-emerald-500 border-emerald-500'
-                              : 'border-surface-600 hover:border-surface-500'
+                              : 'border-surface-300 hover:border-surface-500'
                           }`}
                         >
                           {allSelected && <CheckIcon className="w-4 h-4 text-white" />}
@@ -391,10 +391,10 @@ function PermissionGroupModal({
         </div>
       </div>
 
-      <div className="p-4 border-t border-surface-700 flex justify-end gap-3">
+      <div className="p-4 border-t border-surface-200 flex justify-end gap-3">
         <button
           onClick={onClose}
-          className="px-4 py-2 bg-surface-700 text-white rounded-lg hover:bg-surface-600 transition-colors"
+          className="px-4 py-2 bg-surface-200 text-white rounded-lg hover:bg-surface-600 transition-colors"
         >
           Cancel
         </button>
@@ -418,7 +418,7 @@ function GroupMembersModal({ group, onClose }: { group: PermissionGroup; onClose
 
   return (
     <Dialog open onClose={onClose}>
-      <div className="p-4 border-b border-surface-700 flex items-center justify-between">
+      <div className="p-4 border-b border-surface-200 flex items-center justify-between">
         <h2 className="text-lg font-semibold text-white">Members of {group.name}</h2>
         <button onClick={onClose} className="p-1 text-surface-600 hover:text-white">
           <XMarkIcon className="w-5 h-5" />
@@ -434,7 +434,7 @@ function GroupMembersModal({ group, onClose }: { group: PermissionGroup; onClose
             {members?.map((member: any) => (
               <div
                 key={member.id}
-                className="flex items-center gap-3 p-3 bg-surface-700 rounded-lg"
+                className="flex items-center gap-3 p-3 bg-surface-200 rounded-lg"
               >
                 <div className="w-10 h-10 rounded-full bg-brand-500/20 flex items-center justify-center text-brand-400 font-medium">
                   {member.displayName.charAt(0).toUpperCase()}

--- a/frontend/src/pages/Policies.tsx
+++ b/frontend/src/pages/Policies.tsx
@@ -66,7 +66,7 @@ export default function Policies() {
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-bold text-surface-100">Policy Center</h1>
+          <h1 className="text-2xl font-bold text-surface-900">Policy Center</h1>
           <p className="text-surface-600 mt-1">
             Manage your organization's policies and track review cycles
           </p>
@@ -88,7 +88,7 @@ export default function Policies() {
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <div className="card p-4">
           <p className="text-sm text-surface-600">Total Policies</p>
-          <p className="text-2xl font-bold text-surface-100 mt-1">{stats?.total || 0}</p>
+          <p className="text-2xl font-bold text-surface-900 mt-1">{stats?.total || 0}</p>
         </div>
         <div className="card p-4">
           <p className="text-sm text-surface-600">Approved</p>
@@ -150,10 +150,10 @@ export default function Policies() {
                           to={`/policies/${policy.id}`}
                           className="flex items-center gap-3 hover:text-brand-400"
                         >
-                          <div className="p-2 bg-surface-800 rounded-lg">
+                          <div className="p-2 bg-white rounded-lg">
                             <DocumentTextIcon className="w-5 h-5 text-surface-600" />
                           </div>
-                          <span className="font-medium text-surface-100">{policy.title}</span>
+                          <span className="font-medium text-surface-900">{policy.title}</span>
                         </Link>
                       </td>
                       <td>
@@ -261,8 +261,8 @@ function UploadPolicyModal({ onClose, onSuccess }: { onClose: () => void; onSucc
   return (
     <Dialog open onClose={onClose}>
       <div className="flex items-center justify-between mb-6">
-        <h2 className="text-lg font-semibold text-surface-100">Upload Policy</h2>
-        <button onClick={onClose} className="text-surface-600 hover:text-surface-100">
+        <h2 className="text-lg font-semibold text-surface-900">Upload Policy</h2>
+        <button onClick={onClose} className="text-surface-600 hover:text-surface-900">
           <XMarkIcon className="w-5 h-5" />
         </button>
       </div>
@@ -272,7 +272,7 @@ function UploadPolicyModal({ onClose, onSuccess }: { onClose: () => void; onSucc
         <div
           className={clsx(
             'border-2 border-dashed rounded-lg p-8 text-center transition-colors',
-            isDragging ? 'border-brand-500 bg-brand-500/10' : 'border-surface-700',
+            isDragging ? 'border-brand-500 bg-brand-500/10' : 'border-surface-200',
             file && 'border-green-500 bg-green-500/10'
           )}
           onDragOver={(e) => {
@@ -286,7 +286,7 @@ function UploadPolicyModal({ onClose, onSuccess }: { onClose: () => void; onSucc
             <div className="flex items-center justify-center gap-3">
               <DocumentTextIcon className="w-8 h-8 text-green-600" />
               <div className="text-left">
-                <p className="text-surface-100 font-medium">{file.name}</p>
+                <p className="text-surface-900 font-medium">{file.name}</p>
                 <p className="text-surface-500 text-sm">
                   {(file.size / 1024 / 1024).toFixed(2)} MB
                 </p>

--- a/frontend/src/pages/PolicyDetail.tsx
+++ b/frontend/src/pages/PolicyDetail.tsx
@@ -163,18 +163,18 @@ export default function PolicyDetail() {
       <div>
         <Link
           to="/policies"
-          className="inline-flex items-center text-sm text-surface-600 hover:text-surface-100 mb-4"
+          className="inline-flex items-center text-sm text-surface-600 hover:text-surface-900 mb-4"
         >
           <ArrowLeftIcon className="w-4 h-4 mr-1" />
           Back to Policies
         </Link>
         <div className="flex items-start justify-between">
           <div className="flex items-start gap-4">
-            <div className="p-3 bg-surface-800 rounded-xl">
+            <div className="p-3 bg-white rounded-xl">
               <DocumentTextIcon className="w-8 h-8 text-brand-400" />
             </div>
             <div>
-              <h1 className="text-2xl font-bold text-surface-100">{policy.title}</h1>
+              <h1 className="text-2xl font-bold text-surface-900">{policy.title}</h1>
               <p className="text-surface-600 mt-1">{policy.description || 'No description'}</p>
               <div className="flex items-center gap-3 mt-3">
                 <span className={clsx('', statusConfig.color)}>{statusConfig.label}</span>
@@ -221,8 +221,8 @@ export default function PolicyDetail() {
         <div className="lg:col-span-2 space-y-6">
           {/* Preview */}
           <div className="card p-6">
-            <h2 className="text-lg font-semibold text-surface-100 mb-4">Preview</h2>
-            <div className="border border-surface-800 rounded-lg overflow-hidden bg-surface-950">
+            <h2 className="text-lg font-semibold text-surface-900 mb-4">Preview</h2>
+            <div className="border border-surface-200 rounded-lg overflow-hidden bg-surface-50">
               {previewError ? (
                 <div className="flex flex-col items-center justify-center py-16 text-surface-500">
                   <DocumentTextIcon className="w-16 h-16 mb-4" />
@@ -265,7 +265,7 @@ export default function PolicyDetail() {
 
           {/* Version History */}
           <div className="card p-6">
-            <h2 className="text-lg font-semibold text-surface-100 mb-4">Version History</h2>
+            <h2 className="text-lg font-semibold text-surface-900 mb-4">Version History</h2>
             {(policy?.versions?.length ?? 0) > 0 ? (
               <div className="space-y-3">
                 {policy?.versions?.map((version: any, index: number) => (
@@ -273,12 +273,12 @@ export default function PolicyDetail() {
                     key={version.id}
                     className={clsx(
                       'flex items-center justify-between p-3 rounded-lg',
-                      index === 0 ? 'bg-brand-500/10 border border-brand-500/30' : 'bg-surface-800'
+                      index === 0 ? 'bg-brand-500/10 border border-brand-500/30' : 'bg-white'
                     )}
                   >
                     <div>
                       <div className="flex items-center gap-2">
-                        <span className="font-mono text-surface-200">v{version.version}</span>
+                        <span className="font-mono text-surface-800">v{version.version}</span>
                         {index === 0 && (
                           <Badge className="text-xs" variant="info">
                             Current
@@ -303,7 +303,7 @@ export default function PolicyDetail() {
           {/* History Tabs */}
           <div className="card overflow-hidden">
             {/* Tab Navigation */}
-            <div className="border-b border-surface-700 px-4">
+            <div className="border-b border-surface-200 px-4">
               <nav className="flex gap-6" aria-label="History Tabs">
                 <button
                   onClick={() => setActiveTab('status')}
@@ -311,7 +311,7 @@ export default function PolicyDetail() {
                     'py-3 px-1 border-b-2 font-medium text-sm transition-colors flex items-center gap-2',
                     activeTab === 'status'
                       ? 'border-brand-500 text-brand-400'
-                      : 'border-transparent text-surface-600 hover:text-surface-200 hover:border-surface-600'
+                      : 'border-transparent text-surface-600 hover:text-surface-800 hover:border-surface-300'
                   )}
                 >
                   <ChatBubbleLeftRightIcon className="w-4 h-4" />
@@ -323,7 +323,7 @@ export default function PolicyDetail() {
                     'py-3 px-1 border-b-2 font-medium text-sm transition-colors flex items-center gap-2',
                     activeTab === 'history'
                       ? 'border-brand-500 text-brand-400'
-                      : 'border-transparent text-surface-600 hover:text-surface-200 hover:border-surface-600'
+                      : 'border-transparent text-surface-600 hover:text-surface-800 hover:border-surface-300'
                   )}
                 >
                   <ClockIcon className="w-4 h-4" />
@@ -342,7 +342,7 @@ export default function PolicyDetail() {
                   {(policy?.statusHistory?.length ?? 0) > 0 ? (
                     <div className="relative">
                       {/* Timeline line */}
-                      <div className="absolute left-4 top-2 bottom-2 w-0.5 bg-surface-700" />
+                      <div className="absolute left-4 top-2 bottom-2 w-0.5 bg-surface-200" />
 
                       <div className="space-y-4">
                         {policy?.statusHistory?.map((entry: any, index: number) => (
@@ -381,7 +381,7 @@ export default function PolicyDetail() {
                               </div>
 
                               <div className="mt-2 text-sm">
-                                <span className="text-surface-200 font-medium">
+                                <span className="text-surface-800 font-medium">
                                   {entry.changedByName || entry.changedBy?.displayName || 'Unknown'}
                                 </span>
                                 <span className="text-surface-500 ml-2">
@@ -411,7 +411,7 @@ export default function PolicyDetail() {
           {/* Linked Controls (Policy as Evidence) */}
           <div className="card p-6">
             <div className="flex items-center justify-between mb-4">
-              <h2 className="text-lg font-semibold text-surface-100">Linked Controls</h2>
+              <h2 className="text-lg font-semibold text-surface-900">Linked Controls</h2>
               {canEdit && (
                 <Button
                   onClick={() => setIsLinkControlOpen(true)}
@@ -431,7 +431,7 @@ export default function PolicyDetail() {
                 {policy?.controlLinks?.map((link: any) => (
                   <div
                     key={link.id}
-                    className="flex items-center justify-between p-3 bg-surface-800 rounded-lg group"
+                    className="flex items-center justify-between p-3 bg-white rounded-lg group"
                   >
                     <Link
                       to={`/controls/${link.control?.id}`}
@@ -442,7 +442,7 @@ export default function PolicyDetail() {
                         <p className="font-mono text-sm text-brand-400">
                           {link.control?.controlId}
                         </p>
-                        <p className="text-sm text-surface-200">{link.control?.title}</p>
+                        <p className="text-sm text-surface-800">{link.control?.title}</p>
                       </div>
                     </Link>
                     {canEdit && (
@@ -468,7 +468,7 @@ export default function PolicyDetail() {
           {/* Status Actions */}
           {canEdit && statusConfig.next && statusConfig.next.length > 0 && (
             <div className="card p-6">
-              <h3 className="text-sm font-semibold text-surface-100 mb-4">Workflow Actions</h3>
+              <h3 className="text-sm font-semibold text-surface-900 mb-4">Workflow Actions</h3>
               <div className="space-y-2">
                 {statusConfig.next.map((nextStatus) => {
                   const nextConfig = STATUS_CONFIG[nextStatus];
@@ -492,13 +492,13 @@ export default function PolicyDetail() {
 
           {/* Details */}
           <div className="card p-6">
-            <h3 className="text-sm font-semibold text-surface-100 mb-4">Details</h3>
+            <h3 className="text-sm font-semibold text-surface-900 mb-4">Details</h3>
             <dl className="space-y-4">
               <div className="flex items-start gap-3">
                 <UserIcon className="w-5 h-5 text-surface-500 mt-0.5" />
                 <div>
                   <dt className="text-xs text-surface-500">Owner</dt>
-                  <dd className="text-sm text-surface-200">
+                  <dd className="text-sm text-surface-800">
                     {policy.owner?.displayName || 'Unassigned'}
                   </dd>
                 </div>
@@ -507,7 +507,7 @@ export default function PolicyDetail() {
                 <CalendarIcon className="w-5 h-5 text-surface-500 mt-0.5" />
                 <div>
                   <dt className="text-xs text-surface-500">Effective Date</dt>
-                  <dd className="text-sm text-surface-200">
+                  <dd className="text-sm text-surface-800">
                     {policy.effectiveDate
                       ? new Date(policy.effectiveDate).toLocaleDateString()
                       : 'Not set'}
@@ -523,7 +523,7 @@ export default function PolicyDetail() {
                       'text-sm',
                       policy.nextReviewDue && new Date(policy.nextReviewDue) < new Date()
                         ? 'text-red-600'
-                        : 'text-surface-200'
+                        : 'text-surface-800'
                     )}
                   >
                     {policy.nextReviewDue
@@ -552,23 +552,23 @@ export default function PolicyDetail() {
 
           {/* File Info */}
           <div className="card p-6">
-            <h3 className="text-sm font-semibold text-surface-100 mb-4">File Information</h3>
+            <h3 className="text-sm font-semibold text-surface-900 mb-4">File Information</h3>
             <dl className="space-y-3 text-sm">
               <div className="flex justify-between">
                 <dt className="text-surface-500">Filename</dt>
-                <dd className="text-surface-200 truncate ml-2">{policy.filename}</dd>
+                <dd className="text-surface-800 truncate ml-2">{policy.filename}</dd>
               </div>
               <div className="flex justify-between">
                 <dt className="text-surface-500">Type</dt>
-                <dd className="text-surface-200">{policy.mimeType}</dd>
+                <dd className="text-surface-800">{policy.mimeType}</dd>
               </div>
               <div className="flex justify-between">
                 <dt className="text-surface-500">Size</dt>
-                <dd className="text-surface-200">{formatFileSize(policy.size)}</dd>
+                <dd className="text-surface-800">{formatFileSize(policy.size)}</dd>
               </div>
               <div className="flex justify-between">
                 <dt className="text-surface-500">Uploaded</dt>
-                <dd className="text-surface-200">
+                <dd className="text-surface-800">
                   {new Date(policy.createdAt).toLocaleDateString()}
                 </dd>
               </div>
@@ -640,13 +640,13 @@ export default function PolicyDetail() {
           }}
         >
           <div className="flex items-center justify-between mb-4">
-            <h2 className="text-lg font-semibold text-surface-100">Change Status</h2>
+            <h2 className="text-lg font-semibold text-surface-900">Change Status</h2>
             <button
               onClick={() => {
                 setStatusChangeModal({ isOpen: false, targetStatus: null });
                 setStatusChangeNotes('');
               }}
-              className="text-surface-600 hover:text-surface-100"
+              className="text-surface-600 hover:text-surface-900"
             >
               <XMarkIcon className="w-5 h-5" />
             </button>
@@ -737,8 +737,8 @@ function NewVersionModal({
   return (
     <Dialog open onClose={onClose}>
       <div className="flex items-center justify-between mb-6">
-        <h2 className="text-lg font-semibold text-surface-100">Upload New Version</h2>
-        <button onClick={onClose} className="text-surface-600 hover:text-surface-100">
+        <h2 className="text-lg font-semibold text-surface-900">Upload New Version</h2>
+        <button onClick={onClose} className="text-surface-600 hover:text-surface-900">
           <XMarkIcon className="w-5 h-5" />
         </button>
       </div>
@@ -838,8 +838,8 @@ function LinkControlModal({
   return (
     <Dialog open onClose={onClose}>
       <div className="flex items-center justify-between mb-4">
-        <h2 className="text-lg font-semibold text-surface-100">Link Policy to Controls</h2>
-        <button onClick={onClose} className="text-surface-600 hover:text-surface-100">
+        <h2 className="text-lg font-semibold text-surface-900">Link Policy to Controls</h2>
+        <button onClick={onClose} className="text-surface-600 hover:text-surface-900">
           <XMarkIcon className="w-5 h-5" />
         </button>
       </div>
@@ -872,18 +872,18 @@ function LinkControlModal({
                 'flex items-center gap-3 p-3 rounded-lg cursor-pointer transition-colors',
                 selectedControlIds.includes(control.id)
                   ? 'bg-brand-500/20 border border-brand-500/50'
-                  : 'bg-surface-800 hover:bg-surface-700'
+                  : 'bg-white hover:bg-surface-200'
               )}
             >
               <input
                 type="checkbox"
                 checked={selectedControlIds.includes(control.id)}
                 onChange={() => toggleControl(control.id)}
-                className="rounded border-surface-600"
+                className="rounded border-surface-300"
               />
               <div>
                 <p className="font-mono text-sm text-brand-400">{control.controlId}</p>
-                <p className="text-sm text-surface-200">{control.title}</p>
+                <p className="text-sm text-surface-800">{control.title}</p>
               </div>
             </label>
           ))
@@ -896,7 +896,7 @@ function LinkControlModal({
         </p>
       )}
 
-      <div className="flex justify-end gap-3 mt-4 pt-4 border-t border-surface-800">
+      <div className="flex justify-end gap-3 mt-4 pt-4 border-t border-surface-200">
         <Button variant="secondary" onClick={onClose}>
           Cancel
         </Button>
@@ -959,8 +959,8 @@ function EditPolicyModal({
   return (
     <Dialog open onClose={onClose}>
       <div className="flex items-center justify-between mb-6">
-        <h2 className="text-lg font-semibold text-surface-100">Edit Policy</h2>
-        <button onClick={onClose} className="text-surface-600 hover:text-surface-100">
+        <h2 className="text-lg font-semibold text-surface-900">Edit Policy</h2>
+        <button onClick={onClose} className="text-surface-600 hover:text-surface-900">
           <XMarkIcon className="w-5 h-5" />
         </button>
       </div>

--- a/frontend/src/pages/QuestionnaireDetail.tsx
+++ b/frontend/src/pages/QuestionnaireDetail.tsx
@@ -280,12 +280,12 @@ export default function QuestionnaireDetail() {
         <div className="flex items-center gap-4">
           <button
             onClick={() => navigate('/questionnaires')}
-            className="p-2 text-surface-600 hover:text-surface-100 hover:bg-surface-800 rounded-lg transition-colors"
+            className="p-2 text-surface-600 hover:text-surface-900 hover:bg-white rounded-lg transition-colors"
           >
             <ArrowLeftIcon className="w-5 h-5" />
           </button>
           <div>
-            <h1 className="text-3xl font-bold text-surface-100">
+            <h1 className="text-3xl font-bold text-surface-900">
               {id === 'new'
                 ? 'Log Incoming Questionnaire'
                 : questionnaire?.title || 'Customer Questionnaire'}
@@ -319,8 +319,8 @@ export default function QuestionnaireDetail() {
       </div>
       {id === 'new' ? (
         <form onSubmit={handleSubmitNewQuestionnaire} className="space-y-6">
-          <div className="bg-surface-900 border border-surface-800 rounded-lg p-6 space-y-4">
-            <h2 className="text-xl font-semibold text-surface-100">Customer Information</h2>
+          <div className="bg-white border border-surface-200 rounded-lg p-6 space-y-4">
+            <h2 className="text-xl font-semibold text-surface-900">Customer Information</h2>
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
@@ -332,7 +332,7 @@ export default function QuestionnaireDetail() {
                   required
                   value={formData.requesterName}
                   onChange={(e) => setFormData({ ...formData, requesterName: e.target.value })}
-                  className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                  className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
                   placeholder="John Doe"
                 />
               </div>
@@ -346,7 +346,7 @@ export default function QuestionnaireDetail() {
                   required
                   value={formData.requesterEmail}
                   onChange={(e) => setFormData({ ...formData, requesterEmail: e.target.value })}
-                  className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                  className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
                   placeholder="john@company.com"
                 />
               </div>
@@ -357,7 +357,7 @@ export default function QuestionnaireDetail() {
                   type="text"
                   value={formData.company}
                   onChange={(e) => setFormData({ ...formData, company: e.target.value })}
-                  className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                  className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
                   placeholder="Acme Corp"
                 />
               </div>
@@ -371,7 +371,7 @@ export default function QuestionnaireDetail() {
                   required
                   value={formData.title}
                   onChange={(e) => setFormData({ ...formData, title: e.target.value })}
-                  className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                  className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
                   placeholder="Security Assessment 2025"
                 />
               </div>
@@ -381,7 +381,7 @@ export default function QuestionnaireDetail() {
                 <SelectNative
                   value={formData.priority}
                   onChange={(e) => setFormData({ ...formData, priority: e.target.value })}
-                  className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                  className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
                 >
                   <option value="low">Low</option>
                   <option value="medium">Medium</option>
@@ -396,7 +396,7 @@ export default function QuestionnaireDetail() {
                   type="date"
                   value={formData.dueDate}
                   onChange={(e) => setFormData({ ...formData, dueDate: e.target.value })}
-                  className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                  className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
                 />
               </div>
             </div>
@@ -407,14 +407,14 @@ export default function QuestionnaireDetail() {
                 value={formData.description}
                 onChange={(e) => setFormData({ ...formData, description: e.target.value })}
                 rows={2}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
                 placeholder="Additional context about this questionnaire..."
               />
             </div>
           </div>
 
-          <div className="bg-surface-900 border border-surface-800 rounded-lg p-6 space-y-4">
-            <h2 className="text-xl font-semibold text-surface-100">
+          <div className="bg-white border border-surface-200 rounded-lg p-6 space-y-4">
+            <h2 className="text-xl font-semibold text-surface-900">
               Upload Questionnaire <span className="text-red-600">*</span>
             </h2>
             <p className="text-sm text-surface-600">
@@ -423,7 +423,7 @@ export default function QuestionnaireDetail() {
             </p>
 
             {!formData.questionsText ? (
-              <div className="border-2 border-dashed border-surface-700 rounded-lg p-12">
+              <div className="border-2 border-dashed border-surface-200 rounded-lg p-12">
                 <input
                   type="file"
                   accept=".csv,.txt,.xlsx,.xls,.doc,.docx,.pdf"
@@ -440,7 +440,7 @@ export default function QuestionnaireDetail() {
                   className="cursor-pointer flex flex-col items-center"
                 >
                   <DocumentArrowUpIcon className="w-16 h-16 text-surface-500 mb-3" />
-                  <span className="text-surface-100 text-lg mb-2">
+                  <span className="text-surface-900 text-lg mb-2">
                     {parsing ? 'Parsing file...' : 'Click to upload questionnaire'}
                   </span>
                   <span className="text-sm text-surface-600 mb-1">or drag and drop</span>
@@ -449,11 +449,11 @@ export default function QuestionnaireDetail() {
               </div>
             ) : (
               <div className="space-y-3">
-                <div className="flex items-center justify-between p-4 bg-surface-800 rounded-lg border border-surface-700">
+                <div className="flex items-center justify-between p-4 bg-white rounded-lg border border-surface-200">
                   <div className="flex items-center gap-3">
                     <DocumentArrowUpIcon className="w-6 h-6 text-green-600" />
                     <div>
-                      <p className="text-surface-100 font-medium">{uploadedFile?.name}</p>
+                      <p className="text-surface-900 font-medium">{uploadedFile?.name}</p>
                       <p className="text-sm text-surface-600">
                         {formData.questionsText.split('\n').filter((l) => l.trim()).length}{' '}
                         questions parsed
@@ -466,14 +466,14 @@ export default function QuestionnaireDetail() {
                       setFormData({ ...formData, questionsText: '' });
                       setUploadedFile(null);
                     }}
-                    className="px-3 py-1.5 text-sm bg-surface-700 text-surface-200 rounded hover:bg-surface-600 transition-colors"
+                    className="px-3 py-1.5 text-sm bg-surface-200 text-surface-800 rounded hover:bg-surface-600 transition-colors"
                   >
                     Replace File
                   </button>
                 </div>
 
                 {/* Preview of parsed questions */}
-                <div className="border border-surface-700 rounded-lg p-4 max-h-60 overflow-y-auto">
+                <div className="border border-surface-200 rounded-lg p-4 max-h-60 overflow-y-auto">
                   <h4 className="text-sm font-medium text-surface-600 mb-2">
                     Parsed Questions Preview:
                   </h4>
@@ -524,7 +524,7 @@ export default function QuestionnaireDetail() {
       ) : null}
       {/* Edit Modal */}
       <Dialog open={showEditModal} onClose={() => setShowEditModal(false)}>
-        <h3 className="text-lg font-semibold text-surface-100 mb-4">Edit Questionnaire Details</h3>
+        <h3 className="text-lg font-semibold text-surface-900 mb-4">Edit Questionnaire Details</h3>
         <div className="space-y-4">
           <div>
             <label className="block text-sm font-medium text-surface-600 mb-1">Title</label>
@@ -532,7 +532,7 @@ export default function QuestionnaireDetail() {
               type="text"
               value={editForm.title}
               onChange={(e) => setEditForm({ ...editForm, title: e.target.value })}
-              className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
             />
           </div>
           <div className="grid grid-cols-2 gap-4">
@@ -544,7 +544,7 @@ export default function QuestionnaireDetail() {
                 type="text"
                 value={editForm.requesterName}
                 onChange={(e) => setEditForm({ ...editForm, requesterName: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               />
             </div>
             <div>
@@ -555,7 +555,7 @@ export default function QuestionnaireDetail() {
                 type="email"
                 value={editForm.requesterEmail}
                 onChange={(e) => setEditForm({ ...editForm, requesterEmail: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               />
             </div>
           </div>
@@ -566,7 +566,7 @@ export default function QuestionnaireDetail() {
                 type="text"
                 value={editForm.company}
                 onChange={(e) => setEditForm({ ...editForm, company: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               />
             </div>
             <div>
@@ -574,7 +574,7 @@ export default function QuestionnaireDetail() {
               <SelectNative
                 value={editForm.priority}
                 onChange={(e) => setEditForm({ ...editForm, priority: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               >
                 <option value="low">Low</option>
                 <option value="medium">Medium</option>
@@ -588,7 +588,7 @@ export default function QuestionnaireDetail() {
               type="date"
               value={editForm.dueDate}
               onChange={(e) => setEditForm({ ...editForm, dueDate: e.target.value })}
-              className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
             />
           </div>
           <div>
@@ -597,7 +597,7 @@ export default function QuestionnaireDetail() {
               value={editForm.description}
               onChange={(e) => setEditForm({ ...editForm, description: e.target.value })}
               rows={3}
-              className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
             />
           </div>
         </div>
@@ -627,7 +627,7 @@ export default function QuestionnaireDetail() {
       </Dialog>
       {/* Delete Confirmation */}
       <Dialog open={showDeleteConfirm} onClose={() => setShowDeleteConfirm(false)}>
-        <h3 className="text-lg font-semibold text-surface-100 mb-2">Delete Questionnaire</h3>
+        <h3 className="text-lg font-semibold text-surface-900 mb-2">Delete Questionnaire</h3>
         <p className="text-surface-600 mb-6">
           Are you sure you want to delete "{questionnaire?.title}"? This action cannot be undone.
         </p>
@@ -717,11 +717,11 @@ function QuestionnaireWorkspace({
   return (
     <div className="space-y-4">
       {/* Progress Header */}
-      <div className="bg-surface-900 border border-surface-800 rounded-lg p-4">
+      <div className="bg-white border border-surface-200 rounded-lg p-4">
         <div className="flex items-center justify-between mb-3">
           <div className="flex items-center gap-4">
             <div>
-              <h2 className="text-lg font-semibold text-surface-100">Progress</h2>
+              <h2 className="text-lg font-semibold text-surface-900">Progress</h2>
               <p className="text-sm text-surface-600">
                 {answeredCount} of {totalCount} questions answered
               </p>
@@ -746,7 +746,7 @@ function QuestionnaireWorkspace({
                     ? 'bg-red-500/20 text-red-600'
                     : questionnaire.priority === 'high'
                       ? 'bg-orange-500/20 text-orange-600'
-                      : 'bg-surface-700 text-surface-700'
+                      : 'bg-surface-200 text-surface-700'
                 )}
               >
                 {questionnaire.priority} priority
@@ -757,7 +757,7 @@ function QuestionnaireWorkspace({
             {questionnaire.dueDate && (
               <div className="text-right">
                 <p className="text-xs text-surface-500">Due Date</p>
-                <p className="text-sm font-medium text-surface-200">
+                <p className="text-sm font-medium text-surface-800">
                   {new Date(questionnaire.dueDate).toLocaleDateString()}
                 </p>
               </div>
@@ -768,7 +768,7 @@ function QuestionnaireWorkspace({
                 'flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors',
                 showKbPanel
                   ? 'bg-brand-600 text-white'
-                  : 'bg-surface-700 text-surface-200 hover:bg-surface-600'
+                  : 'bg-surface-200 text-surface-800 hover:bg-surface-600'
               )}
             >
               <BookOpenIcon className="w-4 h-4" />
@@ -778,7 +778,7 @@ function QuestionnaireWorkspace({
         </div>
 
         {/* Progress Bar */}
-        <div className="relative h-2 bg-surface-700 rounded-full overflow-hidden">
+        <div className="relative h-2 bg-surface-200 rounded-full overflow-hidden">
           <div
             className="absolute inset-y-0 left-0 bg-gradient-to-r from-brand-600 to-brand-400 transition-all duration-500"
             style={{ width: `${progressPercent}%` }}
@@ -804,7 +804,7 @@ function QuestionnaireWorkspace({
         {/* Questions Panel */}
         <div className={clsx('space-y-3 transition-all', showKbPanel ? 'w-2/3' : 'w-full')}>
           <div className="flex items-center justify-between">
-            <h3 className="text-lg font-semibold text-surface-100">Questions</h3>
+            <h3 className="text-lg font-semibold text-surface-900">Questions</h3>
             {pendingCount > 0 && (
               <button
                 onClick={goToNextPending}
@@ -885,10 +885,10 @@ function QuestionAnswerCard({
   return (
     <div
       className={clsx(
-        'bg-surface-900 border rounded-lg transition-all cursor-pointer',
+        'bg-white border rounded-lg transition-all cursor-pointer',
         isActive
           ? 'border-brand-500 ring-2 ring-brand-500/20'
-          : 'border-surface-800 hover:border-surface-600'
+          : 'border-surface-200 hover:border-surface-300'
       )}
       onClick={onSelect}
     >
@@ -896,11 +896,11 @@ function QuestionAnswerCard({
         <div className="flex items-start justify-between mb-3">
           <div className="flex-1">
             <div className="flex items-center gap-2 mb-2">
-              <span className="flex items-center justify-center w-6 h-6 text-xs font-bold bg-surface-700 text-surface-700 rounded-full">
+              <span className="flex items-center justify-center w-6 h-6 text-xs font-bold bg-surface-200 text-surface-700 rounded-full">
                 {question.questionNumber || index + 1}
               </span>
               {question.category && (
-                <span className="px-2 py-0.5 text-xs bg-surface-700 text-surface-700 rounded">
+                <span className="px-2 py-0.5 text-xs bg-surface-200 text-surface-700 rounded">
                   {question.category}
                 </span>
               )}
@@ -913,7 +913,7 @@ function QuestionAnswerCard({
                 {question.status.replace('_', ' ')}
               </span>
             </div>
-            <p className="text-surface-100 font-medium leading-relaxed">{question.questionText}</p>
+            <p className="text-surface-900 font-medium leading-relaxed">{question.questionText}</p>
           </div>
           <ChevronRightIcon
             className={clsx(
@@ -925,7 +925,7 @@ function QuestionAnswerCard({
 
         {isActive && (
           <div
-            className="space-y-3 mt-4 pt-4 border-t border-surface-700"
+            className="space-y-3 mt-4 pt-4 border-t border-surface-200"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="flex items-center justify-between">
@@ -940,7 +940,7 @@ function QuestionAnswerCard({
               value={currentAnswer}
               onChange={(e) => onAnswerChange(e.target.value)}
               rows={5}
-              className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500 resize-y"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 resize-y"
               placeholder="Enter your answer here, or use the Knowledge Base panel to find a pre-approved answer..."
             />
 

--- a/frontend/src/pages/Questionnaires.tsx
+++ b/frontend/src/pages/Questionnaires.tsx
@@ -39,7 +39,7 @@ export default function Questionnaires() {
       <div className="space-y-6">
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-3xl font-bold text-surface-100">Security Questionnaires</h1>
+            <h1 className="text-3xl font-bold text-surface-900">Security Questionnaires</h1>
             <p className="mt-1 text-surface-600">
               Respond to incoming customer security questionnaires
             </p>
@@ -55,7 +55,7 @@ export default function Questionnaires() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold text-surface-100">Security Questionnaires</h1>
+          <h1 className="text-3xl font-bold text-surface-900">Security Questionnaires</h1>
           <p className="mt-1 text-surface-600">
             Respond to incoming customer security questionnaires
           </p>
@@ -77,7 +77,7 @@ export default function Questionnaires() {
             className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
               filter === status
                 ? 'bg-brand-600 text-white'
-                : 'bg-surface-800 text-surface-700 hover:bg-surface-700'
+                : 'bg-white text-surface-700 hover:bg-surface-200'
             }`}
           >
             {status === 'all'
@@ -100,9 +100,9 @@ export default function Questionnaires() {
           }}
         />
       ) : (
-        <div className="bg-surface-900 border border-surface-800 rounded-lg overflow-hidden">
+        <div className="bg-white border border-surface-200 rounded-lg overflow-hidden">
           <table className="w-full">
-            <thead className="bg-surface-800 border-b border-surface-700">
+            <thead className="bg-white border-b border-surface-200">
               <tr>
                 <th className="px-6 py-3 text-left text-xs font-medium text-surface-600 uppercase tracking-wider">
                   Customer Request
@@ -124,18 +124,18 @@ export default function Questionnaires() {
                 </th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-surface-800">
+            <tbody className="divide-y divide-surface-200">
               {(questionnaires as any[]).map((questionnaire) => {
                 const completion = getCompletionPercentage(questionnaire.questions);
                 return (
                   <tr
                     key={questionnaire.id}
                     onClick={() => navigate(`/questionnaires/${questionnaire.id}`)}
-                    className="hover:bg-surface-800 cursor-pointer transition-colors"
+                    className="hover:bg-white cursor-pointer transition-colors"
                   >
                     <td className="px-6 py-4">
                       <div>
-                        <div className="text-sm font-medium text-surface-100">
+                        <div className="text-sm font-medium text-surface-900">
                           {questionnaire.title}
                         </div>
                         <div className="text-sm text-surface-500">
@@ -177,7 +177,7 @@ export default function Questionnaires() {
                               ? 'bg-blue-500/20 text-blue-600'
                               : questionnaire.status === 'pending'
                                 ? 'bg-yellow-500/20 text-yellow-600'
-                                : 'bg-surface-700 text-surface-600'
+                                : 'bg-surface-200 text-surface-600'
                         }`}
                       >
                         {questionnaire.status.replace('_', ' ')}
@@ -185,8 +185,8 @@ export default function Questionnaires() {
                     </td>
                     <td className="px-6 py-4">
                       <div className="flex items-center gap-2">
-                        <span className="text-sm font-medium text-surface-100">{completion}%</span>
-                        <div className="w-24 h-2 bg-surface-700 rounded-full overflow-hidden">
+                        <span className="text-sm font-medium text-surface-900">{completion}%</span>
+                        <div className="w-24 h-2 bg-surface-200 rounded-full overflow-hidden">
                           <div
                             className={`h-full ${
                               completion === 100

--- a/frontend/src/pages/ReportBuilder.tsx
+++ b/frontend/src/pages/ReportBuilder.tsx
@@ -168,7 +168,7 @@ export default function ReportBuilderPage() {
         <div className="flex items-center gap-2">
           <button
             onClick={() => setShowTemplates(true)}
-            className="flex items-center gap-2 px-4 py-2 bg-surface-800 hover:bg-surface-700 text-white rounded-lg transition-colors"
+            className="flex items-center gap-2 px-4 py-2 bg-white hover:bg-surface-200 text-white rounded-lg transition-colors"
           >
             <FolderIcon className="w-4 h-4" />
             Templates
@@ -187,11 +187,11 @@ export default function ReportBuilderPage() {
       {isLoading ? (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           {[1, 2, 3].map((i) => (
-            <div key={i} className="h-40 bg-surface-800 rounded-xl animate-pulse" />
+            <div key={i} className="h-40 bg-white rounded-xl animate-pulse" />
           ))}
         </div>
       ) : reports.length === 0 ? (
-        <div className="text-center py-16 bg-surface-800/50 rounded-xl border border-surface-700">
+        <div className="text-center py-16 bg-white/50 rounded-xl border border-surface-200">
           <DocumentTextIcon className="w-12 h-12 text-surface-600 mx-auto mb-4" />
           <h3 className="text-lg font-medium text-white mb-2">No Custom Reports Yet</h3>
           <p className="text-surface-600 mb-4">
@@ -200,7 +200,7 @@ export default function ReportBuilderPage() {
           <div className="flex items-center justify-center gap-3">
             <button
               onClick={() => setShowTemplates(true)}
-              className="px-4 py-2 bg-surface-700 hover:bg-surface-600 text-white rounded-lg transition-colors"
+              className="px-4 py-2 bg-surface-200 hover:bg-surface-600 text-white rounded-lg transition-colors"
             >
               Browse Templates
             </button>
@@ -217,7 +217,7 @@ export default function ReportBuilderPage() {
           {reports.map((report) => (
             <div
               key={report.id}
-              className="p-5 bg-surface-800 rounded-xl border border-surface-700 hover:border-surface-600 transition-colors group"
+              className="p-5 bg-white rounded-xl border border-surface-200 hover:border-surface-300 transition-colors group"
             >
               <div className="flex items-start justify-between mb-3">
                 <div className="p-2 bg-brand-500/20 rounded-lg">
@@ -226,7 +226,7 @@ export default function ReportBuilderPage() {
                 <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
                   <button
                     onClick={() => navigate(`/reports/builder/${report.id}`)}
-                    className="p-1.5 text-surface-600 hover:text-white rounded-lg hover:bg-surface-700"
+                    className="p-1.5 text-surface-600 hover:text-white rounded-lg hover:bg-surface-200"
                     title="Edit"
                   >
                     <PencilIcon className="w-4 h-4" />
@@ -237,7 +237,7 @@ export default function ReportBuilderPage() {
                         deleteMutation.mutate(report.id!);
                       }
                     }}
-                    className="p-1.5 text-red-600 hover:text-red-700 rounded-lg hover:bg-surface-700"
+                    className="p-1.5 text-red-600 hover:text-red-700 rounded-lg hover:bg-surface-200"
                     title="Delete"
                   >
                     <TrashIcon className="w-4 h-4" />
@@ -280,7 +280,7 @@ export default function ReportBuilderPage() {
               <button
                 key={i}
                 onClick={() => createFromTemplate(template)}
-                className="p-4 text-left bg-surface-800 hover:bg-surface-700 rounded-lg border border-surface-700 hover:border-surface-600 transition-colors"
+                className="p-4 text-left bg-white hover:bg-surface-200 rounded-lg border border-surface-200 hover:border-surface-300 transition-colors"
               >
                 <h4 className="font-medium text-white mb-1">{template.name}</h4>
                 <p className="text-sm text-surface-600">{template.description}</p>

--- a/frontend/src/pages/RiskConfiguration.tsx
+++ b/frontend/src/pages/RiskConfiguration.tsx
@@ -190,7 +190,7 @@ export default function RiskConfiguration() {
               }
             }}
             disabled={resetMutation.isPending}
-            className="px-4 py-2 bg-gray-100 dark:bg-surface-700 text-gray-700 dark:text-surface-700 rounded-lg hover:bg-gray-200 dark:hover:bg-surface-600 flex items-center gap-2"
+            className="px-4 py-2 bg-gray-100 dark:bg-surface-200 text-gray-700 dark:text-surface-700 rounded-lg hover:bg-gray-200 dark:hover:bg-surface-600 flex items-center gap-2"
           >
             <ArrowPathIcon className="w-4 h-4" />
             Reset to Defaults
@@ -199,7 +199,7 @@ export default function RiskConfiguration() {
       </div>
 
       {/* Tabs */}
-      <div className="flex gap-2 border-b border-gray-200 dark:border-surface-700 pb-px">
+      <div className="flex gap-2 border-b border-gray-200 dark:border-surface-200 pb-px">
         {tabs.map((tab) => (
           <button
             key={tab.key}
@@ -217,7 +217,7 @@ export default function RiskConfiguration() {
       </div>
 
       {/* Tab Content */}
-      <div className="bg-white dark:bg-surface-800 rounded-xl border border-gray-200 dark:border-surface-700 p-6">
+      <div className="bg-white dark:bg-white rounded-xl border border-gray-200 dark:border-surface-200 p-6">
         {activeTab === 'scoring' && config && (
           <ScoringMethodology config={config} onUpdate={(data) => updateMutation.mutate(data)} />
         )}
@@ -369,7 +369,7 @@ function ScoringMethodology({
             className={`p-4 rounded-lg border cursor-pointer transition-all ${
               methodology === 'qualitative'
                 ? 'border-brand-500 bg-brand-500/10 ring-2 ring-brand-500'
-                : 'border-gray-200 dark:border-surface-700 bg-gray-50 dark:bg-surface-700/50 hover:border-brand-500/50'
+                : 'border-gray-200 dark:border-surface-200 bg-gray-50 dark:bg-surface-200/50 hover:border-brand-500/50'
             }`}
           >
             <input
@@ -413,7 +413,7 @@ function ScoringMethodology({
             className={`p-4 rounded-lg border cursor-pointer transition-all ${
               methodology === 'quantitative'
                 ? 'border-brand-500 bg-brand-500/10 ring-2 ring-brand-500'
-                : 'border-gray-200 dark:border-surface-700 bg-gray-50 dark:bg-surface-700/50 hover:border-brand-500/50'
+                : 'border-gray-200 dark:border-surface-200 bg-gray-50 dark:bg-surface-200/50 hover:border-brand-500/50'
             }`}
           >
             <input
@@ -467,7 +467,7 @@ function ScoringMethodology({
             className={`p-4 rounded-lg border cursor-pointer transition-all ${
               methodology === 'hybrid'
                 ? 'border-brand-500 bg-brand-500/10 ring-2 ring-brand-500'
-                : 'border-gray-200 dark:border-surface-700 bg-gray-50 dark:bg-surface-700/50 hover:border-brand-500/50'
+                : 'border-gray-200 dark:border-surface-200 bg-gray-50 dark:bg-surface-200/50 hover:border-brand-500/50'
             }`}
           >
             <input
@@ -520,7 +520,7 @@ function ScoringMethodology({
 
       {/* Methodology Details Panel */}
       {showMethodologyDetails && currentMethodology && (
-        <div className="p-6 bg-gray-50 dark:bg-surface-700/30 rounded-xl border border-gray-200 dark:border-surface-700">
+        <div className="p-6 bg-gray-50 dark:bg-surface-200/30 rounded-xl border border-gray-200 dark:border-surface-200">
           <h4 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
             {currentMethodology.title}
           </h4>
@@ -529,7 +529,7 @@ function ScoringMethodology({
           </p>
 
           {/* Formula */}
-          <div className="mb-6 p-4 bg-gray-900 dark:bg-surface-900 rounded-lg">
+          <div className="mb-6 p-4 bg-gray-900 dark:bg-white rounded-lg">
             <p className="text-xs text-gray-400 mb-2 uppercase tracking-wider">Formula</p>
             <pre className="text-emerald-600 font-mono text-sm whitespace-pre-wrap">
               {currentMethodology.formula}
@@ -590,7 +590,7 @@ function ScoringMethodology({
             </div>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-6 pt-6 border-t border-gray-200 dark:border-surface-700">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-6 pt-6 border-t border-gray-200 dark:border-surface-200">
             {/* Best For */}
             <div>
               <h5 className="text-sm font-medium text-blue-600 mb-3 flex items-center gap-2">
@@ -664,11 +664,11 @@ function ScoringMethodology({
             calculation.
           </p>
           <div className="grid grid-cols-2 gap-4 text-sm">
-            <div className="p-3 bg-surface-800/50 rounded-lg">
+            <div className="p-3 bg-white/50 rounded-lg">
               <p className="text-gray-500 dark:text-surface-600">Currency</p>
               <p className="text-gray-900 dark:text-white font-medium">USD ($)</p>
             </div>
-            <div className="p-3 bg-surface-800/50 rounded-lg">
+            <div className="p-3 bg-white/50 rounded-lg">
               <p className="text-gray-500 dark:text-surface-600">Analysis Period</p>
               <p className="text-gray-900 dark:text-white font-medium">Annual (12 months)</p>
             </div>
@@ -689,7 +689,7 @@ function ScoringMethodology({
             {config.likelihoodScale.map((level) => (
               <div
                 key={level.value}
-                className="flex items-center gap-3 p-3 bg-gray-50 dark:bg-gray-50 dark:bg-surface-700/50 rounded-lg"
+                className="flex items-center gap-3 p-3 bg-gray-50 dark:bg-gray-50 dark:bg-surface-200/50 rounded-lg"
               >
                 <span className="w-6 h-6 rounded bg-gray-200 dark:bg-surface-600 flex items-center justify-center text-gray-900 dark:text-gray-900 dark:text-white text-sm font-medium">
                   {level.weight}
@@ -714,7 +714,7 @@ function ScoringMethodology({
             {config.impactScale.map((level) => (
               <div
                 key={level.value}
-                className="flex items-center gap-3 p-3 bg-gray-50 dark:bg-gray-50 dark:bg-surface-700/50 rounded-lg"
+                className="flex items-center gap-3 p-3 bg-gray-50 dark:bg-gray-50 dark:bg-surface-200/50 rounded-lg"
               >
                 <span className="w-6 h-6 rounded bg-gray-200 dark:bg-surface-600 flex items-center justify-center text-gray-900 dark:text-gray-900 dark:text-white text-sm font-medium">
                   {level.weight}
@@ -827,7 +827,7 @@ function RiskCategories({
         {categories.map((cat) => (
           <div
             key={cat.id}
-            className="flex items-center gap-4 p-4 bg-gray-50 dark:bg-gray-50 dark:bg-surface-700/50 rounded-lg"
+            className="flex items-center gap-4 p-4 bg-gray-50 dark:bg-gray-50 dark:bg-surface-200/50 rounded-lg"
           >
             <div className="w-4 h-4 rounded" style={{ backgroundColor: cat.color }} />
             <div className="flex-1">
@@ -847,7 +847,7 @@ function RiskCategories({
           </div>
         ))}
       </div>
-      <div className="pt-4 border-t border-surface-700">
+      <div className="pt-4 border-t border-surface-200">
         <h4 className="text-gray-900 dark:text-white font-medium mb-3">Add Category</h4>
         <div className="flex gap-4">
           <Input
@@ -855,14 +855,14 @@ function RiskCategories({
             placeholder="Category name"
             value={newCategory.name ?? ''}
             onChange={(e) => setNewCategory((prev) => ({ ...prev, name: e.target.value }))}
-            className="flex-1 px-4 py-2 bg-gray-50 dark:bg-surface-700 border border-gray-300 dark:border-surface-600 rounded-lg text-gray-900 dark:text-white"
+            className="flex-1 px-4 py-2 bg-gray-50 dark:bg-surface-200 border border-gray-300 dark:border-surface-300 rounded-lg text-gray-900 dark:text-white"
           />
           <Input
             type="text"
             placeholder="Description"
             value={newCategory.description ?? ''}
             onChange={(e) => setNewCategory((prev) => ({ ...prev, description: e.target.value }))}
-            className="flex-1 px-4 py-2 bg-gray-50 dark:bg-surface-700 border border-gray-300 dark:border-surface-600 rounded-lg text-gray-900 dark:text-white"
+            className="flex-1 px-4 py-2 bg-gray-50 dark:bg-surface-200 border border-gray-300 dark:border-surface-300 rounded-lg text-gray-900 dark:text-white"
           />
           <input
             type="color"
@@ -914,7 +914,7 @@ function WorkflowSettingsTab({
       <div className="space-y-4">
         <h4 className="text-gray-900 dark:text-white font-medium">Assessment Workflow</h4>
 
-        <label className="flex items-center justify-between p-4 bg-gray-50 dark:bg-surface-700/50 rounded-lg">
+        <label className="flex items-center justify-between p-4 bg-gray-50 dark:bg-surface-200/50 rounded-lg">
           <div>
             <p className="text-gray-900 dark:text-white">Require Formal Assessment</p>
             <p className="text-gray-500 dark:text-surface-600 text-sm">
@@ -925,11 +925,11 @@ function WorkflowSettingsTab({
             type="checkbox"
             checked={settings.requireAssessment ?? true}
             onChange={(e) => handleChange('requireAssessment', e.target.checked)}
-            className="rounded border-surface-600"
+            className="rounded border-surface-300"
           />
         </label>
 
-        <label className="flex items-center justify-between p-4 bg-gray-50 dark:bg-surface-700/50 rounded-lg">
+        <label className="flex items-center justify-between p-4 bg-gray-50 dark:bg-surface-200/50 rounded-lg">
           <div>
             <p className="text-gray-900 dark:text-white">Require GRC Review</p>
             <p className="text-gray-500 dark:text-surface-600 text-sm">
@@ -940,11 +940,11 @@ function WorkflowSettingsTab({
             type="checkbox"
             checked={settings.requireGrcReview ?? true}
             onChange={(e) => handleChange('requireGrcReview', e.target.checked)}
-            className="rounded border-surface-600"
+            className="rounded border-surface-300"
           />
         </label>
 
-        <div className="p-4 bg-gray-50 dark:bg-surface-700/50 rounded-lg">
+        <div className="p-4 bg-gray-50 dark:bg-surface-200/50 rounded-lg">
           <div className="flex items-center justify-between mb-2">
             <p className="text-gray-900 dark:text-white">Executive Approval Threshold</p>
           </div>
@@ -954,7 +954,7 @@ function WorkflowSettingsTab({
           <SelectNative
             value={settings.executiveApprovalThreshold ?? 'high'}
             onChange={(e) => handleChange('executiveApprovalThreshold', e.target.value)}
-            className="w-full px-4 py-2 bg-gray-50 dark:bg-surface-700 border border-gray-300 dark:border-surface-600 rounded-lg text-gray-900 dark:text-white"
+            className="w-full px-4 py-2 bg-gray-50 dark:bg-surface-200 border border-gray-300 dark:border-surface-300 rounded-lg text-gray-900 dark:text-white"
           >
             <option value="critical">Critical only</option>
             <option value="high">High and above</option>
@@ -963,15 +963,15 @@ function WorkflowSettingsTab({
           </SelectNative>
         </div>
       </div>
-      <div className="space-y-4 pt-4 border-t border-surface-700">
+      <div className="space-y-4 pt-4 border-t border-surface-200">
         <h4 className="text-gray-900 dark:text-white font-medium">Review Settings</h4>
 
-        <div className="p-4 bg-gray-50 dark:bg-surface-700/50 rounded-lg">
+        <div className="p-4 bg-gray-50 dark:bg-surface-200/50 rounded-lg">
           <p className="text-gray-900 dark:text-white mb-2">Default Review Frequency</p>
           <SelectNative
             value={settings.defaultReviewFrequency ?? 'quarterly'}
             onChange={(e) => handleChange('defaultReviewFrequency', e.target.value)}
-            className="w-full px-4 py-2 bg-gray-50 dark:bg-surface-700 border border-gray-300 dark:border-surface-600 rounded-lg text-gray-900 dark:text-white"
+            className="w-full px-4 py-2 bg-gray-50 dark:bg-surface-200 border border-gray-300 dark:border-surface-300 rounded-lg text-gray-900 dark:text-white"
           >
             <option value="monthly">Monthly</option>
             <option value="quarterly">Quarterly</option>
@@ -980,10 +980,10 @@ function WorkflowSettingsTab({
           </SelectNative>
         </div>
       </div>
-      <div className="space-y-4 pt-4 border-t border-surface-700">
+      <div className="space-y-4 pt-4 border-t border-surface-200">
         <h4 className="text-gray-900 dark:text-white font-medium">Notifications</h4>
 
-        <label className="flex items-center justify-between p-4 bg-gray-50 dark:bg-surface-700/50 rounded-lg">
+        <label className="flex items-center justify-between p-4 bg-gray-50 dark:bg-surface-200/50 rounded-lg">
           <div>
             <p className="text-gray-900 dark:text-white">Notify on Status Change</p>
             <p className="text-gray-500 dark:text-surface-600 text-sm">
@@ -994,11 +994,11 @@ function WorkflowSettingsTab({
             type="checkbox"
             checked={settings.notifyOnStatusChange ?? true}
             onChange={(e) => handleChange('notifyOnStatusChange', e.target.checked)}
-            className="rounded border-surface-600"
+            className="rounded border-surface-300"
           />
         </label>
 
-        <div className="p-4 bg-gray-50 dark:bg-surface-700/50 rounded-lg">
+        <div className="p-4 bg-gray-50 dark:bg-surface-200/50 rounded-lg">
           <div className="flex items-center justify-between mb-2">
             <p className="text-gray-900 dark:text-white">Due Date Reminder</p>
           </div>
@@ -1011,7 +1011,7 @@ function WorkflowSettingsTab({
             onChange={(e) => handleChange('dueDateReminderDays', parseInt(e.target.value))}
             min="1"
             max="30"
-            className="w-full px-4 py-2 bg-gray-50 dark:bg-surface-700 border border-gray-300 dark:border-surface-600 rounded-lg text-gray-900 dark:text-white"
+            className="w-full px-4 py-2 bg-gray-50 dark:bg-surface-200 border border-gray-300 dark:border-surface-300 rounded-lg text-gray-900 dark:text-white"
           />
         </div>
       </div>
@@ -1110,7 +1110,7 @@ function SLASettingsTab({
         </p>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div className="p-4 bg-gray-50 dark:bg-surface-700/50 rounded-lg">
+          <div className="p-4 bg-gray-50 dark:bg-surface-200/50 rounded-lg">
             <label className="block text-gray-900 dark:text-white text-sm font-medium mb-2">
               Intake → Assessment Start
             </label>
@@ -1123,7 +1123,7 @@ function SLASettingsTab({
                 value={settings.intakeToAssessment}
                 onChange={(e) => handleChange('intakeToAssessment', parseInt(e.target.value) || 0)}
                 min="1"
-                className="w-24 px-3 py-2 bg-white dark:bg-surface-700 border border-gray-300 dark:border-surface-600 rounded-lg text-gray-900 dark:text-white text-sm"
+                className="w-24 px-3 py-2 bg-white dark:bg-surface-200 border border-gray-300 dark:border-surface-300 rounded-lg text-gray-900 dark:text-white text-sm"
               />
               <span className="text-gray-500 dark:text-surface-600 text-sm">hours</span>
               <span className="text-gray-400 dark:text-surface-500 text-xs ml-auto">
@@ -1132,7 +1132,7 @@ function SLASettingsTab({
             </div>
           </div>
 
-          <div className="p-4 bg-gray-50 dark:bg-surface-700/50 rounded-lg">
+          <div className="p-4 bg-gray-50 dark:bg-surface-200/50 rounded-lg">
             <label className="block text-gray-900 dark:text-white text-sm font-medium mb-2">
               Assessment Duration
             </label>
@@ -1145,7 +1145,7 @@ function SLASettingsTab({
                 value={settings.assessmentDuration}
                 onChange={(e) => handleChange('assessmentDuration', parseInt(e.target.value) || 0)}
                 min="1"
-                className="w-24 px-3 py-2 bg-white dark:bg-surface-700 border border-gray-300 dark:border-surface-600 rounded-lg text-gray-900 dark:text-white text-sm"
+                className="w-24 px-3 py-2 bg-white dark:bg-surface-200 border border-gray-300 dark:border-surface-300 rounded-lg text-gray-900 dark:text-white text-sm"
               />
               <span className="text-gray-500 dark:text-surface-600 text-sm">hours</span>
               <span className="text-gray-400 dark:text-surface-500 text-xs ml-auto">
@@ -1154,7 +1154,7 @@ function SLASettingsTab({
             </div>
           </div>
 
-          <div className="p-4 bg-gray-50 dark:bg-surface-700/50 rounded-lg">
+          <div className="p-4 bg-gray-50 dark:bg-surface-200/50 rounded-lg">
             <label className="block text-gray-900 dark:text-white text-sm font-medium mb-2">
               GRC Review Duration
             </label>
@@ -1167,7 +1167,7 @@ function SLASettingsTab({
                 value={settings.grcReviewDuration}
                 onChange={(e) => handleChange('grcReviewDuration', parseInt(e.target.value) || 0)}
                 min="1"
-                className="w-24 px-3 py-2 bg-white dark:bg-surface-700 border border-gray-300 dark:border-surface-600 rounded-lg text-gray-900 dark:text-white text-sm"
+                className="w-24 px-3 py-2 bg-white dark:bg-surface-200 border border-gray-300 dark:border-surface-300 rounded-lg text-gray-900 dark:text-white text-sm"
               />
               <span className="text-gray-500 dark:text-surface-600 text-sm">hours</span>
               <span className="text-gray-400 dark:text-surface-500 text-xs ml-auto">
@@ -1176,7 +1176,7 @@ function SLASettingsTab({
             </div>
           </div>
 
-          <div className="p-4 bg-gray-50 dark:bg-surface-700/50 rounded-lg">
+          <div className="p-4 bg-gray-50 dark:bg-surface-200/50 rounded-lg">
             <label className="block text-gray-900 dark:text-white text-sm font-medium mb-2">
               Treatment Decision
             </label>
@@ -1191,7 +1191,7 @@ function SLASettingsTab({
                   handleChange('treatmentDecisionDuration', parseInt(e.target.value) || 0)
                 }
                 min="1"
-                className="w-24 px-3 py-2 bg-white dark:bg-surface-700 border border-gray-300 dark:border-surface-600 rounded-lg text-gray-900 dark:text-white text-sm"
+                className="w-24 px-3 py-2 bg-white dark:bg-surface-200 border border-gray-300 dark:border-surface-300 rounded-lg text-gray-900 dark:text-white text-sm"
               />
               <span className="text-gray-500 dark:text-surface-600 text-sm">hours</span>
               <span className="text-gray-400 dark:text-surface-500 text-xs ml-auto">
@@ -1200,7 +1200,7 @@ function SLASettingsTab({
             </div>
           </div>
 
-          <div className="p-4 bg-gray-50 dark:bg-surface-700/50 rounded-lg">
+          <div className="p-4 bg-gray-50 dark:bg-surface-200/50 rounded-lg">
             <label className="block text-gray-900 dark:text-white text-sm font-medium mb-2">
               Executive Approval
             </label>
@@ -1215,7 +1215,7 @@ function SLASettingsTab({
                   handleChange('executiveApprovalDuration', parseInt(e.target.value) || 0)
                 }
                 min="1"
-                className="w-24 px-3 py-2 bg-white dark:bg-surface-700 border border-gray-300 dark:border-surface-600 rounded-lg text-gray-900 dark:text-white text-sm"
+                className="w-24 px-3 py-2 bg-white dark:bg-surface-200 border border-gray-300 dark:border-surface-300 rounded-lg text-gray-900 dark:text-white text-sm"
               />
               <span className="text-gray-500 dark:text-surface-600 text-sm">hours</span>
               <span className="text-gray-400 dark:text-surface-500 text-xs ml-auto">
@@ -1226,7 +1226,7 @@ function SLASettingsTab({
         </div>
       </div>
       {/* Mitigation SLAs by Risk Level */}
-      <div className="space-y-4 pt-6 border-t border-gray-200 dark:border-surface-700">
+      <div className="space-y-4 pt-6 border-t border-gray-200 dark:border-surface-200">
         <h4 className="text-gray-900 dark:text-white font-medium flex items-center gap-2">
           <ExclamationTriangleIcon className="w-5 h-5 text-amber-600" />
           Mitigation SLAs by Risk Level
@@ -1246,7 +1246,7 @@ function SLASettingsTab({
                   handleMitigationSLAChange('critical', parseInt(e.target.value) || 0)
                 }
                 min="1"
-                className="w-20 px-3 py-2 bg-white dark:bg-surface-700 border border-gray-300 dark:border-surface-600 rounded-lg text-gray-900 dark:text-white text-sm"
+                className="w-20 px-3 py-2 bg-white dark:bg-surface-200 border border-gray-300 dark:border-surface-300 rounded-lg text-gray-900 dark:text-white text-sm"
               />
               <span className="text-gray-500 dark:text-surface-600 text-sm">days</span>
             </div>
@@ -1260,7 +1260,7 @@ function SLASettingsTab({
                 value={settings.mitigationSLA.high}
                 onChange={(e) => handleMitigationSLAChange('high', parseInt(e.target.value) || 0)}
                 min="1"
-                className="w-20 px-3 py-2 bg-white dark:bg-surface-700 border border-gray-300 dark:border-surface-600 rounded-lg text-gray-900 dark:text-white text-sm"
+                className="w-20 px-3 py-2 bg-white dark:bg-surface-200 border border-gray-300 dark:border-surface-300 rounded-lg text-gray-900 dark:text-white text-sm"
               />
               <span className="text-gray-500 dark:text-surface-600 text-sm">days</span>
             </div>
@@ -1274,7 +1274,7 @@ function SLASettingsTab({
                 value={settings.mitigationSLA.medium}
                 onChange={(e) => handleMitigationSLAChange('medium', parseInt(e.target.value) || 0)}
                 min="1"
-                className="w-20 px-3 py-2 bg-white dark:bg-surface-700 border border-gray-300 dark:border-surface-600 rounded-lg text-gray-900 dark:text-white text-sm"
+                className="w-20 px-3 py-2 bg-white dark:bg-surface-200 border border-gray-300 dark:border-surface-300 rounded-lg text-gray-900 dark:text-white text-sm"
               />
               <span className="text-gray-500 dark:text-surface-600 text-sm">days</span>
             </div>
@@ -1288,7 +1288,7 @@ function SLASettingsTab({
                 value={settings.mitigationSLA.low}
                 onChange={(e) => handleMitigationSLAChange('low', parseInt(e.target.value) || 0)}
                 min="1"
-                className="w-20 px-3 py-2 bg-white dark:bg-surface-700 border border-gray-300 dark:border-surface-600 rounded-lg text-gray-900 dark:text-white text-sm"
+                className="w-20 px-3 py-2 bg-white dark:bg-surface-200 border border-gray-300 dark:border-surface-300 rounded-lg text-gray-900 dark:text-white text-sm"
               />
               <span className="text-gray-500 dark:text-surface-600 text-sm">days</span>
             </div>
@@ -1296,7 +1296,7 @@ function SLASettingsTab({
         </div>
       </div>
       {/* Review Cycle SLAs by Risk Level */}
-      <div className="space-y-4 pt-6 border-t border-gray-200 dark:border-surface-700">
+      <div className="space-y-4 pt-6 border-t border-gray-200 dark:border-surface-200">
         <h4 className="text-gray-900 dark:text-white font-medium flex items-center gap-2">
           <ArrowPathIcon className="w-5 h-5 text-blue-600" />
           Review Cycle SLAs by Risk Level
@@ -1316,7 +1316,7 @@ function SLASettingsTab({
                   handleReviewCycleSLAChange('critical', parseInt(e.target.value) || 0)
                 }
                 min="1"
-                className="w-20 px-3 py-2 bg-white dark:bg-surface-700 border border-gray-300 dark:border-surface-600 rounded-lg text-gray-900 dark:text-white text-sm"
+                className="w-20 px-3 py-2 bg-white dark:bg-surface-200 border border-gray-300 dark:border-surface-300 rounded-lg text-gray-900 dark:text-white text-sm"
               />
               <span className="text-gray-500 dark:text-surface-600 text-sm">days</span>
             </div>
@@ -1330,7 +1330,7 @@ function SLASettingsTab({
                 value={settings.reviewCycleSLA.high}
                 onChange={(e) => handleReviewCycleSLAChange('high', parseInt(e.target.value) || 0)}
                 min="1"
-                className="w-20 px-3 py-2 bg-white dark:bg-surface-700 border border-gray-300 dark:border-surface-600 rounded-lg text-gray-900 dark:text-white text-sm"
+                className="w-20 px-3 py-2 bg-white dark:bg-surface-200 border border-gray-300 dark:border-surface-300 rounded-lg text-gray-900 dark:text-white text-sm"
               />
               <span className="text-gray-500 dark:text-surface-600 text-sm">days</span>
             </div>
@@ -1346,7 +1346,7 @@ function SLASettingsTab({
                   handleReviewCycleSLAChange('medium', parseInt(e.target.value) || 0)
                 }
                 min="1"
-                className="w-20 px-3 py-2 bg-white dark:bg-surface-700 border border-gray-300 dark:border-surface-600 rounded-lg text-gray-900 dark:text-white text-sm"
+                className="w-20 px-3 py-2 bg-white dark:bg-surface-200 border border-gray-300 dark:border-surface-300 rounded-lg text-gray-900 dark:text-white text-sm"
               />
               <span className="text-gray-500 dark:text-surface-600 text-sm">days</span>
             </div>
@@ -1360,7 +1360,7 @@ function SLASettingsTab({
                 value={settings.reviewCycleSLA.low}
                 onChange={(e) => handleReviewCycleSLAChange('low', parseInt(e.target.value) || 0)}
                 min="1"
-                className="w-20 px-3 py-2 bg-white dark:bg-surface-700 border border-gray-300 dark:border-surface-600 rounded-lg text-gray-900 dark:text-white text-sm"
+                className="w-20 px-3 py-2 bg-white dark:bg-surface-200 border border-gray-300 dark:border-surface-300 rounded-lg text-gray-900 dark:text-white text-sm"
               />
               <span className="text-gray-500 dark:text-surface-600 text-sm">days</span>
             </div>
@@ -1368,7 +1368,7 @@ function SLASettingsTab({
         </div>
       </div>
       {/* Escalation Settings */}
-      <div className="space-y-4 pt-6 border-t border-gray-200 dark:border-surface-700">
+      <div className="space-y-4 pt-6 border-t border-gray-200 dark:border-surface-200">
         <h4 className="text-gray-900 dark:text-white font-medium flex items-center gap-2">
           <BellAlertIcon className="w-5 h-5 text-purple-600" />
           Escalation & Breach Handling
@@ -1378,7 +1378,7 @@ function SLASettingsTab({
         </p>
 
         <div className="space-y-4">
-          <label className="flex items-center justify-between p-4 bg-gray-50 dark:bg-surface-700/50 rounded-lg">
+          <label className="flex items-center justify-between p-4 bg-gray-50 dark:bg-surface-200/50 rounded-lg">
             <div>
               <p className="text-gray-900 dark:text-white">Enable Escalation Warnings</p>
               <p className="text-gray-500 dark:text-surface-600 text-sm">
@@ -1389,12 +1389,12 @@ function SLASettingsTab({
               type="checkbox"
               checked={settings.escalationEnabled}
               onChange={(e) => handleChange('escalationEnabled', e.target.checked)}
-              className="rounded border-surface-600"
+              className="rounded border-surface-300"
             />
           </label>
 
           {settings.escalationEnabled && (
-            <div className="p-4 bg-gray-50 dark:bg-surface-700/50 rounded-lg ml-4 border-l-2 border-purple-500">
+            <div className="p-4 bg-gray-50 dark:bg-surface-200/50 rounded-lg ml-4 border-l-2 border-purple-500">
               <label className="block text-gray-900 dark:text-white text-sm font-medium mb-2">
                 Escalation Threshold
               </label>
@@ -1410,7 +1410,7 @@ function SLASettingsTab({
                   }
                   min="50"
                   max="99"
-                  className="w-20 px-3 py-2 bg-white dark:bg-surface-700 border border-gray-300 dark:border-surface-600 rounded-lg text-gray-900 dark:text-white text-sm"
+                  className="w-20 px-3 py-2 bg-white dark:bg-surface-200 border border-gray-300 dark:border-surface-300 rounded-lg text-gray-900 dark:text-white text-sm"
                 />
                 <span className="text-gray-500 dark:text-surface-600 text-sm">%</span>
                 <span className="text-gray-400 dark:text-surface-500 text-xs">
@@ -1421,7 +1421,7 @@ function SLASettingsTab({
             </div>
           )}
 
-          <label className="flex items-center justify-between p-4 bg-gray-50 dark:bg-surface-700/50 rounded-lg">
+          <label className="flex items-center justify-between p-4 bg-gray-50 dark:bg-surface-200/50 rounded-lg">
             <div>
               <p className="text-gray-900 dark:text-white">Auto-Escalate on Breach</p>
               <p className="text-gray-500 dark:text-surface-600 text-sm">
@@ -1432,11 +1432,11 @@ function SLASettingsTab({
               type="checkbox"
               checked={settings.autoEscalateOnBreach}
               onChange={(e) => handleChange('autoEscalateOnBreach', e.target.checked)}
-              className="rounded border-surface-600"
+              className="rounded border-surface-300"
             />
           </label>
 
-          <label className="flex items-center justify-between p-4 bg-gray-50 dark:bg-surface-700/50 rounded-lg">
+          <label className="flex items-center justify-between p-4 bg-gray-50 dark:bg-surface-200/50 rounded-lg">
             <div>
               <p className="text-gray-900 dark:text-white">Breach Notifications</p>
               <p className="text-gray-500 dark:text-surface-600 text-sm">
@@ -1447,11 +1447,11 @@ function SLASettingsTab({
               type="checkbox"
               checked={settings.breachNotificationEnabled}
               onChange={(e) => handleChange('breachNotificationEnabled', e.target.checked)}
-              className="rounded border-surface-600"
+              className="rounded border-surface-300"
             />
           </label>
 
-          <div className="p-4 bg-gray-50 dark:bg-surface-700/50 rounded-lg">
+          <div className="p-4 bg-gray-50 dark:bg-surface-200/50 rounded-lg">
             <label className="block text-gray-900 dark:text-white text-sm font-medium mb-2">
               Breach Grace Period
             </label>
@@ -1466,7 +1466,7 @@ function SLASettingsTab({
                   handleChange('breachGracePeriodHours', parseInt(e.target.value) || 0)
                 }
                 min="0"
-                className="w-20 px-3 py-2 bg-white dark:bg-surface-700 border border-gray-300 dark:border-surface-600 rounded-lg text-gray-900 dark:text-white text-sm"
+                className="w-20 px-3 py-2 bg-white dark:bg-surface-200 border border-gray-300 dark:border-surface-300 rounded-lg text-gray-900 dark:text-white text-sm"
               />
               <span className="text-gray-500 dark:text-surface-600 text-sm">hours</span>
             </div>
@@ -1549,7 +1549,7 @@ function RiskAppetiteTab({
       </div>
       <div className="space-y-4">
         {appetite.map((item) => (
-          <div key={item.category} className="p-4 bg-gray-50 dark:bg-surface-700/50 rounded-lg">
+          <div key={item.category} className="p-4 bg-gray-50 dark:bg-surface-200/50 rounded-lg">
             <div className="flex items-center justify-between mb-3">
               <div className="flex items-center gap-3">
                 <div className={`w-3 h-3 rounded-full ${getLevelColor(item.level)}`} />
@@ -1558,7 +1558,7 @@ function RiskAppetiteTab({
               <SelectNative
                 value={item.level}
                 onChange={(e) => handleLevelChange(item.category, e.target.value)}
-                className="px-3 py-1 bg-gray-50 dark:bg-surface-700 border border-gray-300 dark:border-surface-600 rounded-lg text-gray-900 dark:text-white text-sm"
+                className="px-3 py-1 bg-gray-50 dark:bg-surface-200 border border-gray-300 dark:border-surface-300 rounded-lg text-gray-900 dark:text-white text-sm"
               >
                 <option value="low">Low Appetite</option>
                 <option value="medium">Medium Appetite</option>
@@ -1569,7 +1569,7 @@ function RiskAppetiteTab({
           </div>
         ))}
       </div>
-      <div className="p-4 bg-gray-50 dark:bg-surface-700/50 rounded-lg">
+      <div className="p-4 bg-gray-50 dark:bg-surface-200/50 rounded-lg">
         <h4 className="text-gray-900 dark:text-white font-medium mb-3">Appetite Legend</h4>
         <div className="flex gap-6">
           <div className="flex items-center gap-2">

--- a/frontend/src/pages/RiskDashboard.tsx
+++ b/frontend/src/pages/RiskDashboard.tsx
@@ -34,7 +34,7 @@ function DashboardEditToggle({
         <>
           <button
             onClick={onReset}
-            className="px-3 py-1.5 text-sm text-gray-600 dark:text-surface-600 hover:text-gray-800 dark:hover:text-surface-200 flex items-center gap-1"
+            className="px-3 py-1.5 text-sm text-gray-600 dark:text-surface-600 hover:text-gray-800 dark:hover:text-surface-800 flex items-center gap-1"
           >
             <ArrowPathIcon className="w-4 h-4" />
             Reset
@@ -48,7 +48,7 @@ function DashboardEditToggle({
           </button>
           <button
             onClick={onToggle}
-            className="px-3 py-1.5 text-sm bg-gray-200 dark:bg-surface-700 text-gray-700 dark:text-surface-700 rounded-lg hover:bg-gray-300 dark:hover:bg-surface-600"
+            className="px-3 py-1.5 text-sm bg-gray-200 dark:bg-surface-200 text-gray-700 dark:text-surface-700 rounded-lg hover:bg-gray-300 dark:hover:bg-surface-600"
           >
             Done
           </button>
@@ -56,7 +56,7 @@ function DashboardEditToggle({
       ) : (
         <button
           onClick={onToggle}
-          className="px-3 py-1.5 text-sm text-gray-600 dark:text-surface-600 hover:text-gray-800 dark:hover:text-surface-200 flex items-center gap-1"
+          className="px-3 py-1.5 text-sm text-gray-600 dark:text-surface-600 hover:text-gray-800 dark:hover:text-surface-800 flex items-center gap-1"
           title="Customize dashboard layout"
         >
           <Cog6ToothIcon className="w-4 h-4" />
@@ -405,7 +405,7 @@ export default function RiskDashboard() {
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
           {/* Risk Level Distribution */}
           {activeConfig.riskLevelDistribution && (
-            <div className="bg-white dark:bg-surface-800 rounded-xl border border-gray-200 dark:border-surface-700 p-6">
+            <div className="bg-white dark:bg-white rounded-xl border border-gray-200 dark:border-surface-200 p-6">
               <h2 className="text-lg font-medium text-gray-900 dark:text-white mb-4">
                 Risk Level Distribution
               </h2>
@@ -435,7 +435,7 @@ export default function RiskDashboard() {
                         <span className="text-gray-600 dark:text-surface-700">{label}</span>
                         <span className="text-gray-900 dark:text-white font-medium">{count}</span>
                       </div>
-                      <div className="h-2 bg-gray-200 dark:bg-surface-700 rounded-full overflow-hidden">
+                      <div className="h-2 bg-gray-200 dark:bg-surface-200 rounded-full overflow-hidden">
                         <div
                           className={`h-full ${getRiskLevelColor(key === 'very_high' ? 'critical' : key)} transition-all duration-500`}
                           style={{ width: `${percentage}%` }}
@@ -450,7 +450,7 @@ export default function RiskDashboard() {
 
           {/* Risk by Category */}
           {activeConfig.risksByCategory && (
-            <div className="bg-white dark:bg-surface-800 rounded-xl border border-gray-200 dark:border-surface-700 p-6">
+            <div className="bg-white dark:bg-white rounded-xl border border-gray-200 dark:border-surface-200 p-6">
               <h2 className="text-lg font-medium text-gray-900 dark:text-white mb-4">
                 Risks by Category
               </h2>
@@ -460,7 +460,7 @@ export default function RiskDashboard() {
                     <span className="text-gray-600 dark:text-surface-700 capitalize">
                       {cat.category?.replace('_', ' ') || 'Uncategorized'}
                     </span>
-                    <span className="px-2 py-1 bg-gray-100 dark:bg-surface-700 rounded text-gray-900 dark:text-white text-sm font-medium">
+                    <span className="px-2 py-1 bg-gray-100 dark:bg-surface-200 rounded text-gray-900 dark:text-white text-sm font-medium">
                       {cat.count}
                     </span>
                   </div>
@@ -481,7 +481,7 @@ export default function RiskDashboard() {
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
           {/* Recent Risks */}
           {activeConfig.recentRisks && (
-            <div className="lg:col-span-2 bg-white dark:bg-surface-800 rounded-xl border border-gray-200 dark:border-surface-700 p-6">
+            <div className="lg:col-span-2 bg-white dark:bg-white rounded-xl border border-gray-200 dark:border-surface-200 p-6">
               <div className="flex items-center justify-between mb-4">
                 <h2 className="text-lg font-medium text-gray-900 dark:text-white">Recent Risks</h2>
                 <Link
@@ -496,7 +496,7 @@ export default function RiskDashboard() {
                   <Link
                     key={risk.id}
                     to={`/risks/${risk.id}`}
-                    className="flex items-center gap-4 p-3 bg-gray-50 dark:bg-surface-700/50 rounded-lg hover:bg-gray-100 dark:hover:bg-surface-700 transition-colors"
+                    className="flex items-center gap-4 p-3 bg-gray-50 dark:bg-surface-200/50 rounded-lg hover:bg-gray-100 dark:hover:bg-surface-200 transition-colors"
                   >
                     <div
                       className={`w-2 h-2 rounded-full ${getRiskLevelColor(risk.inherentRisk)}`}
@@ -527,7 +527,7 @@ export default function RiskDashboard() {
 
           {/* Quick Actions */}
           {activeConfig.quickActions && (
-            <div className="bg-white dark:bg-surface-800 rounded-xl border border-gray-200 dark:border-surface-700 p-6">
+            <div className="bg-white dark:bg-white rounded-xl border border-gray-200 dark:border-surface-200 p-6">
               <h2 className="text-lg font-medium text-gray-900 dark:text-white mb-4">
                 Quick Actions
               </h2>
@@ -541,21 +541,21 @@ export default function RiskDashboard() {
                 </Link>
                 <Link
                   to="/risk-queue"
-                  className="flex items-center gap-3 p-3 bg-gray-100 dark:bg-surface-700 text-gray-700 dark:text-surface-700 rounded-lg hover:bg-gray-200 dark:hover:bg-surface-600 transition-colors"
+                  className="flex items-center gap-3 p-3 bg-gray-100 dark:bg-surface-200 text-gray-700 dark:text-surface-700 rounded-lg hover:bg-gray-200 dark:hover:bg-surface-600 transition-colors"
                 >
                   <ClockIcon className="w-5 h-5" />
                   <span>View My Queue</span>
                 </Link>
                 <Link
                   to="/risk-heatmap"
-                  className="flex items-center gap-3 p-3 bg-gray-100 dark:bg-surface-700 text-gray-700 dark:text-surface-700 rounded-lg hover:bg-gray-200 dark:hover:bg-surface-600 transition-colors"
+                  className="flex items-center gap-3 p-3 bg-gray-100 dark:bg-surface-200 text-gray-700 dark:text-surface-700 rounded-lg hover:bg-gray-200 dark:hover:bg-surface-600 transition-colors"
                 >
                   <ChartBarIcon className="w-5 h-5" />
                   <span>View Heatmap</span>
                 </Link>
                 <Link
                   to="/risk-reports"
-                  className="flex items-center gap-3 p-3 bg-gray-100 dark:bg-surface-700 text-gray-700 dark:text-surface-700 rounded-lg hover:bg-gray-200 dark:hover:bg-surface-600 transition-colors"
+                  className="flex items-center gap-3 p-3 bg-gray-100 dark:bg-surface-200 text-gray-700 dark:text-surface-700 rounded-lg hover:bg-gray-200 dark:hover:bg-surface-600 transition-colors"
                 >
                   <ArrowTrendingUpIcon className="w-5 h-5" />
                   <span>Generate Report</span>
@@ -568,7 +568,7 @@ export default function RiskDashboard() {
 
       {/* Risk Appetite Indicator */}
       {activeConfig.riskAppetite && (
-        <div className="bg-white dark:bg-surface-800 rounded-xl border border-gray-200 dark:border-surface-700 p-6">
+        <div className="bg-white dark:bg-white rounded-xl border border-gray-200 dark:border-surface-200 p-6">
           <h2 className="text-lg font-medium text-gray-900 dark:text-white mb-4">
             Risk Appetite Status
           </h2>
@@ -623,7 +623,7 @@ function MetricCard({
   trend?: number;
 }) {
   return (
-    <div className="bg-white dark:bg-surface-800 rounded-xl border border-gray-200 dark:border-surface-700 p-6">
+    <div className="bg-white dark:bg-white rounded-xl border border-gray-200 dark:border-surface-200 p-6">
       <div className="flex items-center gap-4">
         <div className={`p-3 rounded-lg ${bgColor}`}>
           <Icon className={`w-6 h-6 ${color}`} />

--- a/frontend/src/pages/RiskDetail.tsx
+++ b/frontend/src/pages/RiskDetail.tsx
@@ -284,7 +284,7 @@ export default function RiskDetail() {
         <div className="flex items-center gap-4">
           <button
             onClick={() => navigate('/risks')}
-            className="p-2 hover:bg-surface-700 rounded-lg text-surface-600"
+            className="p-2 hover:bg-surface-200 rounded-lg text-surface-600"
           >
             <ArrowLeft className="w-5 h-5" />
           </button>
@@ -304,7 +304,7 @@ export default function RiskDetail() {
           <button
             onClick={() => markReviewedMutation.mutate()}
             disabled={markReviewedMutation.isPending}
-            className="px-4 py-2 bg-surface-700 text-surface-700 rounded-lg hover:bg-surface-600 flex items-center gap-2"
+            className="px-4 py-2 bg-surface-200 text-surface-700 rounded-lg hover:bg-surface-600 flex items-center gap-2"
           >
             <CheckCircle className="w-4 h-4" />
             Mark Reviewed
@@ -318,7 +318,7 @@ export default function RiskDetail() {
           </button>
           <button
             onClick={() => setShowEditModal(true)}
-            className="p-2 hover:bg-surface-700 rounded-lg text-surface-600"
+            className="p-2 hover:bg-surface-200 rounded-lg text-surface-600"
           >
             <Edit2 className="w-5 h-5" />
           </button>
@@ -344,10 +344,10 @@ export default function RiskDetail() {
       {/* Risk Overview */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Main Info */}
-        <div className="lg:col-span-2 bg-surface-800 rounded-xl border border-surface-700 p-6 space-y-6">
+        <div className="lg:col-span-2 bg-white rounded-xl border border-surface-200 p-6 space-y-6">
           <div>
             <h3 className="text-sm font-medium text-surface-600 mb-2">Description</h3>
-            <p className="text-surface-200">{risk.description}</p>
+            <p className="text-surface-800">{risk.description}</p>
           </div>
 
           <div className="grid grid-cols-2 gap-6">
@@ -392,7 +392,7 @@ export default function RiskDetail() {
 
           {/* Treatment Info */}
           {risk.treatmentPlan && (
-            <div className="pt-4 border-t border-surface-700">
+            <div className="pt-4 border-t border-surface-200">
               <h3 className="text-sm font-medium text-surface-600 mb-2">Treatment Plan</h3>
               <div className="flex items-center gap-4">
                 <span className="px-3 py-1 bg-brand-500/20 text-brand-400 rounded capitalize">
@@ -415,7 +415,7 @@ export default function RiskDetail() {
         {/* Risk Scoring */}
         <div className="space-y-4">
           {/* Qualitative */}
-          <div className="bg-surface-800 rounded-xl border border-surface-700 p-6">
+          <div className="bg-white rounded-xl border border-surface-200 p-6">
             <h3 className="text-lg font-medium text-white mb-4">Risk Assessment</h3>
 
             <div className="space-y-4">
@@ -429,7 +429,7 @@ export default function RiskDetail() {
                 <span className="text-surface-600">Impact</span>
                 <span className="text-white capitalize">{risk.impact}</span>
               </div>
-              <div className="flex justify-between items-center pt-2 border-t border-surface-700">
+              <div className="flex justify-between items-center pt-2 border-t border-surface-200">
                 <span className="text-surface-600">Inherent Risk</span>
                 <div className="flex items-center gap-2">
                   <span
@@ -454,7 +454,7 @@ export default function RiskDetail() {
 
           {/* Quantitative */}
           {(risk.likelihoodPct !== undefined || risk.impactValue !== undefined) && (
-            <div className="bg-surface-800 rounded-xl border border-surface-700 p-6">
+            <div className="bg-white rounded-xl border border-surface-200 p-6">
               <h3 className="text-lg font-medium text-white mb-4">Quantitative Analysis</h3>
               <div className="space-y-4">
                 {risk.likelihoodPct !== undefined && (
@@ -476,7 +476,7 @@ export default function RiskDetail() {
                   </div>
                 )}
                 {risk.annualLossExp !== undefined && (
-                  <div className="flex justify-between items-center pt-2 border-t border-surface-700">
+                  <div className="flex justify-between items-center pt-2 border-t border-surface-200">
                     <span className="text-surface-600 flex items-center gap-2">
                       <TrendingUp className="w-4 h-4" />
                       Annual Loss Exp.
@@ -491,7 +491,7 @@ export default function RiskDetail() {
           )}
 
           {/* Quick Stats */}
-          <div className="bg-surface-800 rounded-xl border border-surface-700 p-6">
+          <div className="bg-white rounded-xl border border-surface-200 p-6">
             <h3 className="text-lg font-medium text-white mb-4">Linked Items</h3>
             <div className="space-y-3">
               <div className="flex justify-between items-center">
@@ -521,9 +521,9 @@ export default function RiskDetail() {
       </div>
 
       {/* Tabs */}
-      <div className="bg-surface-800 rounded-xl border border-surface-700">
+      <div className="bg-white rounded-xl border border-surface-200">
         {/* Tab Headers */}
-        <div className="flex border-b border-surface-700">
+        <div className="flex border-b border-surface-200">
           {[
             {
               key: 'controls',
@@ -553,7 +553,7 @@ export default function RiskDetail() {
               <tab.icon className="w-4 h-4" />
               {tab.label}
               {tab.count !== null && (
-                <span className="px-2 py-0.5 bg-surface-700 rounded text-xs">{tab.count}</span>
+                <span className="px-2 py-0.5 bg-surface-200 rounded text-xs">{tab.count}</span>
               )}
             </button>
           ))}
@@ -583,7 +583,7 @@ export default function RiskDetail() {
                   {risk?.controls?.map((control) => (
                     <div
                       key={control.id}
-                      className="flex items-center justify-between p-4 bg-surface-700 rounded-lg"
+                      className="flex items-center justify-between p-4 bg-surface-200 rounded-lg"
                     >
                       <div className="flex items-center gap-4">
                         <div>
@@ -638,7 +638,7 @@ export default function RiskDetail() {
                   {risk?.assets?.map((asset) => (
                     <div
                       key={asset.id}
-                      className="flex items-center justify-between p-4 bg-surface-700 rounded-lg"
+                      className="flex items-center justify-between p-4 bg-surface-200 rounded-lg"
                     >
                       <div className="flex items-center gap-4">
                         <Server className="w-8 h-8 text-surface-600" />
@@ -682,7 +682,7 @@ export default function RiskDetail() {
               ) : (
                 <div className="space-y-3">
                   {risk?.scenarios?.map((scenario) => (
-                    <div key={scenario.id} className="p-4 bg-surface-700 rounded-lg">
+                    <div key={scenario.id} className="p-4 bg-surface-200 rounded-lg">
                       <div className="flex justify-between items-start">
                         <div>
                           <h4 className="text-white font-medium">{scenario.title}</h4>
@@ -825,9 +825,9 @@ function LinkControlModal({
 
   return (
     <Dialog open onClose={onClose}>
-      <div className="p-4 border-b border-surface-700 flex justify-between items-center">
+      <div className="p-4 border-b border-surface-200 flex justify-between items-center">
         <h3 className="text-lg font-medium text-white">Link Control</h3>
-        <button onClick={onClose} className="p-1 hover:bg-surface-700 rounded">
+        <button onClick={onClose} className="p-1 hover:bg-surface-200 rounded">
           <X className="w-5 h-5 text-surface-600" />
         </button>
       </div>
@@ -837,7 +837,7 @@ function LinkControlModal({
           placeholder="Search controls..."
           value={search}
           onChange={(e) => setSearch(e.target.value)}
-          className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+          className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
         />
         <div className="max-h-60 overflow-y-auto space-y-2">
           {availableControls.map((control) => (
@@ -846,7 +846,7 @@ function LinkControlModal({
               className={`flex items-center gap-3 p-3 rounded-lg cursor-pointer ${
                 selectedControlId === control.id
                   ? 'bg-brand-500/20'
-                  : 'bg-surface-700 hover:bg-surface-600'
+                  : 'bg-surface-200 hover:bg-surface-600'
               }`}
             >
               <input
@@ -870,7 +870,7 @@ function LinkControlModal({
             <SelectNative
               value={effectiveness}
               onChange={(e) => setEffectiveness(e.target.value)}
-              className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+              className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
             >
               <option value="none">None</option>
               <option value="partial">Partial</option>
@@ -879,8 +879,8 @@ function LinkControlModal({
           </div>
         )}
       </div>
-      <div className="p-4 border-t border-surface-700 flex justify-end gap-3">
-        <button onClick={onClose} className="px-4 py-2 bg-surface-700 text-surface-700 rounded-lg">
+      <div className="p-4 border-t border-surface-200 flex justify-end gap-3">
+        <button onClick={onClose} className="px-4 py-2 bg-surface-200 text-surface-700 rounded-lg">
           Cancel
         </button>
         <button
@@ -923,9 +923,9 @@ function LinkAssetModal({
 
   return (
     <Dialog open onClose={onClose}>
-      <div className="p-4 border-b border-surface-700 flex justify-between items-center">
+      <div className="p-4 border-b border-surface-200 flex justify-between items-center">
         <h3 className="text-lg font-medium text-white">Link Assets</h3>
-        <button onClick={onClose} className="p-1 hover:bg-surface-700 rounded">
+        <button onClick={onClose} className="p-1 hover:bg-surface-200 rounded">
           <X className="w-5 h-5 text-surface-600" />
         </button>
       </div>
@@ -935,7 +935,7 @@ function LinkAssetModal({
           placeholder="Search assets..."
           value={search}
           onChange={(e) => setSearch(e.target.value)}
-          className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+          className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
         />
         <div className="max-h-60 overflow-y-auto space-y-2">
           {availableAssets.length === 0 ? (
@@ -947,7 +947,7 @@ function LinkAssetModal({
                 className={`flex items-center gap-3 p-3 rounded-lg cursor-pointer ${
                   selectedAssetIds.includes(asset.id)
                     ? 'bg-brand-500/20'
-                    : 'bg-surface-700 hover:bg-surface-600'
+                    : 'bg-surface-200 hover:bg-surface-600'
                 }`}
               >
                 <input
@@ -967,8 +967,8 @@ function LinkAssetModal({
           )}
         </div>
       </div>
-      <div className="p-4 border-t border-surface-700 flex justify-end gap-3">
-        <button onClick={onClose} className="px-4 py-2 bg-surface-700 text-surface-700 rounded-lg">
+      <div className="p-4 border-t border-surface-200 flex justify-end gap-3">
+        <button onClick={onClose} className="px-4 py-2 bg-surface-200 text-surface-700 rounded-lg">
           Cancel
         </button>
         <button
@@ -1004,9 +1004,9 @@ function TreatmentModal({
 
   return (
     <Dialog open onClose={onClose}>
-      <div className="p-4 border-b border-surface-700 flex justify-between items-center">
+      <div className="p-4 border-b border-surface-200 flex justify-between items-center">
         <h3 className="text-lg font-medium text-white">Treatment Plan</h3>
-        <button onClick={onClose} className="p-1 hover:bg-surface-700 rounded">
+        <button onClick={onClose} className="p-1 hover:bg-surface-200 rounded">
           <X className="w-5 h-5 text-surface-600" />
         </button>
       </div>
@@ -1022,7 +1022,7 @@ function TreatmentModal({
                 className={`p-3 rounded-lg text-left ${
                   plan === tp.value
                     ? 'bg-brand-500/20 border border-brand-500'
-                    : 'bg-surface-700 border border-surface-600 hover:bg-surface-600'
+                    : 'bg-surface-200 border border-surface-300 hover:bg-surface-600'
                 }`}
               >
                 <p className="text-white font-medium">{tp.label}</p>
@@ -1037,7 +1037,7 @@ function TreatmentModal({
             type="date"
             value={dueDate}
             onChange={(e) => setDueDate(e.target.value)}
-            className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+            className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
           />
         </div>
         <div>
@@ -1046,13 +1046,13 @@ function TreatmentModal({
             value={notes}
             onChange={(e) => setNotes(e.target.value)}
             rows={3}
-            className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+            className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
             placeholder="Describe the treatment approach..."
           />
         </div>
       </div>
-      <div className="p-4 border-t border-surface-700 flex justify-end gap-3">
-        <button onClick={onClose} className="px-4 py-2 bg-surface-700 text-surface-700 rounded-lg">
+      <div className="p-4 border-t border-surface-200 flex justify-end gap-3">
+        <button onClick={onClose} className="px-4 py-2 bg-surface-200 text-surface-700 rounded-lg">
           Cancel
         </button>
         <button
@@ -1094,9 +1094,9 @@ function ScenarioModal({
 
   return (
     <Dialog open onClose={onClose}>
-      <div className="p-4 border-b border-surface-700 flex justify-between items-center">
+      <div className="p-4 border-b border-surface-200 flex justify-between items-center">
         <h3 className="text-lg font-medium text-white">Add Scenario</h3>
-        <button onClick={onClose} className="p-1 hover:bg-surface-700 rounded">
+        <button onClick={onClose} className="p-1 hover:bg-surface-200 rounded">
           <X className="w-5 h-5 text-surface-600" />
         </button>
       </div>
@@ -1114,7 +1114,7 @@ function ScenarioModal({
             value={scenario.title}
             onChange={(e) => setScenario((prev) => ({ ...prev, title: e.target.value }))}
             required
-            className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+            className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
             placeholder="e.g., Phishing attack on employees"
           />
         </div>
@@ -1125,7 +1125,7 @@ function ScenarioModal({
             onChange={(e) => setScenario((prev) => ({ ...prev, description: e.target.value }))}
             required
             rows={2}
-            className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+            className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
           />
         </div>
         <div className="grid grid-cols-2 gap-4">
@@ -1134,7 +1134,7 @@ function ScenarioModal({
             <SelectNative
               value={scenario.threatActor}
               onChange={(e) => setScenario((prev) => ({ ...prev, threatActor: e.target.value }))}
-              className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+              className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
             >
               <option value="">Select...</option>
               <option value="insider">Insider</option>
@@ -1148,7 +1148,7 @@ function ScenarioModal({
               type="text"
               value={scenario.attackVector}
               onChange={(e) => setScenario((prev) => ({ ...prev, attackVector: e.target.value }))}
-              className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+              className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
               placeholder="e.g., Email, Network"
             />
           </div>
@@ -1159,7 +1159,7 @@ function ScenarioModal({
             <SelectNative
               value={scenario.likelihood}
               onChange={(e) => setScenario((prev) => ({ ...prev, likelihood: e.target.value }))}
-              className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+              className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
             >
               {LIKELIHOODS.map((l) => (
                 <option key={l} value={l}>
@@ -1173,7 +1173,7 @@ function ScenarioModal({
             <SelectNative
               value={scenario.impact}
               onChange={(e) => setScenario((prev) => ({ ...prev, impact: e.target.value }))}
-              className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+              className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
             >
               {IMPACTS.map((i) => (
                 <option key={i} value={i}>
@@ -1187,7 +1187,7 @@ function ScenarioModal({
           <button
             type="button"
             onClick={onClose}
-            className="px-4 py-2 bg-surface-700 text-surface-700 rounded-lg"
+            className="px-4 py-2 bg-surface-200 text-surface-700 rounded-lg"
           >
             Cancel
           </button>
@@ -1272,9 +1272,9 @@ function EditRiskModal({
 
   return (
     <Dialog open onClose={onClose}>
-      <div className="p-6 border-b border-surface-700 flex items-center justify-between">
+      <div className="p-6 border-b border-surface-200 flex items-center justify-between">
         <h2 className="text-xl font-semibold text-white">Edit Risk</h2>
-        <button onClick={onClose} className="p-2 hover:bg-surface-700 rounded-lg text-surface-600">
+        <button onClick={onClose} className="p-2 hover:bg-surface-200 rounded-lg text-surface-600">
           <X className="w-5 h-5" />
         </button>
       </div>
@@ -1294,7 +1294,7 @@ function EditRiskModal({
             value={formData.title}
             onChange={(e) => setFormData((prev) => ({ ...prev, title: e.target.value }))}
             required
-            className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white placeholder-surface-400 focus:outline-none focus:ring-2 focus:ring-brand-500"
+            className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white placeholder-surface-500 focus:outline-none focus:ring-2 focus:ring-brand-500"
           />
         </div>
 
@@ -1306,7 +1306,7 @@ function EditRiskModal({
             onChange={(e) => setFormData((prev) => ({ ...prev, description: e.target.value }))}
             required
             rows={4}
-            className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white placeholder-surface-400 focus:outline-none focus:ring-2 focus:ring-brand-500"
+            className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white placeholder-surface-500 focus:outline-none focus:ring-2 focus:ring-brand-500"
           />
         </div>
 
@@ -1317,7 +1317,7 @@ function EditRiskModal({
             <SelectNative
               value={formData.category}
               onChange={(e) => setFormData((prev) => ({ ...prev, category: e.target.value }))}
-              className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+              className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
             >
               {CATEGORIES.map((cat) => (
                 <option key={cat.value} value={cat.value}>
@@ -1331,7 +1331,7 @@ function EditRiskModal({
             <SelectNative
               value={formData.source}
               onChange={(e) => setFormData((prev) => ({ ...prev, source: e.target.value }))}
-              className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+              className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
             >
               {SOURCES.map((src) => (
                 <option key={src.value} value={src.value}>
@@ -1352,7 +1352,7 @@ function EditRiskModal({
             onChange={(e) =>
               setFormData((prev) => ({ ...prev, initialSeverity: e.target.value as any }))
             }
-            className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+            className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
           >
             {SEVERITIES.map((sev) => (
               <option key={sev.value} value={sev.value}>
@@ -1388,13 +1388,13 @@ function EditRiskModal({
               value={tagInput}
               onChange={(e) => setTagInput(e.target.value)}
               onKeyPress={(e) => e.key === 'Enter' && (e.preventDefault(), handleAddTag())}
-              className="flex-1 px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white placeholder-surface-400 focus:outline-none focus:ring-2 focus:ring-brand-500"
+              className="flex-1 px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white placeholder-surface-500 focus:outline-none focus:ring-2 focus:ring-brand-500"
               placeholder="Add tag..."
             />
             <button
               type="button"
               onClick={handleAddTag}
-              className="px-4 py-2 bg-surface-700 text-surface-700 rounded-lg hover:bg-surface-600"
+              className="px-4 py-2 bg-surface-200 text-surface-700 rounded-lg hover:bg-surface-600"
             >
               Add
             </button>
@@ -1402,11 +1402,11 @@ function EditRiskModal({
         </div>
 
         {/* Actions */}
-        <div className="flex justify-end gap-3 pt-4 border-t border-surface-700">
+        <div className="flex justify-end gap-3 pt-4 border-t border-surface-200">
           <button
             type="button"
             onClick={onClose}
-            className="px-4 py-2 bg-surface-700 text-surface-700 rounded-lg hover:bg-surface-600"
+            className="px-4 py-2 bg-surface-200 text-surface-700 rounded-lg hover:bg-surface-600"
           >
             Cancel
           </button>

--- a/frontend/src/pages/RiskHeatmap.tsx
+++ b/frontend/src/pages/RiskHeatmap.tsx
@@ -58,7 +58,7 @@ function getCellColor(likelihoodIdx: number, impactIdx: number): string {
     case 'low':
       return 'bg-emerald-500/40 hover:bg-emerald-500/60';
     default:
-      return 'bg-surface-700 hover:bg-surface-600';
+      return 'bg-surface-200 hover:bg-surface-600';
   }
 }
 
@@ -232,7 +232,7 @@ export default function RiskHeatmap() {
         <div className="flex items-center gap-4">
           <button
             onClick={() => navigate('/risks')}
-            className="p-2 hover:bg-surface-700 rounded-lg text-surface-600"
+            className="p-2 hover:bg-surface-200 rounded-lg text-surface-600"
           >
             <ArrowLeft className="w-5 h-5" />
           </button>
@@ -260,10 +260,10 @@ export default function RiskHeatmap() {
           </button>
 
           {showExportMenu && !isExporting && (
-            <div className="absolute right-0 mt-2 w-48 bg-surface-800 border border-surface-700 rounded-lg shadow-xl z-10">
+            <div className="absolute right-0 mt-2 w-48 bg-white border border-surface-200 rounded-lg shadow-xl z-10">
               <button
                 onClick={exportToPNG}
-                className="w-full flex items-center gap-3 px-4 py-3 text-left text-surface-700 hover:bg-surface-700 transition-colors"
+                className="w-full flex items-center gap-3 px-4 py-3 text-left text-surface-700 hover:bg-surface-200 transition-colors"
               >
                 <FileImage className="w-4 h-4" />
                 <div>
@@ -273,7 +273,7 @@ export default function RiskHeatmap() {
               </button>
               <button
                 onClick={exportToPDF}
-                className="w-full flex items-center gap-3 px-4 py-3 text-left text-surface-700 hover:bg-surface-700 transition-colors border-t border-surface-700"
+                className="w-full flex items-center gap-3 px-4 py-3 text-left text-surface-700 hover:bg-surface-200 transition-colors border-t border-surface-200"
               >
                 <FileText className="w-4 h-4" />
                 <div>
@@ -288,7 +288,7 @@ export default function RiskHeatmap() {
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Heatmap Grid */}
-        <div className="lg:col-span-2 bg-surface-800 rounded-xl border border-surface-700 p-6">
+        <div className="lg:col-span-2 bg-white rounded-xl border border-surface-200 p-6">
           {isLoading ? (
             <div className="flex items-center justify-center h-96">
               <div className="text-surface-600">Loading heatmap...</div>
@@ -385,7 +385,7 @@ export default function RiskHeatmap() {
         {/* Sidebar */}
         <div className="space-y-6">
           {/* Selected Cell Details */}
-          <div className="bg-surface-800 rounded-xl border border-surface-700 p-6">
+          <div className="bg-white rounded-xl border border-surface-200 p-6">
             <h3 className="text-lg font-medium text-white mb-4">
               {selectedCell ? 'Selected Risks' : 'Click a Cell'}
             </h3>
@@ -410,7 +410,7 @@ export default function RiskHeatmap() {
                     <button
                       key={risk.id}
                       onClick={() => navigate(`/risks/${risk.id}`)}
-                      className="w-full p-3 bg-surface-700 rounded-lg text-left hover:bg-surface-600 transition-colors"
+                      className="w-full p-3 bg-surface-200 rounded-lg text-left hover:bg-surface-600 transition-colors"
                     >
                       <span className="text-brand-400 font-mono text-sm">{risk.riskId}</span>
                       <p className="text-white mt-1">{risk.title}</p>
@@ -428,7 +428,7 @@ export default function RiskHeatmap() {
 
           {/* Stats */}
           {dashboard && (
-            <div className="bg-surface-800 rounded-xl border border-surface-700 p-6">
+            <div className="bg-white rounded-xl border border-surface-200 p-6">
               <h3 className="text-lg font-medium text-white mb-4">Risk Distribution</h3>
               <div className="space-y-3">
                 {dashboard.byRiskLevel?.map((level: any) => {
@@ -450,7 +450,7 @@ export default function RiskHeatmap() {
                           {level.count} ({percentage}%)
                         </span>
                       </div>
-                      <div className="h-2 bg-surface-700 rounded-full overflow-hidden">
+                      <div className="h-2 bg-surface-200 rounded-full overflow-hidden">
                         <div
                           className={`h-full ${levelColors[level.level] || 'bg-surface-500'}`}
                           style={{ width: `${percentage}%` }}
@@ -465,13 +465,13 @@ export default function RiskHeatmap() {
 
           {/* Category Distribution */}
           {dashboard && (
-            <div className="bg-surface-800 rounded-xl border border-surface-700 p-6">
+            <div className="bg-white rounded-xl border border-surface-200 p-6">
               <h3 className="text-lg font-medium text-white mb-4">By Category</h3>
               <div className="space-y-2">
                 {dashboard.byCategory?.map((cat: any) => (
                   <div
                     key={cat.category}
-                    className="flex justify-between items-center p-2 bg-surface-700 rounded"
+                    className="flex justify-between items-center p-2 bg-surface-200 rounded"
                   >
                     <span className="text-surface-700 capitalize">{cat.category}</span>
                     <span className="text-white font-medium">{cat.count}</span>

--- a/frontend/src/pages/RiskQueue.tsx
+++ b/frontend/src/pages/RiskQueue.tsx
@@ -220,12 +220,12 @@ export default function RiskQueue() {
             className={`p-4 rounded-xl border transition-colors text-left ${
               activeTab === tab.key
                 ? 'bg-brand-500/20 border-brand-500'
-                : 'bg-surface-800 border-surface-700 hover:border-surface-600'
+                : 'bg-white border-surface-200 hover:border-surface-300'
             }`}
           >
             <div className="flex items-center gap-3">
               <div
-                className={`p-2 rounded-lg ${activeTab === tab.key ? 'bg-brand-500/30' : 'bg-surface-700'}`}
+                className={`p-2 rounded-lg ${activeTab === tab.key ? 'bg-brand-500/30' : 'bg-surface-200'}`}
               >
                 <tab.icon className={`w-5 h-5 ${tab.color}`} />
               </div>
@@ -239,8 +239,8 @@ export default function RiskQueue() {
       </div>
 
       {/* Queue List */}
-      <div className="bg-surface-800 rounded-xl border border-surface-700">
-        <div className="p-4 border-b border-surface-700">
+      <div className="bg-white rounded-xl border border-surface-200">
+        <div className="p-4 border-b border-surface-200">
           <h2 className="text-lg font-medium text-white">
             {tabs.find((t) => t.key === activeTab)?.label}
           </h2>
@@ -251,7 +251,7 @@ export default function RiskQueue() {
           )}
         </div>
 
-        <div className="divide-y divide-surface-700">
+        <div className="divide-y divide-surface-200">
           {/* Tasks Tab Content */}
           {activeTab === 'tasks' && (
             <>
@@ -267,7 +267,7 @@ export default function RiskQueue() {
                   return (
                     <div
                       key={task.id}
-                      className={`p-4 hover:bg-surface-700/50 transition-colors ${
+                      className={`p-4 hover:bg-surface-200/50 transition-colors ${
                         isOverdue ? 'bg-red-900/10' : ''
                       }`}
                     >
@@ -359,7 +359,7 @@ export default function RiskQueue() {
                           )}
                           <Link
                             to={`/risks/${task.riskId}`}
-                            className="flex items-center gap-1 px-3 py-1.5 bg-surface-700 text-white rounded-lg hover:bg-surface-600 text-sm"
+                            className="flex items-center gap-1 px-3 py-1.5 bg-surface-200 text-white rounded-lg hover:bg-surface-600 text-sm"
                           >
                             View Risk
                             <ArrowRightIcon className="w-4 h-4" />
@@ -384,7 +384,7 @@ export default function RiskQueue() {
                 </div>
               ) : (
                 getActiveQueue().map((risk: any) => (
-                  <div key={risk.id} className="p-4 hover:bg-surface-700/50 transition-colors">
+                  <div key={risk.id} className="p-4 hover:bg-surface-200/50 transition-colors">
                     <div className="flex items-center gap-4">
                       {/* Risk Level Indicator */}
                       <div
@@ -434,7 +434,7 @@ export default function RiskQueue() {
       </div>
 
       {/* Tips Section */}
-      <div className="bg-surface-800 rounded-xl border border-surface-700 p-6">
+      <div className="bg-white rounded-xl border border-surface-200 p-6">
         <h3 className="text-lg font-medium text-white mb-3">Queue Tips</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
           <div className="flex gap-3">
@@ -442,7 +442,7 @@ export default function RiskQueue() {
               <span className="text-amber-600 font-bold">1</span>
             </div>
             <p className="text-surface-600">
-              <strong className="text-surface-200">Assessments:</strong> Complete risk analysis
+              <strong className="text-surface-800">Assessments:</strong> Complete risk analysis
               including likelihood, impact, and recommended treatment.
             </p>
           </div>
@@ -451,7 +451,7 @@ export default function RiskQueue() {
               <span className="text-orange-600 font-bold">2</span>
             </div>
             <p className="text-surface-600">
-              <strong className="text-surface-200">Treatments:</strong> Decide how to handle the
+              <strong className="text-surface-800">Treatments:</strong> Decide how to handle the
               risk - mitigate, accept, transfer, or avoid.
             </p>
           </div>
@@ -460,7 +460,7 @@ export default function RiskQueue() {
               <span className="text-purple-600 font-bold">3</span>
             </div>
             <p className="text-surface-600">
-              <strong className="text-surface-200">Approvals:</strong> Executive review required for
+              <strong className="text-surface-800">Approvals:</strong> Executive review required for
               high-risk accept/transfer/avoid decisions.
             </p>
           </div>
@@ -469,7 +469,7 @@ export default function RiskQueue() {
               <span className="text-cyan-600 font-bold">4</span>
             </div>
             <p className="text-surface-600">
-              <strong className="text-surface-200">Reviews:</strong> GRC team validates assessments
+              <strong className="text-surface-800">Reviews:</strong> GRC team validates assessments
               before treatment decisions.
             </p>
           </div>

--- a/frontend/src/pages/RiskReports.tsx
+++ b/frontend/src/pages/RiskReports.tsx
@@ -552,7 +552,7 @@ export default function RiskReports() {
       <div className="grid grid-cols-1 lg:grid-cols-12 gap-6 items-start">
         {/* Report Templates - Left Panel */}
         <div className="lg:col-span-4">
-          <div className="bg-white dark:bg-surface-800 rounded-xl border border-gray-200 dark:border-surface-700 p-5">
+          <div className="bg-white dark:bg-white rounded-xl border border-gray-200 dark:border-surface-200 p-5">
             <h2 className="text-base font-medium text-gray-900 dark:text-white mb-4">
               Report Templates
             </h2>
@@ -564,7 +564,7 @@ export default function RiskReports() {
                   className={`w-full p-3 rounded-lg border text-left transition-all ${
                     selectedReport === template.id
                       ? 'bg-brand-500/10 border-brand-500/50'
-                      : 'bg-gray-50 dark:bg-surface-700/50 border-gray-200 dark:border-surface-700 hover:border-gray-300 dark:hover:border-surface-600 hover:bg-gray-100 dark:hover:bg-surface-700'
+                      : 'bg-gray-50 dark:bg-surface-200/50 border-gray-200 dark:border-surface-200 hover:border-gray-300 dark:hover:border-surface-300 hover:bg-gray-100 dark:hover:bg-surface-200'
                   }`}
                 >
                   <div className="flex items-start gap-3">
@@ -609,7 +609,7 @@ export default function RiskReports() {
           {selectedReport && selectedTemplate ? (
             <>
               {/* Selected Report Header */}
-              <div className="bg-white dark:bg-surface-800 rounded-xl border border-gray-200 dark:border-surface-700 p-5">
+              <div className="bg-white dark:bg-white rounded-xl border border-gray-200 dark:border-surface-200 p-5">
                 <div className="flex items-center gap-3 mb-4">
                   <div className="p-2.5 rounded-lg bg-brand-500/20">
                     <selectedTemplate.icon className="w-5 h-5 text-brand-500 dark:text-brand-400" />
@@ -635,7 +635,7 @@ export default function RiskReports() {
                       type="date"
                       value={dateRange.start}
                       onChange={(e) => setDateRange((prev) => ({ ...prev, start: e.target.value }))}
-                      className="w-full px-3 py-2 bg-gray-50 dark:bg-surface-700 border border-gray-300 dark:border-surface-600 rounded-lg text-gray-900 dark:text-white text-sm"
+                      className="w-full px-3 py-2 bg-gray-50 dark:bg-surface-200 border border-gray-300 dark:border-surface-300 rounded-lg text-gray-900 dark:text-white text-sm"
                     />
                   </div>
                   <div>
@@ -647,7 +647,7 @@ export default function RiskReports() {
                       type="date"
                       value={dateRange.end}
                       onChange={(e) => setDateRange((prev) => ({ ...prev, end: e.target.value }))}
-                      className="w-full px-3 py-2 bg-gray-50 dark:bg-surface-700 border border-gray-300 dark:border-surface-600 rounded-lg text-gray-900 dark:text-white text-sm"
+                      className="w-full px-3 py-2 bg-gray-50 dark:bg-surface-200 border border-gray-300 dark:border-surface-300 rounded-lg text-gray-900 dark:text-white text-sm"
                     />
                   </div>
                   <div>
@@ -660,7 +660,7 @@ export default function RiskReports() {
                       onChange={(e) =>
                         setFilters((prev) => ({ ...prev, category: e.target.value }))
                       }
-                      className="w-full px-3 py-2 bg-gray-50 dark:bg-surface-700 border border-gray-300 dark:border-surface-600 rounded-lg text-gray-900 dark:text-white text-sm"
+                      className="w-full px-3 py-2 bg-gray-50 dark:bg-surface-200 border border-gray-300 dark:border-surface-300 rounded-lg text-gray-900 dark:text-white text-sm"
                     >
                       <option value="">All</option>
                       <option value="security">Security</option>
@@ -679,7 +679,7 @@ export default function RiskReports() {
                       onChange={(e) =>
                         setFilters((prev) => ({ ...prev, riskLevel: e.target.value }))
                       }
-                      className="w-full px-3 py-2 bg-gray-50 dark:bg-surface-700 border border-gray-300 dark:border-surface-600 rounded-lg text-gray-900 dark:text-white text-sm"
+                      className="w-full px-3 py-2 bg-gray-50 dark:bg-surface-200 border border-gray-300 dark:border-surface-300 rounded-lg text-gray-900 dark:text-white text-sm"
                     >
                       <option value="">All</option>
                       <option value="critical">Critical</option>
@@ -695,7 +695,7 @@ export default function RiskReports() {
                     <SelectNative
                       value={filters.status}
                       onChange={(e) => setFilters((prev) => ({ ...prev, status: e.target.value }))}
-                      className="w-full px-3 py-2 bg-gray-50 dark:bg-surface-700 border border-gray-300 dark:border-surface-600 rounded-lg text-gray-900 dark:text-white text-sm"
+                      className="w-full px-3 py-2 bg-gray-50 dark:bg-surface-200 border border-gray-300 dark:border-surface-300 rounded-lg text-gray-900 dark:text-white text-sm"
                     >
                       <option value="">All</option>
                       <option value="open">Open</option>
@@ -707,7 +707,7 @@ export default function RiskReports() {
                 </div>
 
                 {/* Export Section */}
-                <div className="flex items-center justify-between mt-4 pt-4 border-t border-gray-200 dark:border-surface-700">
+                <div className="flex items-center justify-between mt-4 pt-4 border-t border-gray-200 dark:border-surface-200">
                   <div className="flex items-center gap-3">
                     <span className="text-xs text-gray-500 dark:text-surface-500">Format:</span>
                     <div className="flex gap-1">
@@ -718,7 +718,7 @@ export default function RiskReports() {
                           className={`px-3 py-1.5 rounded text-xs font-medium transition-colors ${
                             exportFormat === format
                               ? 'bg-brand-500 text-white'
-                              : 'bg-gray-100 dark:bg-surface-700 text-gray-600 dark:text-surface-600 hover:bg-gray-200 dark:hover:bg-surface-600 hover:text-gray-700 dark:hover:text-surface-700'
+                              : 'bg-gray-100 dark:bg-surface-200 text-gray-600 dark:text-surface-600 hover:bg-gray-200 dark:hover:bg-surface-600 hover:text-gray-700 dark:hover:text-surface-700'
                           }`}
                         >
                           {format.toUpperCase()}
@@ -761,7 +761,7 @@ export default function RiskReports() {
               </div>
 
               {/* Preview */}
-              <div className="bg-white dark:bg-surface-800 rounded-xl border border-gray-200 dark:border-surface-700 p-5">
+              <div className="bg-white dark:bg-white rounded-xl border border-gray-200 dark:border-surface-200 p-5">
                 <h3 className="text-base font-medium text-gray-900 dark:text-white mb-4">
                   Preview
                 </h3>
@@ -798,7 +798,7 @@ export default function RiskReports() {
               </div>
             </>
           ) : (
-            <div className="bg-white dark:bg-surface-800 rounded-xl border border-gray-200 dark:border-surface-700 p-12 text-center">
+            <div className="bg-white dark:bg-white rounded-xl border border-gray-200 dark:border-surface-200 p-12 text-center">
               <DocumentChartBarIcon className="w-12 h-12 text-gray-400 dark:text-surface-600 mx-auto mb-4" />
               <p className="text-gray-600 dark:text-surface-600 text-lg font-medium">
                 Select a Report Template
@@ -823,25 +823,25 @@ function ExecutiveSummaryPreview({ data, risks }: { data: any; risks: Risk[] }) 
   return (
     <div className="space-y-5">
       <div className="grid grid-cols-4 gap-3">
-        <div className="p-4 bg-gray-50 dark:bg-surface-700/50 rounded-lg text-center border border-gray-200 dark:border-surface-600/50">
+        <div className="p-4 bg-gray-50 dark:bg-surface-200/50 rounded-lg text-center border border-gray-200 dark:border-surface-300/50">
           <p className="text-2xl font-bold text-gray-900 dark:text-white">
             {data?.totalRisks || risks.length}
           </p>
           <p className="text-gray-500 dark:text-surface-600 text-xs mt-1">Total Risks</p>
         </div>
-        <div className="p-4 bg-gray-50 dark:bg-surface-700/50 rounded-lg text-center border border-gray-200 dark:border-surface-600/50">
+        <div className="p-4 bg-gray-50 dark:bg-surface-200/50 rounded-lg text-center border border-gray-200 dark:border-surface-300/50">
           <p className="text-2xl font-bold text-red-500 dark:text-red-600">
             {data?.openRisks || risks.filter((r) => r.status === 'open').length}
           </p>
           <p className="text-gray-500 dark:text-surface-600 text-xs mt-1">Open</p>
         </div>
-        <div className="p-4 bg-gray-50 dark:bg-surface-700/50 rounded-lg text-center border border-gray-200 dark:border-surface-600/50">
+        <div className="p-4 bg-gray-50 dark:bg-surface-200/50 rounded-lg text-center border border-gray-200 dark:border-surface-300/50">
           <p className="text-2xl font-bold text-amber-500 dark:text-amber-600">
             {data?.inTreatment || risks.filter((r) => r.status === 'in_treatment').length}
           </p>
           <p className="text-gray-500 dark:text-surface-600 text-xs mt-1">In Treatment</p>
         </div>
-        <div className="p-4 bg-gray-50 dark:bg-surface-700/50 rounded-lg text-center border border-gray-200 dark:border-surface-600/50">
+        <div className="p-4 bg-gray-50 dark:bg-surface-200/50 rounded-lg text-center border border-gray-200 dark:border-surface-300/50">
           <p className="text-2xl font-bold text-emerald-500 dark:text-emerald-600">
             {data?.mitigatedThisMonth || risks.filter((r) => r.status === 'mitigated').length}
           </p>
@@ -857,7 +857,7 @@ function ExecutiveSummaryPreview({ data, risks }: { data: any; risks: Risk[] }) 
             {topRisks.map((risk) => (
               <div
                 key={risk.id}
-                className="flex items-center justify-between py-2 border-b border-gray-200 dark:border-surface-700/50"
+                className="flex items-center justify-between py-2 border-b border-gray-200 dark:border-surface-200/50"
               >
                 <div className="flex items-center gap-3">
                   <span
@@ -886,7 +886,7 @@ function RiskRegisterPreview({ risks }: { risks: Risk[] }) {
     <div className="overflow-x-auto">
       <table className="w-full text-sm">
         <thead>
-          <tr className="text-left text-gray-500 dark:text-surface-600 border-b border-gray-200 dark:border-surface-700">
+          <tr className="text-left text-gray-500 dark:text-surface-600 border-b border-gray-200 dark:border-surface-200">
             <th className="pb-2 text-xs font-medium">Risk ID</th>
             <th className="pb-2 text-xs font-medium">Title</th>
             <th className="pb-2 text-xs font-medium">Category</th>
@@ -896,7 +896,7 @@ function RiskRegisterPreview({ risks }: { risks: Risk[] }) {
         </thead>
         <tbody>
           {risks.slice(0, 5).map((risk) => (
-            <tr key={risk.id} className="border-b border-gray-200 dark:border-surface-700/50">
+            <tr key={risk.id} className="border-b border-gray-200 dark:border-surface-200/50">
               <td className="py-2.5 text-brand-500 dark:text-brand-400 font-mono text-xs">
                 {risk.riskId}
               </td>
@@ -965,7 +965,7 @@ function RiskSummaryPreview({ data, risks }: { data: any; risks: Risk[] }) {
           {['critical', 'high', 'medium', 'low'].map((level) => (
             <div
               key={level}
-              className="p-3 bg-gray-50 dark:bg-surface-700/50 rounded-lg border border-gray-200 dark:border-surface-600/50"
+              className="p-3 bg-gray-50 dark:bg-surface-200/50 rounded-lg border border-gray-200 dark:border-surface-300/50"
             >
               <p className="text-xl font-bold text-gray-900 dark:text-white">
                 {levelCounts[level] ||
@@ -983,7 +983,7 @@ function RiskSummaryPreview({ data, risks }: { data: any; risks: Risk[] }) {
           {categories.slice(0, 4).map((cat) => (
             <div
               key={cat.category}
-              className="flex justify-between items-center py-1.5 border-b border-gray-200 dark:border-surface-700/50"
+              className="flex justify-between items-center py-1.5 border-b border-gray-200 dark:border-surface-200/50"
             >
               <span className="text-gray-600 dark:text-surface-700 capitalize text-sm">
                 {cat.category}
@@ -1013,25 +1013,25 @@ function TreatmentStatusPreview({ risks }: { risks: Risk[] }) {
   return (
     <div className="space-y-4">
       <div className="grid grid-cols-4 gap-3">
-        <div className="p-3 bg-gray-50 dark:bg-surface-700/50 rounded-lg text-center border border-gray-200 dark:border-surface-600/50">
+        <div className="p-3 bg-gray-50 dark:bg-surface-200/50 rounded-lg text-center border border-gray-200 dark:border-surface-300/50">
           <p className="text-xl font-bold text-gray-900 dark:text-white">
             {treatmentCounts.mitigate}
           </p>
           <p className="text-gray-500 dark:text-surface-600 text-xs mt-1">Mitigating</p>
         </div>
-        <div className="p-3 bg-gray-50 dark:bg-surface-700/50 rounded-lg text-center border border-gray-200 dark:border-surface-600/50">
+        <div className="p-3 bg-gray-50 dark:bg-surface-200/50 rounded-lg text-center border border-gray-200 dark:border-surface-300/50">
           <p className="text-xl font-bold text-gray-900 dark:text-white">
             {treatmentCounts.accept}
           </p>
           <p className="text-gray-500 dark:text-surface-600 text-xs mt-1">Accepting</p>
         </div>
-        <div className="p-3 bg-gray-50 dark:bg-surface-700/50 rounded-lg text-center border border-gray-200 dark:border-surface-600/50">
+        <div className="p-3 bg-gray-50 dark:bg-surface-200/50 rounded-lg text-center border border-gray-200 dark:border-surface-300/50">
           <p className="text-xl font-bold text-gray-900 dark:text-white">
             {treatmentCounts.transfer}
           </p>
           <p className="text-gray-500 dark:text-surface-600 text-xs mt-1">Transferring</p>
         </div>
-        <div className="p-3 bg-gray-50 dark:bg-surface-700/50 rounded-lg text-center border border-gray-200 dark:border-surface-600/50">
+        <div className="p-3 bg-gray-50 dark:bg-surface-200/50 rounded-lg text-center border border-gray-200 dark:border-surface-300/50">
           <p className="text-xl font-bold text-gray-900 dark:text-white">{treatmentCounts.avoid}</p>
           <p className="text-gray-500 dark:text-surface-600 text-xs mt-1">Avoiding</p>
         </div>
@@ -1049,7 +1049,7 @@ function TreatmentStatusPreview({ risks }: { risks: Risk[] }) {
             .map((risk) => (
               <div
                 key={risk.id}
-                className="flex items-center justify-between py-2 border-b border-gray-200 dark:border-surface-700/50"
+                className="flex items-center justify-between py-2 border-b border-gray-200 dark:border-surface-200/50"
               >
                 <div>
                   <span className="text-gray-900 dark:text-white text-sm">{risk.title}</span>
@@ -1107,7 +1107,7 @@ function RiskTrendsPreview({ trendData }: { trendData: TrendDataPoint[] }) {
     <div className="space-y-5">
       {/* Trend Summary Cards */}
       <div className="grid grid-cols-3 gap-3">
-        <div className="p-3 bg-gray-50 dark:bg-surface-700/50 rounded-lg border border-gray-200 dark:border-surface-600/50">
+        <div className="p-3 bg-gray-50 dark:bg-surface-200/50 rounded-lg border border-gray-200 dark:border-surface-300/50">
           <div className="flex items-center justify-between">
             <span className="text-gray-500 dark:text-surface-600 text-xs">Open Risks</span>
             {openChange !== 0 && (
@@ -1127,7 +1127,7 @@ function RiskTrendsPreview({ trendData }: { trendData: TrendDataPoint[] }) {
             {latestData.openRisks}
           </p>
         </div>
-        <div className="p-3 bg-gray-50 dark:bg-surface-700/50 rounded-lg border border-gray-200 dark:border-surface-600/50">
+        <div className="p-3 bg-gray-50 dark:bg-surface-200/50 rounded-lg border border-gray-200 dark:border-surface-300/50">
           <div className="flex items-center justify-between">
             <span className="text-gray-500 dark:text-surface-600 text-xs">Mitigated</span>
             {mitigatedChange !== 0 && (
@@ -1147,7 +1147,7 @@ function RiskTrendsPreview({ trendData }: { trendData: TrendDataPoint[] }) {
             {latestData.mitigatedRisks}
           </p>
         </div>
-        <div className="p-3 bg-gray-50 dark:bg-surface-700/50 rounded-lg border border-gray-200 dark:border-surface-600/50">
+        <div className="p-3 bg-gray-50 dark:bg-surface-200/50 rounded-lg border border-gray-200 dark:border-surface-300/50">
           <span className="text-gray-500 dark:text-surface-600 text-xs">Critical/High</span>
           <p className="text-xl font-bold text-red-500 dark:text-red-600 mt-1">
             {latestData.criticalHighRisks}
@@ -1156,7 +1156,7 @@ function RiskTrendsPreview({ trendData }: { trendData: TrendDataPoint[] }) {
       </div>
 
       {/* Chart */}
-      <div className="bg-gray-100/50 dark:bg-surface-700/30 rounded-lg p-4 border border-gray-200 dark:border-surface-600/30">
+      <div className="bg-gray-100/50 dark:bg-surface-200/30 rounded-lg p-4 border border-gray-200 dark:border-surface-300/30">
         <div className="flex items-end justify-between gap-2" style={{ height: chartHeight }}>
           {trendData.map((data, index) => {
             const openHeight = maxValue > 0 ? (data.openRisks / maxValue) * (chartHeight - 30) : 0;
@@ -1186,7 +1186,7 @@ function RiskTrendsPreview({ trendData }: { trendData: TrendDataPoint[] }) {
         </div>
 
         {/* Legend */}
-        <div className="flex items-center justify-center gap-4 mt-4 pt-3 border-t border-gray-200 dark:border-surface-700/50">
+        <div className="flex items-center justify-center gap-4 mt-4 pt-3 border-t border-gray-200 dark:border-surface-200/50">
           <div className="flex items-center gap-1.5">
             <div className="w-3 h-3 bg-red-500/70 rounded" />
             <span className="text-xs text-gray-500 dark:text-surface-600">Open Risks</span>
@@ -1206,7 +1206,7 @@ function RiskTrendsPreview({ trendData }: { trendData: TrendDataPoint[] }) {
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
-              <tr className="text-left text-gray-500 dark:text-surface-600 border-b border-gray-200 dark:border-surface-700">
+              <tr className="text-left text-gray-500 dark:text-surface-600 border-b border-gray-200 dark:border-surface-200">
                 <th className="pb-2 text-xs font-medium">Month</th>
                 <th className="pb-2 text-xs font-medium text-right">Total</th>
                 <th className="pb-2 text-xs font-medium text-right">Open</th>
@@ -1219,7 +1219,7 @@ function RiskTrendsPreview({ trendData }: { trendData: TrendDataPoint[] }) {
                 .slice()
                 .reverse()
                 .map((data, index) => (
-                  <tr key={index} className="border-b border-gray-200 dark:border-surface-700/50">
+                  <tr key={index} className="border-b border-gray-200 dark:border-surface-200/50">
                     <td className="py-2 text-gray-900 dark:text-white">{data.month}</td>
                     <td className="py-2 text-gray-600 dark:text-surface-700 text-right">
                       {data.totalRisks}

--- a/frontend/src/pages/RiskScenarios.tsx
+++ b/frontend/src/pages/RiskScenarios.tsx
@@ -294,14 +294,14 @@ export default function RiskScenarios() {
                 placeholder="Search scenarios..."
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
-                className="w-full pl-10 pr-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-foreground"
+                className="w-full pl-10 pr-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-foreground"
               />
             </div>
           </div>
           <SelectNative
             value={categoryFilter}
             onChange={(e) => setCategoryFilter(e.target.value)}
-            className="px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-foreground"
+            className="px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-foreground"
           >
             <option value="">All Categories</option>
             {CATEGORIES.map((cat) => (
@@ -313,7 +313,7 @@ export default function RiskScenarios() {
           <SelectNative
             value={threatActorFilter}
             onChange={(e) => setThreatActorFilter(e.target.value)}
-            className="px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-foreground"
+            className="px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-foreground"
           >
             <option value="">All Threat Actors</option>
             {THREAT_ACTORS.map((actor) => (
@@ -327,7 +327,7 @@ export default function RiskScenarios() {
               type="checkbox"
               checked={showTemplatesOnly}
               onChange={(e) => setShowTemplatesOnly(e.target.checked)}
-              className="rounded border-surface-600"
+              className="rounded border-surface-300"
             />
             Templates Only
           </label>
@@ -380,7 +380,7 @@ export default function RiskScenarios() {
                       {getThreatActorLabel(scenario.threatActor)}
                     </span>
                     <span>{getAttackVectorLabel(scenario.attackVector)}</span>
-                    <span className="bg-surface-700 px-2 py-0.5 rounded">{scenario.category}</span>
+                    <span className="bg-surface-200 px-2 py-0.5 rounded">{scenario.category}</span>
                     {scenario.tags?.slice(0, 3).map((tag: string) => (
                       <span key={tag} className="flex items-center gap-1">
                         <TagIcon className="h-3 w-3" />
@@ -397,21 +397,21 @@ export default function RiskScenarios() {
                       setSimulationResult(null);
                       setSimulationParams({ controlEffectiveness: 50, mitigations: [] });
                     }}
-                    className="p-2 text-surface-600 hover:text-brand-400 hover:bg-surface-700 rounded-lg transition-colors"
+                    className="p-2 text-surface-600 hover:text-brand-400 hover:bg-surface-200 rounded-lg transition-colors"
                     title="Run Simulation"
                   >
                     <PlayCircleIcon className="h-5 w-5" />
                   </button>
                   <button
                     onClick={() => cloneMutation.mutate({ id: scenario.id })}
-                    className="p-2 text-surface-600 hover:text-brand-400 hover:bg-surface-700 rounded-lg transition-colors"
+                    className="p-2 text-surface-600 hover:text-brand-400 hover:bg-surface-200 rounded-lg transition-colors"
                     title="Clone"
                   >
                     <DocumentDuplicateIcon className="h-5 w-5" />
                   </button>
                   <button
                     onClick={() => setEditingScenario(scenario)}
-                    className="p-2 text-surface-600 hover:text-brand-400 hover:bg-surface-700 rounded-lg transition-colors"
+                    className="p-2 text-surface-600 hover:text-brand-400 hover:bg-surface-200 rounded-lg transition-colors"
                     title="Edit"
                   >
                     <PencilIcon className="h-5 w-5" />
@@ -422,7 +422,7 @@ export default function RiskScenarios() {
                         deleteMutation.mutate(scenario.id);
                       }
                     }}
-                    className="p-2 text-surface-600 hover:text-red-600 hover:bg-surface-700 rounded-lg transition-colors"
+                    className="p-2 text-surface-600 hover:text-red-600 hover:bg-surface-200 rounded-lg transition-colors"
                     title="Delete"
                   >
                     <TrashIcon className="h-5 w-5" />
@@ -463,7 +463,7 @@ export default function RiskScenarios() {
                   {categoryGroup.templates.map((template: RiskScenario) => (
                     <div
                       key={template.id}
-                      className="bg-surface-700/50 hover:bg-surface-700 rounded-lg p-4 transition-colors group"
+                      className="bg-surface-200/50 hover:bg-surface-200 rounded-lg p-4 transition-colors group"
                     >
                       <h5 className="font-medium text-foreground text-sm line-clamp-1">
                         {template.title}
@@ -481,7 +481,7 @@ export default function RiskScenarios() {
                           </span>
                         ))}
                       </div>
-                      <div className="flex items-center justify-between mt-3 pt-2 border-t border-surface-600">
+                      <div className="flex items-center justify-between mt-3 pt-2 border-t border-surface-300">
                         <div className="flex items-center gap-2 text-xs text-muted-foreground">
                           <span>{getThreatActorLabel(template.threatActor)}</span>
                           {(template.usageCount ?? 0) > 0 && (
@@ -539,7 +539,7 @@ export default function RiskScenarios() {
       >
         {simulatingScenario && (
           <div className="space-y-6">
-            <div className="bg-surface-700/50 rounded-lg p-4">
+            <div className="bg-surface-200/50 rounded-lg p-4">
               <h4 className="font-medium text-foreground">{simulatingScenario.title}</h4>
               <p className="text-sm text-muted-foreground mt-1">{simulatingScenario.description}</p>
               <div className="flex items-center gap-4 mt-3 text-sm">
@@ -595,7 +595,7 @@ export default function RiskScenarios() {
                         .filter(Boolean),
                     })
                   }
-                  className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-foreground"
+                  className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-foreground"
                 />
               </div>
 
@@ -606,7 +606,7 @@ export default function RiskScenarios() {
             </div>
 
             {simulationResult && (
-              <div className="bg-surface-800 rounded-lg p-6 border border-surface-700">
+              <div className="bg-white rounded-lg p-6 border border-surface-200">
                 <h4 className="font-semibold text-foreground mb-4">Simulation Results</h4>
                 <div className="grid grid-cols-2 gap-6">
                   <div>
@@ -639,7 +639,7 @@ export default function RiskScenarios() {
                 <div className="mt-4">
                   <p className="text-sm text-muted-foreground">Risk Reduction</p>
                   <div className="flex items-center gap-2 mt-1">
-                    <div className="flex-1 h-2 bg-surface-700 rounded-full overflow-hidden">
+                    <div className="flex-1 h-2 bg-surface-200 rounded-full overflow-hidden">
                       <div
                         className="h-full bg-green-500 rounded-full transition-all"
                         style={{ width: `${simulationResult.riskReduction}%` }}
@@ -722,7 +722,7 @@ function ScenarioForm({ scenario, onSubmit, isLoading }: ScenarioFormProps) {
           required
           value={formData.title}
           onChange={(e) => setFormData({ ...formData, title: e.target.value })}
-          className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-foreground"
+          className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-foreground"
           placeholder="e.g., Phishing Attack on Employees"
         />
       </div>
@@ -733,7 +733,7 @@ function ScenarioForm({ scenario, onSubmit, isLoading }: ScenarioFormProps) {
           rows={3}
           value={formData.description}
           onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-          className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-foreground"
+          className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-foreground"
           placeholder="Describe the risk scenario in detail..."
         />
       </div>
@@ -744,7 +744,7 @@ function ScenarioForm({ scenario, onSubmit, isLoading }: ScenarioFormProps) {
             required
             value={formData.category}
             onChange={(e) => setFormData({ ...formData, category: e.target.value })}
-            className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-foreground"
+            className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-foreground"
           >
             {CATEGORIES.map((cat) => (
               <option key={cat} value={cat}>
@@ -760,7 +760,7 @@ function ScenarioForm({ scenario, onSubmit, isLoading }: ScenarioFormProps) {
             required
             value={formData.threatActor}
             onChange={(e) => setFormData({ ...formData, threatActor: e.target.value })}
-            className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-foreground"
+            className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-foreground"
           >
             {THREAT_ACTORS.map((actor) => (
               <option key={actor.value} value={actor.value}>
@@ -777,7 +777,7 @@ function ScenarioForm({ scenario, onSubmit, isLoading }: ScenarioFormProps) {
             required
             value={formData.attackVector}
             onChange={(e) => setFormData({ ...formData, attackVector: e.target.value })}
-            className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-foreground"
+            className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-foreground"
           >
             {ATTACK_VECTORS.map((vector) => (
               <option key={vector.value} value={vector.value}>
@@ -793,7 +793,7 @@ function ScenarioForm({ scenario, onSubmit, isLoading }: ScenarioFormProps) {
             type="text"
             value={formData.targetAssets}
             onChange={(e) => setFormData({ ...formData, targetAssets: e.target.value })}
-            className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-foreground"
+            className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-foreground"
             placeholder="e.g., Email System, Database (comma-separated)"
           />
         </div>
@@ -805,7 +805,7 @@ function ScenarioForm({ scenario, onSubmit, isLoading }: ScenarioFormProps) {
             required
             value={formData.likelihood}
             onChange={(e) => setFormData({ ...formData, likelihood: e.target.value })}
-            className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-foreground"
+            className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-foreground"
           >
             {LIKELIHOOD_OPTIONS.map((opt) => (
               <option key={opt.value} value={opt.value}>
@@ -821,7 +821,7 @@ function ScenarioForm({ scenario, onSubmit, isLoading }: ScenarioFormProps) {
             required
             value={formData.impact}
             onChange={(e) => setFormData({ ...formData, impact: e.target.value })}
-            className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-foreground"
+            className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-foreground"
           >
             {IMPACT_OPTIONS.map((opt) => (
               <option key={opt.value} value={opt.value}>
@@ -837,7 +837,7 @@ function ScenarioForm({ scenario, onSubmit, isLoading }: ScenarioFormProps) {
           type="text"
           value={formData.tags}
           onChange={(e) => setFormData({ ...formData, tags: e.target.value })}
-          className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-foreground"
+          className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-foreground"
           placeholder="e.g., critical, compliance, data (comma-separated)"
         />
       </div>
@@ -849,7 +849,7 @@ function ScenarioForm({ scenario, onSubmit, isLoading }: ScenarioFormProps) {
           rows={2}
           value={formData.mitigationStrategy}
           onChange={(e) => setFormData({ ...formData, mitigationStrategy: e.target.value })}
-          className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-foreground"
+          className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-foreground"
           placeholder="Describe how this risk can be mitigated..."
         />
       </div>
@@ -859,13 +859,13 @@ function ScenarioForm({ scenario, onSubmit, isLoading }: ScenarioFormProps) {
           id="isTemplate"
           checked={formData.isTemplate}
           onChange={(e) => setFormData({ ...formData, isTemplate: e.target.checked })}
-          className="rounded border-surface-600"
+          className="rounded border-surface-300"
         />
         <label htmlFor="isTemplate" className="text-sm text-foreground">
           Save as template (available for reuse)
         </label>
       </div>
-      <div className="flex justify-end gap-3 pt-4 border-t border-surface-700">
+      <div className="flex justify-end gap-3 pt-4 border-t border-surface-200">
         <Button type="submit" isLoading={isLoading}>
           {scenario ? 'Update Scenario' : 'Create Scenario'}
         </Button>

--- a/frontend/src/pages/Risks.tsx
+++ b/frontend/src/pages/Risks.tsx
@@ -461,7 +461,7 @@ export default function Risks() {
       {!dashboard ? (
         <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
           {[1, 2, 3, 4].map((i) => (
-            <SkeletonStatCard key={i} className="bg-surface-800 border border-surface-700" />
+            <SkeletonStatCard key={i} className="bg-white border border-surface-200" />
           ))}
         </div>
       ) : (
@@ -469,10 +469,10 @@ export default function Risks() {
           <button
             onClick={() => setStatFilter(statFilter === 'all' ? 'all' : 'all')}
             className={clsx(
-              'bg-surface-800 rounded-xl border p-4 text-left transition-all',
+              'bg-white rounded-xl border p-4 text-left transition-all',
               statFilter === 'all'
                 ? 'border-brand-500 ring-2 ring-brand-500'
-                : 'border-surface-700 hover:bg-surface-700/50 cursor-pointer'
+                : 'border-surface-200 hover:bg-surface-200/50 cursor-pointer'
             )}
           >
             <div className="flex items-center gap-3">
@@ -491,10 +491,10 @@ export default function Risks() {
           <button
             onClick={() => setStatFilter(statFilter === 'open' ? 'all' : 'open')}
             className={clsx(
-              'bg-surface-800 rounded-xl border p-4 text-left transition-all',
+              'bg-white rounded-xl border p-4 text-left transition-all',
               statFilter === 'open'
                 ? 'border-red-500 ring-2 ring-red-500'
-                : 'border-surface-700 hover:bg-surface-700/50 cursor-pointer'
+                : 'border-surface-200 hover:bg-surface-200/50 cursor-pointer'
             )}
           >
             <div className="flex items-center gap-3">
@@ -513,10 +513,10 @@ export default function Risks() {
           <button
             onClick={() => setStatFilter(statFilter === 'reviews_due' ? 'all' : 'reviews_due')}
             className={clsx(
-              'bg-surface-800 rounded-xl border p-4 text-left transition-all',
+              'bg-white rounded-xl border p-4 text-left transition-all',
               statFilter === 'reviews_due'
                 ? 'border-amber-500 ring-2 ring-amber-500'
-                : 'border-surface-700 hover:bg-surface-700/50 cursor-pointer'
+                : 'border-surface-200 hover:bg-surface-200/50 cursor-pointer'
             )}
           >
             <div className="flex items-center gap-3">
@@ -537,10 +537,10 @@ export default function Risks() {
           <button
             onClick={() => setStatFilter(statFilter === 'mitigated' ? 'all' : 'mitigated')}
             className={clsx(
-              'bg-surface-800 rounded-xl border p-4 text-left transition-all',
+              'bg-white rounded-xl border p-4 text-left transition-all',
               statFilter === 'mitigated'
                 ? 'border-emerald-500 ring-2 ring-emerald-500'
-                : 'border-surface-700 hover:bg-surface-700/50 cursor-pointer'
+                : 'border-surface-200 hover:bg-surface-200/50 cursor-pointer'
             )}
           >
             <div className="flex items-center gap-3">
@@ -579,14 +579,14 @@ export default function Risks() {
           <span className="text-surface-500">({data?.total || 0} results)</span>
           <button
             onClick={() => setStatFilter('all')}
-            className="text-surface-600 hover:text-surface-100 ml-2"
+            className="text-surface-600 hover:text-surface-900 ml-2"
           >
             <X className="w-4 h-4" />
           </button>
         </div>
       )}
       {/* Search and Filters */}
-      <div className="bg-surface-800 rounded-xl border border-surface-700 p-4">
+      <div className="bg-white rounded-xl border border-surface-200 p-4">
         <div className="flex flex-col lg:flex-row gap-4">
           {/* Search */}
           <div className="flex-1 relative">
@@ -596,7 +596,7 @@ export default function Risks() {
               placeholder="Search risks..."
               value={searchInput}
               onChange={(e) => setSearchInput(e.target.value)}
-              className="w-full pl-10 pr-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white placeholder-surface-400 focus:outline-none focus:ring-2 focus:ring-brand-500"
+              className="w-full pl-10 pr-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white placeholder-surface-500 focus:outline-none focus:ring-2 focus:ring-brand-500"
             />
           </div>
 
@@ -605,7 +605,7 @@ export default function Risks() {
             <SelectNative
               value={filters.category}
               onChange={(e) => updateFilter('category', e.target.value)}
-              className="px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+              className="px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
             >
               <option value="">All Categories</option>
               {CATEGORIES.map((cat) => (
@@ -618,7 +618,7 @@ export default function Risks() {
             <SelectNative
               value={filters.status}
               onChange={(e) => updateFilter('status', e.target.value)}
-              className="px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+              className="px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
             >
               <option value="">All Statuses</option>
               {STATUSES.map((status) => (
@@ -631,7 +631,7 @@ export default function Risks() {
             <SelectNative
               value={filters.riskLevel}
               onChange={(e) => updateFilter('riskLevel', e.target.value)}
-              className="px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+              className="px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
             >
               <option value="">All Risk Levels</option>
               {RISK_LEVELS.map((level) => (
@@ -643,7 +643,7 @@ export default function Risks() {
 
             <button
               onClick={() => navigate('/risks/heatmap')}
-              className="px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-surface-700 hover:text-white hover:bg-surface-600 transition-colors flex items-center gap-2"
+              className="px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-surface-700 hover:text-white hover:bg-surface-600 transition-colors flex items-center gap-2"
             >
               <BarChart3 className="w-4 h-4" />
               Heatmap
@@ -652,7 +652,7 @@ export default function Risks() {
         </div>
       </div>
       {/* Risks Table */}
-      <div className="bg-surface-800 rounded-xl border border-surface-700 overflow-hidden">
+      <div className="bg-white rounded-xl border border-surface-200 overflow-hidden">
         {isLoading ? (
           <SkeletonTable rows={8} columns={8} className="border-none shadow-none" />
         ) : data?.risks.length === 0 ? (
@@ -664,7 +664,7 @@ export default function Risks() {
         ) : (
           <table className="w-full">
             <thead>
-              <tr className="border-b border-surface-700">
+              <tr className="border-b border-surface-200">
                 <th className="text-left px-4 py-3 text-sm font-medium text-surface-600">
                   Risk ID
                 </th>
@@ -693,7 +693,7 @@ export default function Risks() {
                   key={risk.id}
                   onClick={() => navigate(`/risks/${risk.id}`)}
                   onMouseEnter={() => prefetchRisk(risk.id)}
-                  className="border-b border-surface-700 hover:bg-surface-700/50 cursor-pointer transition-colors"
+                  className="border-b border-surface-200 hover:bg-surface-200/50 cursor-pointer transition-colors"
                 >
                   <td className="px-4 py-3">
                     <span className="text-brand-400 font-mono text-sm">{risk.riskId}</span>
@@ -750,7 +750,7 @@ export default function Risks() {
 
         {/* Pagination */}
         {data && data.total > 25 && (
-          <div className="px-4 py-3 border-t border-surface-700 flex items-center justify-between">
+          <div className="px-4 py-3 border-t border-surface-200 flex items-center justify-between">
             <p className="text-sm text-surface-600">
               Showing {(filters.page - 1) * 25 + 1} to {Math.min(filters.page * 25, data.total)} of{' '}
               {data.total} risks
@@ -759,14 +759,14 @@ export default function Risks() {
               <button
                 onClick={() => updateFilter('page', String(filters.page - 1))}
                 disabled={filters.page === 1}
-                className="px-3 py-1 bg-surface-700 rounded text-surface-700 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-surface-600"
+                className="px-3 py-1 bg-surface-200 rounded text-surface-700 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-surface-600"
               >
                 Previous
               </button>
               <button
                 onClick={() => updateFilter('page', String(filters.page + 1))}
                 disabled={filters.page * 25 >= data.total}
-                className="px-3 py-1 bg-surface-700 rounded text-surface-700 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-surface-600"
+                className="px-3 py-1 bg-surface-200 rounded text-surface-700 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-surface-600"
               >
                 Next
               </button>
@@ -776,11 +776,11 @@ export default function Risks() {
       </div>
       {/* Create Risk Modal */}
       <Dialog open={showCreateModal} onClose={() => setShowCreateModal(false)}>
-        <div className="p-6 border-b border-surface-700 flex items-center justify-between">
+        <div className="p-6 border-b border-surface-200 flex items-center justify-between">
           <h2 className="text-xl font-semibold text-white">Create New Risk</h2>
           <button
             onClick={() => setShowCreateModal(false)}
-            className="p-2 hover:bg-surface-700 rounded-lg text-surface-600"
+            className="p-2 hover:bg-surface-200 rounded-lg text-surface-600"
           >
             <X className="w-5 h-5" />
           </button>
@@ -896,7 +896,7 @@ export default function Risks() {
           </div>
 
           {/* Actions */}
-          <div className="flex justify-end gap-3 pt-4 border-t border-surface-700">
+          <div className="flex justify-end gap-3 pt-4 border-t border-surface-200">
             <Button
               type="button"
               variant="secondary"

--- a/frontend/src/pages/RunbookDetail.tsx
+++ b/frontend/src/pages/RunbookDetail.tsx
@@ -62,7 +62,7 @@ const STATUS_OPTIONS = [
   { value: 'approved', label: 'Approved', color: 'bg-blue-500/20 text-blue-600' },
   { value: 'published', label: 'Published', color: 'bg-green-500/20 text-green-600' },
   { value: 'needs_review', label: 'Needs Review', color: 'bg-yellow-500/20 text-yellow-600' },
-  { value: 'archived', label: 'Archived', color: 'bg-surface-700 text-surface-600' },
+  { value: 'archived', label: 'Archived', color: 'bg-surface-200 text-surface-600' },
 ];
 
 const CATEGORY_OPTIONS = [
@@ -217,7 +217,7 @@ export default function RunbookDetail() {
       <div className="p-6">
         <div className="card p-8 text-center">
           <ExclamationCircleIcon className="w-12 h-12 mx-auto mb-4 text-red-600" />
-          <h2 className="text-lg font-semibold text-surface-100 mb-2">Runbook Not Found</h2>
+          <h2 className="text-lg font-semibold text-surface-900 mb-2">Runbook Not Found</h2>
           <p className="text-surface-600 mb-4">The requested runbook could not be loaded.</p>
           <Button onClick={() => navigate('/bcdr/runbooks')}>Back to Runbooks</Button>
         </div>
@@ -232,12 +232,12 @@ export default function RunbookDetail() {
         <div className="flex items-start gap-4">
           <button
             onClick={() => navigate('/bcdr/runbooks')}
-            className="p-2 hover:bg-surface-700 rounded-lg text-surface-600 mt-1"
+            className="p-2 hover:bg-surface-200 rounded-lg text-surface-600 mt-1"
           >
             <ArrowLeftIcon className="w-5 h-5" />
           </button>
           <div>
-            <h1 className="text-2xl font-bold text-surface-100">Create New Runbook</h1>
+            <h1 className="text-2xl font-bold text-surface-900">Create New Runbook</h1>
             <p className="text-surface-600">Define step-by-step recovery procedures</p>
           </div>
         </div>
@@ -373,7 +373,7 @@ export default function RunbookDetail() {
               />
             </div>
 
-            <div className="flex justify-end gap-3 pt-4 border-t border-surface-700">
+            <div className="flex justify-end gap-3 pt-4 border-t border-surface-200">
               <Button type="button" variant="secondary" onClick={() => navigate('/bcdr/runbooks')}>
                 Cancel
               </Button>
@@ -397,14 +397,14 @@ export default function RunbookDetail() {
       <div className="flex items-start gap-4">
         <button
           onClick={() => navigate('/bcdr/runbooks')}
-          className="p-2 hover:bg-surface-700 rounded-lg text-surface-600 mt-1"
+          className="p-2 hover:bg-surface-200 rounded-lg text-surface-600 mt-1"
         >
           <ArrowLeftIcon className="w-5 h-5" />
         </button>
         <div className="flex-1">
           <div className="flex items-center gap-3 mb-2">
             <span className="text-2xl">{categoryConfig.icon}</span>
-            <h1 className="text-2xl font-bold text-surface-100">{runbook!.title}</h1>
+            <h1 className="text-2xl font-bold text-surface-900">{runbook!.title}</h1>
             <span
               className={clsx('px-3 py-1 rounded-full text-sm font-medium', statusConfig.color)}
             >
@@ -432,7 +432,7 @@ export default function RunbookDetail() {
         <div className="lg:col-span-2 space-y-6">
           {/* Description */}
           <div className="card p-6">
-            <h2 className="text-lg font-semibold text-surface-100 mb-4">Description</h2>
+            <h2 className="text-lg font-semibold text-surface-900 mb-4">Description</h2>
             <p className="text-surface-700 whitespace-pre-wrap">
               {runbook!.description || 'No description provided'}
             </p>
@@ -441,7 +441,7 @@ export default function RunbookDetail() {
           {/* Prerequisites */}
           {runbook!.prerequisites && (
             <div className="card p-6">
-              <h2 className="text-lg font-semibold text-surface-100 mb-4">Prerequisites</h2>
+              <h2 className="text-lg font-semibold text-surface-900 mb-4">Prerequisites</h2>
               <p className="text-surface-700 whitespace-pre-wrap">{runbook!.prerequisites}</p>
             </div>
           )}
@@ -449,18 +449,18 @@ export default function RunbookDetail() {
           {/* Steps */}
           <div className="card p-6">
             <div className="flex items-center justify-between mb-4">
-              <h2 className="text-lg font-semibold text-surface-100">Steps</h2>
+              <h2 className="text-lg font-semibold text-surface-900">Steps</h2>
               <span className="text-surface-600 text-sm">{runbook!.steps?.length || 0} steps</span>
             </div>
             {runbook!.steps && runbook!.steps.length > 0 ? (
               <div className="space-y-4">
                 {runbook!.steps.map((step, index) => (
-                  <div key={step.id} className="flex gap-4 p-4 bg-surface-800 rounded-lg">
+                  <div key={step.id} className="flex gap-4 p-4 bg-white rounded-lg">
                     <div className="flex-shrink-0 w-8 h-8 bg-brand-500/20 text-brand-400 rounded-full flex items-center justify-center font-semibold">
                       {index + 1}
                     </div>
                     <div className="flex-1">
-                      <h4 className="font-medium text-surface-100">{step.title}</h4>
+                      <h4 className="font-medium text-surface-900">{step.title}</h4>
                       <p className="text-surface-600 text-sm mt-1">{step.description}</p>
                       {step.role_responsible && (
                         <p className="text-surface-500 text-xs mt-2">
@@ -487,7 +487,7 @@ export default function RunbookDetail() {
           {/* Rollback Procedure */}
           {runbook!.rollback_procedure && (
             <div className="card p-6 border-l-4 border-yellow-500">
-              <h2 className="text-lg font-semibold text-surface-100 mb-4">Rollback Procedure</h2>
+              <h2 className="text-lg font-semibold text-surface-900 mb-4">Rollback Procedure</h2>
               <p className="text-surface-700 whitespace-pre-wrap">{runbook!.rollback_procedure}</p>
             </div>
           )}
@@ -497,23 +497,23 @@ export default function RunbookDetail() {
         <div className="space-y-6">
           {/* Quick Info */}
           <div className="card p-6">
-            <h3 className="text-lg font-semibold text-surface-100 mb-4">Details</h3>
+            <h3 className="text-lg font-semibold text-surface-900 mb-4">Details</h3>
             <dl className="space-y-4">
               <div>
                 <dt className="text-surface-600 text-sm">Category</dt>
-                <dd className="text-surface-100 mt-1">
+                <dd className="text-surface-900 mt-1">
                   {categoryConfig.icon} {categoryConfig.label}
                 </dd>
               </div>
               {runbook!.system_name && (
                 <div>
                   <dt className="text-surface-600 text-sm">System</dt>
-                  <dd className="text-surface-100 mt-1">{runbook!.system_name}</dd>
+                  <dd className="text-surface-900 mt-1">{runbook!.system_name}</dd>
                 </div>
               )}
               <div>
                 <dt className="text-surface-600 text-sm">Estimated Duration</dt>
-                <dd className="text-surface-100 mt-1 flex items-center gap-1">
+                <dd className="text-surface-900 mt-1 flex items-center gap-1">
                   <ClockIcon className="w-4 h-4" />
                   {runbook!.estimated_duration_minutes || 0} minutes
                 </dd>
@@ -521,13 +521,13 @@ export default function RunbookDetail() {
               {runbook!.owner_name && (
                 <div>
                   <dt className="text-surface-600 text-sm">Owner</dt>
-                  <dd className="text-surface-100 mt-1">{runbook!.owner_name}</dd>
+                  <dd className="text-surface-900 mt-1">{runbook!.owner_name}</dd>
                 </div>
               )}
               {runbook!.process_name && (
                 <div>
                   <dt className="text-surface-600 text-sm">Business Process</dt>
-                  <dd className="text-surface-100 mt-1">{runbook!.process_name}</dd>
+                  <dd className="text-surface-900 mt-1">{runbook!.process_name}</dd>
                 </div>
               )}
             </dl>
@@ -536,7 +536,7 @@ export default function RunbookDetail() {
           {/* Post-Conditions */}
           {runbook!.post_conditions && (
             <div className="card p-6">
-              <h3 className="text-lg font-semibold text-surface-100 mb-4">Post-Conditions</h3>
+              <h3 className="text-lg font-semibold text-surface-900 mb-4">Post-Conditions</h3>
               <p className="text-surface-700 text-sm whitespace-pre-wrap">
                 {runbook!.post_conditions}
               </p>
@@ -547,10 +547,10 @@ export default function RunbookDetail() {
       {/* Edit Modal */}
       <Dialog open={showEditModal} onClose={() => setShowEditModal(false)}>
         <div className="flex items-center justify-between mb-6">
-          <h2 className="text-xl font-bold text-surface-100">Edit Runbook</h2>
+          <h2 className="text-xl font-bold text-surface-900">Edit Runbook</h2>
           <button
             onClick={() => setShowEditModal(false)}
-            className="p-2 hover:bg-surface-700 rounded-lg text-surface-600"
+            className="p-2 hover:bg-surface-200 rounded-lg text-surface-600"
           >
             <XMarkIcon className="w-5 h-5" />
           </button>
@@ -623,7 +623,7 @@ export default function RunbookDetail() {
       </Dialog>
       {/* Delete Confirmation */}
       <Dialog open={showDeleteConfirm} onClose={() => setShowDeleteConfirm(false)}>
-        <h2 className="text-xl font-bold text-surface-100 mb-4">Delete Runbook</h2>
+        <h2 className="text-xl font-bold text-surface-900 mb-4">Delete Runbook</h2>
         <p className="text-surface-600 mb-6">
           Are you sure you want to delete "{runbook!.title}"? This action cannot be undone.
         </p>

--- a/frontend/src/pages/Runbooks.tsx
+++ b/frontend/src/pages/Runbooks.tsx
@@ -41,7 +41,7 @@ const statusColors: Record<string, string> = {
   approved: 'bg-blue-500/20 text-blue-600',
   published: 'bg-green-500/20 text-green-600',
   needs_review: 'bg-yellow-500/20 text-yellow-600',
-  archived: 'bg-surface-700 text-surface-600',
+  archived: 'bg-surface-200 text-surface-600',
 };
 
 const categoryIcons: Record<string, string> = {
@@ -106,7 +106,7 @@ export default function Runbooks() {
       <div className="p-6">
         <div className="card p-8 text-center">
           <ExclamationCircleIcon className="w-12 h-12 mx-auto mb-4 text-red-600" />
-          <h2 className="text-lg font-semibold text-surface-100 mb-2">Failed to load Runbooks</h2>
+          <h2 className="text-lg font-semibold text-surface-900 mb-2">Failed to load Runbooks</h2>
           <p className="text-surface-600 mb-4">
             {(error as Error).message || 'An unexpected error occurred'}
           </p>
@@ -123,7 +123,7 @@ export default function Runbooks() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-surface-100">Runbooks</h1>
+          <h1 className="text-2xl font-bold text-surface-900">Runbooks</h1>
           <p className="text-surface-600 mt-1">
             Step-by-step recovery procedures for systems and processes
           </p>
@@ -138,15 +138,15 @@ export default function Runbooks() {
         <div className="card p-4">
           <p className="text-surface-600 text-sm">Total Runbooks</p>
           {statsLoading ? (
-            <div className="h-8 w-16 bg-surface-700 rounded animate-pulse mt-1"></div>
+            <div className="h-8 w-16 bg-surface-200 rounded animate-pulse mt-1"></div>
           ) : (
-            <p className="text-2xl font-bold text-surface-100">{stats?.total || 0}</p>
+            <p className="text-2xl font-bold text-surface-900">{stats?.total || 0}</p>
           )}
         </div>
         <div className="card p-4">
           <p className="text-surface-600 text-sm">Published</p>
           {statsLoading ? (
-            <div className="h-8 w-16 bg-surface-700 rounded animate-pulse mt-1"></div>
+            <div className="h-8 w-16 bg-surface-200 rounded animate-pulse mt-1"></div>
           ) : (
             <p className="text-2xl font-bold text-green-600">{stats?.published_count || 0}</p>
           )}
@@ -154,7 +154,7 @@ export default function Runbooks() {
         <div className="card p-4">
           <p className="text-surface-600 text-sm">Drafts</p>
           {statsLoading ? (
-            <div className="h-8 w-16 bg-surface-700 rounded animate-pulse mt-1"></div>
+            <div className="h-8 w-16 bg-surface-200 rounded animate-pulse mt-1"></div>
           ) : (
             <p className="text-2xl font-bold text-surface-700">{stats?.draft_count || 0}</p>
           )}
@@ -162,7 +162,7 @@ export default function Runbooks() {
         <div className="card p-4">
           <p className="text-surface-600 text-sm">Needs Review</p>
           {statsLoading ? (
-            <div className="h-8 w-16 bg-surface-700 rounded animate-pulse mt-1"></div>
+            <div className="h-8 w-16 bg-surface-200 rounded animate-pulse mt-1"></div>
           ) : (
             <p className="text-2xl font-bold text-yellow-600">{stats?.needs_review_count || 0}</p>
           )}
@@ -221,9 +221,9 @@ export default function Runbooks() {
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {[1, 2, 3].map((i) => (
             <div key={i} className="card p-6 animate-pulse">
-              <div className="h-6 bg-surface-700 rounded w-3/4 mb-4"></div>
-              <div className="h-4 bg-surface-700 rounded w-1/2 mb-2"></div>
-              <div className="h-4 bg-surface-700 rounded w-2/3"></div>
+              <div className="h-6 bg-surface-200 rounded w-3/4 mb-4"></div>
+              <div className="h-4 bg-surface-200 rounded w-1/2 mb-2"></div>
+              <div className="h-4 bg-surface-200 rounded w-2/3"></div>
             </div>
           ))}
         </div>
@@ -261,7 +261,7 @@ export default function Runbooks() {
                 <span className="text-surface-600 text-xs">v{runbook.version}</span>
               </div>
 
-              <h3 className="text-lg font-semibold text-surface-100 mb-1">{runbook.title}</h3>
+              <h3 className="text-lg font-semibold text-surface-900 mb-1">{runbook.title}</h3>
               <p className="text-surface-600 text-sm mb-3">{runbook.runbook_id}</p>
 
               {runbook.description && (

--- a/frontend/src/pages/ScheduledReportsPage.tsx
+++ b/frontend/src/pages/ScheduledReportsPage.tsx
@@ -7,7 +7,7 @@ export default function ScheduledReportsPage() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-surface-100 flex items-center gap-3">
+          <h1 className="text-2xl font-bold text-surface-900 flex items-center gap-3">
             <DocumentChartBarIcon className="w-8 h-8 text-brand-500" />
             Report Scheduling
           </h1>

--- a/frontend/src/pages/SecurityTrainingDashboard.tsx
+++ b/frontend/src/pages/SecurityTrainingDashboard.tsx
@@ -118,7 +118,7 @@ function ProgressBar({ value, max, color }: { value: number; max: number; color:
   const percentage = max > 0 ? Math.round((value / max) * 100) : 0;
   return (
     <div className="flex items-center gap-3">
-      <div className="flex-1 h-2 bg-surface-700 rounded-full overflow-hidden">
+      <div className="flex-1 h-2 bg-surface-200 rounded-full overflow-hidden">
         <div
           className={clsx('h-full rounded-full transition-all', color)}
           style={{ width: `${percentage}%` }}
@@ -336,7 +336,7 @@ export default function SecurityTrainingDashboard() {
               {stats.departmentStats.slice(0, 6).map((dept) => (
                 <div
                   key={dept.department}
-                  className="flex items-center justify-between py-2 border-b border-surface-700 last:border-0"
+                  className="flex items-center justify-between py-2 border-b border-surface-200 last:border-0"
                 >
                   <div>
                     <p className="text-foreground font-medium">{dept.department}</p>
@@ -386,7 +386,7 @@ export default function SecurityTrainingDashboard() {
               {stats.upcomingDue.slice(0, 10).map((item, idx) => (
                 <div
                   key={idx}
-                  className="flex items-center justify-between py-2 border-b border-surface-700 last:border-0"
+                  className="flex items-center justify-between py-2 border-b border-surface-200 last:border-0"
                 >
                   <div>
                     <p className="text-foreground font-medium">
@@ -424,7 +424,7 @@ export default function SecurityTrainingDashboard() {
           <div className="overflow-x-auto">
             <table className="w-full">
               <thead>
-                <tr className="border-b border-surface-700">
+                <tr className="border-b border-surface-200">
                   <th className="text-left text-sm font-medium text-surface-600 pb-3">Employee</th>
                   <th className="text-left text-sm font-medium text-surface-600 pb-3">Course</th>
                   <th className="text-left text-sm font-medium text-surface-600 pb-3">Completed</th>
@@ -433,7 +433,7 @@ export default function SecurityTrainingDashboard() {
               </thead>
               <tbody>
                 {stats.recentCompletions.slice(0, 10).map((completion, idx) => (
-                  <tr key={idx} className="border-b border-surface-700/50">
+                  <tr key={idx} className="border-b border-surface-200/50">
                     <td className="py-3">
                       <p className="text-foreground">{completion.employeeName}</p>
                       <p className="text-sm text-surface-600">{completion.employeeEmail}</p>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -104,7 +104,7 @@ export default function Settings({ section }: SettingsProps) {
     <div className="space-y-6 animate-fade-in">
       {/* Header */}
       <div>
-        <h1 className="text-2xl font-bold text-surface-100">{title}</h1>
+        <h1 className="text-2xl font-bold text-surface-900">{title}</h1>
         <p className="text-surface-600 mt-1">{description}</p>
       </div>
 
@@ -363,7 +363,7 @@ function OrganizationSettings() {
       {/* Platform Branding */}
       <div className="card p-6 space-y-6">
         <div>
-          <h2 className="text-lg font-semibold text-surface-100">Platform Branding</h2>
+          <h2 className="text-lg font-semibold text-surface-900">Platform Branding</h2>
           <p className="text-surface-600 text-sm mt-1">
             Customize the look and name of your GRC platform
           </p>
@@ -391,7 +391,7 @@ function OrganizationSettings() {
             <div className="mt-2 flex items-start gap-4">
               {/* Current Logo Preview */}
               <div className="flex-shrink-0">
-                <div className="w-20 h-20 rounded-lg border border-surface-700 bg-surface-800 flex items-center justify-center overflow-hidden">
+                <div className="w-20 h-20 rounded-lg border border-surface-200 bg-white flex items-center justify-center overflow-hidden">
                   {logoUrl ? (
                     <img
                       src={safeLogoUrl()}
@@ -428,7 +428,7 @@ function OrganizationSettings() {
                     <Button
                       type="button"
                       onClick={handleResetLogo}
-                      className="text-sm text-surface-600 hover:text-surface-200"
+                      className="text-sm text-surface-600 hover:text-surface-800"
                       variant="ghost"
                     >
                       Reset to Default
@@ -461,7 +461,7 @@ function OrganizationSettings() {
           </div>
         </div>
 
-        <div className="flex justify-end pt-4 border-t border-surface-800">
+        <div className="flex justify-end pt-4 border-t border-surface-200">
           <Button onClick={handleSaveBranding} disabled={isSaving} variant="primary">
             {isSaving ? 'Saving...' : 'Save Branding'}
           </Button>
@@ -469,7 +469,7 @@ function OrganizationSettings() {
       </div>
       {/* Organization Settings */}
       <div className="card p-6 space-y-6">
-        <h2 className="text-lg font-semibold text-surface-100">Organization Details</h2>
+        <h2 className="text-lg font-semibold text-surface-900">Organization Details</h2>
 
         <div className="space-y-4">
           <div>
@@ -534,7 +534,7 @@ function OrganizationSettings() {
           </div>
         </div>
 
-        <div className="flex justify-end pt-4 border-t border-surface-800">
+        <div className="flex justify-end pt-4 border-t border-surface-200">
           <Button onClick={handleSaveOrganization} disabled={isSavingOrg} variant="primary">
             {isSavingOrg ? 'Saving...' : 'Save Organization'}
           </Button>
@@ -546,7 +546,7 @@ function OrganizationSettings() {
       <div className="card p-6 space-y-4">
         <div className="flex items-start justify-between gap-4">
           <div>
-            <h2 className="text-lg font-semibold text-surface-100">
+            <h2 className="text-lg font-semibold text-surface-900">
               Data Portability & Offboarding
             </h2>
             <p className="text-surface-600 text-sm mt-1">
@@ -562,8 +562,8 @@ function OrganizationSettings() {
           />
         </div>
 
-        <div className="bg-surface-800/60 rounded-lg p-4 space-y-2 text-sm text-surface-600">
-          <p className="font-medium text-surface-200">What&apos;s included</p>
+        <div className="bg-white/60 rounded-lg p-4 space-y-2 text-sm text-surface-600">
+          <p className="font-medium text-surface-800">What&apos;s included</p>
           <ul className="list-disc list-inside space-y-1">
             <li>Risk register data (using the full export endpoint)</li>
             <li>Controls and implementations</li>
@@ -577,7 +577,7 @@ function OrganizationSettings() {
           </p>
         </div>
 
-        <div className="flex justify-end pt-4 border-t border-surface-800">
+        <div className="flex justify-end pt-4 border-t border-surface-200">
           <Button
             type="button"
             onClick={handleExportOrganizationData}
@@ -591,8 +591,8 @@ function OrganizationSettings() {
       {/* Demo Data Settings */}
       <DemoDataSettings />
       {/* System Health & Production Readiness */}
-      <div className="space-y-4 pt-4 border-t border-surface-800">
-        <h2 className="text-lg font-semibold text-surface-100">System Health</h2>
+      <div className="space-y-4 pt-4 border-t border-surface-200">
+        <h2 className="text-lg font-semibold text-surface-900">System Health</h2>
         <SystemHealthBanner />
         <ProductionReadiness />
       </div>
@@ -657,7 +657,7 @@ function MultiWorkspaceSettings() {
           <div className="flex items-center gap-3">
             <BuildingOfficeIcon className="w-6 h-6 text-brand-400" />
             <div>
-              <h2 className="text-lg font-semibold text-surface-100">Multi-Workspace Mode</h2>
+              <h2 className="text-lg font-semibold text-surface-900">Multi-Workspace Mode</h2>
               <p className="text-sm text-surface-600">
                 Enable separate workspaces for different products or teams
               </p>
@@ -679,10 +679,10 @@ function MultiWorkspaceSettings() {
         </div>
 
         {isMultiWorkspaceEnabled && (
-          <div className="pt-4 border-t border-surface-700">
+          <div className="pt-4 border-t border-surface-200">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-surface-100 font-medium">
+                <p className="text-surface-900 font-medium">
                   {workspaces.length} workspace{workspaces.length !== 1 ? 's' : ''} active
                 </p>
                 <p className="text-sm text-surface-600">
@@ -701,7 +701,7 @@ function MultiWorkspaceSettings() {
         )}
 
         {!isMultiWorkspaceEnabled && (
-          <div className="bg-surface-800 rounded-lg p-4 text-sm text-surface-600">
+          <div className="bg-white rounded-lg p-4 text-sm text-surface-600">
             <p className="mb-2">Multi-workspace mode allows you to:</p>
             <ul className="list-disc list-inside space-y-1">
               <li>Track compliance progress separately for each product</li>
@@ -715,7 +715,7 @@ function MultiWorkspaceSettings() {
 
       {/* Disable Warning Modal */}
       <Dialog open={showDisableWarning} onClose={() => setShowDisableWarning(false)}>
-        <h3 className="text-lg font-semibold text-surface-100 mb-4">
+        <h3 className="text-lg font-semibold text-surface-900 mb-4">
           Disable Multi-Workspace Mode?
         </h3>
         <p className="text-surface-600 mb-6">
@@ -725,7 +725,7 @@ function MultiWorkspaceSettings() {
         <div className="flex justify-end gap-3">
           <button
             onClick={() => setShowDisableWarning(false)}
-            className="px-4 py-2 text-sm text-surface-600 hover:text-surface-100"
+            className="px-4 py-2 text-sm text-surface-600 hover:text-surface-900"
           >
             Cancel
           </button>
@@ -869,8 +869,8 @@ function CommunicationsSettings() {
     return (
       <div className="card p-6">
         <div className="animate-pulse space-y-4">
-          <div className="h-6 bg-surface-700 rounded w-1/3" />
-          <div className="h-32 bg-surface-700 rounded" />
+          <div className="h-6 bg-surface-200 rounded w-1/3" />
+          <div className="h-32 bg-surface-200 rounded" />
         </div>
       </div>
     );
@@ -882,7 +882,7 @@ function CommunicationsSettings() {
       <div className="card p-6 space-y-6">
         <div className="flex items-center justify-between">
           <div>
-            <h2 className="text-lg font-semibold text-surface-100 flex items-center gap-2">
+            <h2 className="text-lg font-semibold text-surface-900 flex items-center gap-2">
               <EnvelopeIcon className="w-5 h-5" />
               Email Configuration
             </h2>
@@ -938,7 +938,7 @@ function CommunicationsSettings() {
             </div>
 
             {emailProvider === 'smtp' && (
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4 p-4 bg-surface-800/50 rounded-lg">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4 p-4 bg-white/50 rounded-lg">
                 <div>
                   <label className="label">SMTP Host</label>
                   <Input
@@ -983,7 +983,7 @@ function CommunicationsSettings() {
             )}
 
             {emailProvider === 'sendgrid' && (
-              <div className="p-4 bg-surface-800/50 rounded-lg">
+              <div className="p-4 bg-white/50 rounded-lg">
                 <label className="label">SendGrid API Key</label>
                 <Input
                   type="password"
@@ -996,7 +996,7 @@ function CommunicationsSettings() {
             )}
 
             {emailProvider === 'ses' && (
-              <div className="grid grid-cols-1 md:grid-cols-3 gap-4 p-4 bg-surface-800/50 rounded-lg">
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4 p-4 bg-white/50 rounded-lg">
                 <div>
                   <label className="label">AWS Region</label>
                   <SelectNative
@@ -1036,7 +1036,7 @@ function CommunicationsSettings() {
               </div>
             )}
 
-            <div className="flex items-center gap-4 pt-4 border-t border-surface-700">
+            <div className="flex items-center gap-4 pt-4 border-t border-surface-200">
               <div className="flex-1">
                 <Input
                   type="email"
@@ -1057,7 +1057,7 @@ function CommunicationsSettings() {
           </>
         )}
 
-        <div className="flex justify-end pt-4 border-t border-surface-800">
+        <div className="flex justify-end pt-4 border-t border-surface-200">
           <Button
             onClick={handleSaveEmail}
             disabled={updateEmailMutation.isPending}
@@ -1071,7 +1071,7 @@ function CommunicationsSettings() {
       <div className="card p-6 space-y-6">
         <div className="flex items-center justify-between">
           <div>
-            <h2 className="text-lg font-semibold text-surface-100">Slack Notifications</h2>
+            <h2 className="text-lg font-semibold text-surface-900">Slack Notifications</h2>
             <p className="text-surface-600 text-sm mt-1">Send alerts and notifications to Slack</p>
           </div>
           <label className="relative inline-flex items-center cursor-pointer">
@@ -1081,7 +1081,7 @@ function CommunicationsSettings() {
               onChange={(e) => setSlackForm((f) => ({ ...f, enabled: e.target.checked }))}
               className="sr-only peer"
             />
-            <div className="w-11 h-6 bg-surface-700 peer-focus:ring-2 peer-focus:ring-brand-500 rounded-full peer peer-checked:after:translate-x-full after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-brand-600"></div>
+            <div className="w-11 h-6 bg-surface-200 peer-focus:ring-2 peer-focus:ring-brand-500 rounded-full peer peer-checked:after:translate-x-full after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-brand-600"></div>
           </label>
         </div>
 
@@ -1127,7 +1127,7 @@ function CommunicationsSettings() {
               </div>
             </div>
 
-            <div className="flex items-center gap-4 pt-4 border-t border-surface-700">
+            <div className="flex items-center gap-4 pt-4 border-t border-surface-200">
               <Button
                 onClick={() => testSlackMutation.mutate(slackForm.defaultChannel)}
                 disabled={testSlackMutation.isPending}
@@ -1139,7 +1139,7 @@ function CommunicationsSettings() {
           </>
         )}
 
-        <div className="flex justify-end pt-4 border-t border-surface-800">
+        <div className="flex justify-end pt-4 border-t border-surface-200">
           <Button
             onClick={handleSaveSlack}
             disabled={updateSlackMutation.isPending}
@@ -1245,7 +1245,7 @@ function ApiSettings() {
     <div className="card p-6 space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-lg font-semibold text-surface-100">API Keys</h2>
+          <h2 className="text-lg font-semibold text-surface-900">API Keys</h2>
           <p className="text-surface-600 text-sm mt-1">Manage API keys for programmatic access</p>
         </div>
         <Button onClick={() => setShowCreateModal(true)} variant="primary">
@@ -1266,11 +1266,11 @@ function ApiSettings() {
           {keys.map((key: ApiKey) => (
             <div
               key={key.id}
-              className="flex items-center justify-between p-4 bg-surface-800/50 rounded-lg"
+              className="flex items-center justify-between p-4 bg-white/50 rounded-lg"
             >
               <div>
                 <div className="flex items-center gap-2">
-                  <p className="text-surface-100 font-medium">{key.name}</p>
+                  <p className="text-surface-900 font-medium">{key.name}</p>
                   {!key.isActive && (
                     <span className="px-2 py-0.5 text-xs bg-red-500/20 text-red-600 rounded">
                       Revoked
@@ -1367,7 +1367,7 @@ function ApiSettings() {
       </div>
       {/* Create Key Modal */}
       <Dialog open={showCreateModal} onClose={() => setShowCreateModal(false)}>
-        <h3 className="text-lg font-semibold text-surface-100 mb-4">Create API Key</h3>
+        <h3 className="text-lg font-semibold text-surface-900 mb-4">Create API Key</h3>
         <form onSubmit={handleCreate} className="space-y-4">
           <div>
             <label className="block text-sm font-medium text-surface-700 mb-1">Name</label>
@@ -1407,7 +1407,7 @@ function ApiSettings() {
                         setNewKeyScopes(newKeyScopes.filter((s) => s !== scope));
                       }
                     }}
-                    className="rounded border-surface-600 bg-surface-800 text-primary-500"
+                    className="rounded border-surface-300 bg-white text-primary-500"
                   />
                   <span className="text-surface-700 text-sm">{scope}</span>
                 </label>
@@ -1433,14 +1433,14 @@ function ApiSettings() {
         <Dialog open={showNewKeyModal} onClose={() => setShowNewKeyModal(false)}>
           <div className="flex items-center gap-2 mb-4">
             <CheckCircleIcon className="w-6 h-6 text-green-600" />
-            <h3 className="text-lg font-semibold text-surface-100">API Key Created</h3>
+            <h3 className="text-lg font-semibold text-surface-900">API Key Created</h3>
           </div>
           <div className="p-4 bg-amber-500/10 border border-amber-500/20 rounded-lg mb-4">
             <p className="text-amber-600 text-sm">
               Copy this key now. You won't be able to see it again!
             </p>
           </div>
-          <div className="bg-surface-800 rounded-lg p-4">
+          <div className="bg-white rounded-lg p-4">
             <div className="flex items-center justify-between">
               <code className="text-green-600 text-sm break-all">{newKey.key}</code>
               <Button
@@ -1523,7 +1523,7 @@ function DashboardTemplatesSettings() {
       <div className="card p-6">
         <div className="flex items-center justify-between mb-6">
           <div>
-            <h2 className="text-lg font-semibold text-surface-100">Dashboard Templates</h2>
+            <h2 className="text-lg font-semibold text-surface-900">Dashboard Templates</h2>
             <p className="text-surface-600 text-sm mt-1">
               Templates are shared with all users in your organization
             </p>
@@ -1535,10 +1535,10 @@ function DashboardTemplatesSettings() {
 
         {isLoading ? (
           <div className="flex items-center justify-center py-8">
-            <div className="animate-spin w-6 h-6 border-2 border-surface-600 rounded-full border-t-brand-500" />
+            <div className="animate-spin w-6 h-6 border-2 border-surface-300 rounded-full border-t-brand-500" />
           </div>
         ) : templates?.length === 0 ? (
-          <div className="text-center py-12 bg-surface-800/50 rounded-lg">
+          <div className="text-center py-12 bg-white/50 rounded-lg">
             <Squares2X2Icon className="w-12 h-12 mx-auto text-surface-500 mb-4" />
             <h3 className="text-surface-700 font-medium mb-2">No templates yet</h3>
             <p className="text-surface-500 text-sm mb-4">
@@ -1553,14 +1553,14 @@ function DashboardTemplatesSettings() {
             {templates?.map((template: any) => (
               <div
                 key={template.id}
-                className="flex items-center justify-between p-4 bg-surface-800/50 rounded-lg hover:bg-surface-800 transition-colors"
+                className="flex items-center justify-between p-4 bg-white/50 rounded-lg hover:bg-white transition-colors"
               >
                 <div className="flex items-center gap-4">
-                  <div className="p-2 bg-surface-700 rounded">
+                  <div className="p-2 bg-surface-200 rounded">
                     <Squares2X2Icon className="w-5 h-5 text-brand-400" />
                   </div>
                   <div>
-                    <p className="text-surface-100 font-medium">{template.name}</p>
+                    <p className="text-surface-900 font-medium">{template.name}</p>
                     {template.description && (
                       <p className="text-surface-500 text-sm">{template.description}</p>
                     )}
@@ -1597,7 +1597,7 @@ function DashboardTemplatesSettings() {
         )}
       </div>
       <div className="card p-6">
-        <h3 className="text-md font-semibold text-surface-100 mb-4">Template Tips</h3>
+        <h3 className="text-md font-semibold text-surface-900 mb-4">Template Tips</h3>
         <ul className="space-y-2 text-sm text-surface-600">
           <li className="flex items-start gap-2">
             <CheckCircleIcon className="w-5 h-5 text-green-600 flex-shrink-0" />
@@ -1615,7 +1615,7 @@ function DashboardTemplatesSettings() {
       </div>
       {/* Create Template Modal */}
       <Dialog open={showCreateModal} onClose={() => setShowCreateModal(false)}>
-        <h2 className="text-lg font-semibold text-surface-100 mb-4">Create Dashboard Template</h2>
+        <h2 className="text-lg font-semibold text-surface-900 mb-4">Create Dashboard Template</h2>
         <form onSubmit={handleCreate}>
           <div className="space-y-4">
             <div>
@@ -1818,7 +1818,7 @@ function EmployeeComplianceSettings() {
       {/* Score Weights */}
       <div className="card p-6 space-y-4">
         <div>
-          <h2 className="text-lg font-semibold text-surface-100">Compliance Score Weights</h2>
+          <h2 className="text-lg font-semibold text-surface-900">Compliance Score Weights</h2>
           <p className="text-surface-600 text-sm mt-1">
             Configure how much each category contributes to the overall compliance score. Weights
             must total 100%.
@@ -1897,7 +1897,7 @@ function EmployeeComplianceSettings() {
       {/* Compliance Thresholds */}
       <div className="card p-6 space-y-4">
         <div>
-          <h2 className="text-lg font-semibold text-surface-100">Compliance Thresholds</h2>
+          <h2 className="text-lg font-semibold text-surface-900">Compliance Thresholds</h2>
           <p className="text-surface-600 text-sm mt-1">
             Define score thresholds for compliance status categories.
           </p>
@@ -1960,7 +1960,7 @@ function EmployeeComplianceSettings() {
       {/* Compliance Requirements */}
       <div className="card p-6 space-y-4">
         <div>
-          <h2 className="text-lg font-semibold text-surface-100">Compliance Requirements</h2>
+          <h2 className="text-lg font-semibold text-surface-900">Compliance Requirements</h2>
           <p className="text-surface-600 text-sm mt-1">
             Configure what is required for employee compliance.
           </p>
@@ -1968,9 +1968,9 @@ function EmployeeComplianceSettings() {
 
         <div className="space-y-4">
           {/* Background Check */}
-          <div className="p-4 bg-surface-800/50 rounded-lg space-y-3">
+          <div className="p-4 bg-white/50 rounded-lg space-y-3">
             <div className="flex items-center justify-between">
-              <label className="text-surface-200 font-medium">Background Check</label>
+              <label className="text-surface-800 font-medium">Background Check</label>
               <label className="relative inline-flex items-center cursor-pointer">
                 <input
                   type="checkbox"
@@ -1978,7 +1978,7 @@ function EmployeeComplianceSettings() {
                   onChange={(e) => updateRequirement('backgroundCheckRequired', e.target.checked)}
                   className="sr-only peer"
                 />
-                <div className="w-11 h-6 bg-surface-700 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-brand-500"></div>
+                <div className="w-11 h-6 bg-surface-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-brand-500"></div>
               </label>
             </div>
             {config.requirements.backgroundCheckRequired && (
@@ -2003,9 +2003,9 @@ function EmployeeComplianceSettings() {
           </div>
 
           {/* Training */}
-          <div className="p-4 bg-surface-800/50 rounded-lg space-y-3">
+          <div className="p-4 bg-white/50 rounded-lg space-y-3">
             <div className="flex items-center justify-between">
-              <label className="text-surface-200 font-medium">Training Completion</label>
+              <label className="text-surface-800 font-medium">Training Completion</label>
               <label className="relative inline-flex items-center cursor-pointer">
                 <input
                   type="checkbox"
@@ -2015,7 +2015,7 @@ function EmployeeComplianceSettings() {
                   }
                   className="sr-only peer"
                 />
-                <div className="w-11 h-6 bg-surface-700 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-brand-500"></div>
+                <div className="w-11 h-6 bg-surface-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-brand-500"></div>
               </label>
             </div>
             {config.requirements.trainingCompletionRequired && (
@@ -2037,9 +2037,9 @@ function EmployeeComplianceSettings() {
           </div>
 
           {/* Attestation */}
-          <div className="p-4 bg-surface-800/50 rounded-lg space-y-3">
+          <div className="p-4 bg-white/50 rounded-lg space-y-3">
             <div className="flex items-center justify-between">
-              <label className="text-surface-200 font-medium">Policy Attestation</label>
+              <label className="text-surface-800 font-medium">Policy Attestation</label>
               <label className="relative inline-flex items-center cursor-pointer">
                 <input
                   type="checkbox"
@@ -2047,7 +2047,7 @@ function EmployeeComplianceSettings() {
                   onChange={(e) => updateRequirement('attestationRequired', e.target.checked)}
                   className="sr-only peer"
                 />
-                <div className="w-11 h-6 bg-surface-700 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-brand-500"></div>
+                <div className="w-11 h-6 bg-surface-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-brand-500"></div>
               </label>
             </div>
             {config.requirements.attestationRequired && (
@@ -2069,10 +2069,10 @@ function EmployeeComplianceSettings() {
           </div>
 
           {/* MFA */}
-          <div className="p-4 bg-surface-800/50 rounded-lg">
+          <div className="p-4 bg-white/50 rounded-lg">
             <div className="flex items-center justify-between">
               <div>
-                <label className="text-surface-200 font-medium">MFA Required</label>
+                <label className="text-surface-800 font-medium">MFA Required</label>
                 <p className="text-surface-500 text-xs mt-1">
                   Require multi-factor authentication for all employees
                 </p>
@@ -2084,7 +2084,7 @@ function EmployeeComplianceSettings() {
                   onChange={(e) => updateRequirement('mfaRequired', e.target.checked)}
                   className="sr-only peer"
                 />
-                <div className="w-11 h-6 bg-surface-700 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-brand-500"></div>
+                <div className="w-11 h-6 bg-surface-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-brand-500"></div>
               </label>
             </div>
           </div>
@@ -2093,7 +2093,7 @@ function EmployeeComplianceSettings() {
       {/* Data Sources Info */}
       <div className="card p-6 space-y-4">
         <div>
-          <h2 className="text-lg font-semibold text-surface-100">Data Sources</h2>
+          <h2 className="text-lg font-semibold text-surface-900">Data Sources</h2>
           <p className="text-surface-600 text-sm mt-1">
             Employee compliance data is gathered from configured integrations. Click a category to
             view or configure integrations.
@@ -2103,60 +2103,60 @@ function EmployeeComplianceSettings() {
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
           <Link
             to="/integrations?search=HR%20Tools"
-            className="p-3 bg-surface-800/50 rounded-lg hover:bg-surface-700/50 hover:border-brand-500/50 border border-transparent transition-all cursor-pointer group"
+            className="p-3 bg-white/50 rounded-lg hover:bg-surface-200/50 hover:border-brand-500/50 border border-transparent transition-all cursor-pointer group"
           >
             <p className="text-surface-600 text-xs uppercase tracking-wider mb-1 group-hover:text-brand-400">
               HRIS / Employee List
             </p>
-            <p className="text-surface-200 text-sm">BambooHR, Workday, ADP, etc.</p>
+            <p className="text-surface-800 text-sm">BambooHR, Workday, ADP, etc.</p>
             <p className="text-surface-500 text-xs mt-2 group-hover:text-brand-400">
               Click to configure →
             </p>
           </Link>
           <Link
             to="/integrations?search=Background%20Check"
-            className="p-3 bg-surface-800/50 rounded-lg hover:bg-surface-700/50 hover:border-brand-500/50 border border-transparent transition-all cursor-pointer group"
+            className="p-3 bg-white/50 rounded-lg hover:bg-surface-200/50 hover:border-brand-500/50 border border-transparent transition-all cursor-pointer group"
           >
             <p className="text-surface-600 text-xs uppercase tracking-wider mb-1 group-hover:text-brand-400">
               Background Check
             </p>
-            <p className="text-surface-200 text-sm">Certn, Checkr, Sterling, etc.</p>
+            <p className="text-surface-800 text-sm">Certn, Checkr, Sterling, etc.</p>
             <p className="text-surface-500 text-xs mt-2 group-hover:text-brand-400">
               Click to configure →
             </p>
           </Link>
           <Link
             to="/integrations?search=Security%20Awareness"
-            className="p-3 bg-surface-800/50 rounded-lg hover:bg-surface-700/50 hover:border-brand-500/50 border border-transparent transition-all cursor-pointer group"
+            className="p-3 bg-white/50 rounded-lg hover:bg-surface-200/50 hover:border-brand-500/50 border border-transparent transition-all cursor-pointer group"
           >
             <p className="text-surface-600 text-xs uppercase tracking-wider mb-1 group-hover:text-brand-400">
               Training / LMS
             </p>
-            <p className="text-surface-200 text-sm">KnowBe4, Proofpoint, Curricula, etc.</p>
+            <p className="text-surface-800 text-sm">KnowBe4, Proofpoint, Curricula, etc.</p>
             <p className="text-surface-500 text-xs mt-2 group-hover:text-brand-400">
               Click to configure →
             </p>
           </Link>
           <Link
             to="/integrations?search=MDM"
-            className="p-3 bg-surface-800/50 rounded-lg hover:bg-surface-700/50 hover:border-brand-500/50 border border-transparent transition-all cursor-pointer group"
+            className="p-3 bg-white/50 rounded-lg hover:bg-surface-200/50 hover:border-brand-500/50 border border-transparent transition-all cursor-pointer group"
           >
             <p className="text-surface-600 text-xs uppercase tracking-wider mb-1 group-hover:text-brand-400">
               MDM / Device
             </p>
-            <p className="text-surface-200 text-sm">Jamf, Kandji, Intune, etc.</p>
+            <p className="text-surface-800 text-sm">Jamf, Kandji, Intune, etc.</p>
             <p className="text-surface-500 text-xs mt-2 group-hover:text-brand-400">
               Click to configure →
             </p>
           </Link>
           <Link
             to="/integrations?search=Identity%20Provider"
-            className="p-3 bg-surface-800/50 rounded-lg hover:bg-surface-700/50 hover:border-brand-500/50 border border-transparent transition-all cursor-pointer group"
+            className="p-3 bg-white/50 rounded-lg hover:bg-surface-200/50 hover:border-brand-500/50 border border-transparent transition-all cursor-pointer group"
           >
             <p className="text-surface-600 text-xs uppercase tracking-wider mb-1 group-hover:text-brand-400">
               Identity Provider
             </p>
-            <p className="text-surface-200 text-sm">Okta, Azure AD, Google Workspace</p>
+            <p className="text-surface-800 text-sm">Okta, Azure AD, Google Workspace</p>
             <p className="text-surface-500 text-xs mt-2 group-hover:text-brand-400">
               Click to configure →
             </p>
@@ -2224,7 +2224,7 @@ function AISettings() {
       {/* AI Provider Selection */}
       <div className="card p-6 space-y-4">
         <div>
-          <h2 className="text-lg font-semibold text-surface-100">AI Provider</h2>
+          <h2 className="text-lg font-semibold text-surface-900">AI Provider</h2>
           <p className="text-surface-600 text-sm mt-1">
             Select an AI provider for intelligent automation features.
           </p>
@@ -2236,10 +2236,10 @@ function AISettings() {
             className={`p-4 rounded-lg border-2 transition-all ${
               aiProvider === 'disabled'
                 ? 'border-brand-500 bg-brand-500/10'
-                : 'border-surface-700 hover:border-surface-600'
+                : 'border-surface-200 hover:border-surface-300'
             }`}
           >
-            <p className="text-surface-100 font-medium">Disabled</p>
+            <p className="text-surface-900 font-medium">Disabled</p>
             <p className="text-surface-500 text-sm mt-1">No AI features</p>
           </button>
           <button
@@ -2250,10 +2250,10 @@ function AISettings() {
             className={`p-4 rounded-lg border-2 transition-all ${
               aiProvider === 'openai'
                 ? 'border-brand-500 bg-brand-500/10'
-                : 'border-surface-700 hover:border-surface-600'
+                : 'border-surface-200 hover:border-surface-300'
             }`}
           >
-            <p className="text-surface-100 font-medium">OpenAI</p>
+            <p className="text-surface-900 font-medium">OpenAI</p>
             <p className="text-surface-500 text-sm mt-1">GPT-4, GPT-3.5</p>
           </button>
           <button
@@ -2264,16 +2264,16 @@ function AISettings() {
             className={`p-4 rounded-lg border-2 transition-all ${
               aiProvider === 'anthropic'
                 ? 'border-brand-500 bg-brand-500/10'
-                : 'border-surface-700 hover:border-surface-600'
+                : 'border-surface-200 hover:border-surface-300'
             }`}
           >
-            <p className="text-surface-100 font-medium">Anthropic</p>
+            <p className="text-surface-900 font-medium">Anthropic</p>
             <p className="text-surface-500 text-sm mt-1">Claude 3</p>
           </button>
         </div>
 
         {aiProvider !== 'disabled' && (
-          <div className="space-y-4 pt-4 border-t border-surface-700">
+          <div className="space-y-4 pt-4 border-t border-surface-200">
             <div>
               <label className="label">API Key</label>
               <Input
@@ -2307,7 +2307,7 @@ function AISettings() {
       {/* AI Features */}
       <div className="card p-6 space-y-4">
         <div>
-          <h2 className="text-lg font-semibold text-surface-100">AI Features</h2>
+          <h2 className="text-lg font-semibold text-surface-900">AI Features</h2>
           <p className="text-surface-600 text-sm mt-1">
             Enable or disable specific AI-powered features.
           </p>
@@ -2343,10 +2343,10 @@ function AISettings() {
           ].map((feature) => (
             <div
               key={feature.key}
-              className="flex items-center justify-between p-3 bg-surface-800/50 rounded-lg"
+              className="flex items-center justify-between p-3 bg-white/50 rounded-lg"
             >
               <div>
-                <p className="text-surface-200 font-medium">{feature.name}</p>
+                <p className="text-surface-800 font-medium">{feature.name}</p>
                 <p className="text-surface-500 text-sm">{feature.desc}</p>
               </div>
               <label className="relative inline-flex items-center cursor-pointer">
@@ -2357,7 +2357,7 @@ function AISettings() {
                   disabled={aiProvider === 'disabled'}
                   className="sr-only peer"
                 />
-                <div className="w-11 h-6 bg-surface-700 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-brand-500 peer-disabled:opacity-50"></div>
+                <div className="w-11 h-6 bg-surface-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-brand-500 peer-disabled:opacity-50"></div>
               </label>
             </div>
           ))}
@@ -2367,7 +2367,7 @@ function AISettings() {
       <div className="card p-6">
         <div className="flex items-center justify-between">
           <div>
-            <h2 className="text-lg font-semibold text-surface-100">MCP Server Integration</h2>
+            <h2 className="text-lg font-semibold text-surface-900">MCP Server Integration</h2>
             <p className="text-surface-600 text-sm mt-1">
               Configure Model Context Protocol (MCP) servers for advanced AI workflows.
             </p>

--- a/frontend/src/pages/TPRMConfiguration.tsx
+++ b/frontend/src/pages/TPRMConfiguration.tsx
@@ -131,7 +131,7 @@ export default function TPRMConfiguration() {
               }
             }}
             disabled={resetMutation.isPending}
-            className="px-4 py-2 bg-surface-700 text-surface-700 rounded-lg hover:bg-surface-600 flex items-center gap-2"
+            className="px-4 py-2 bg-surface-200 text-surface-700 rounded-lg hover:bg-surface-600 flex items-center gap-2"
           >
             <ArrowPathIcon className="w-4 h-4" />
             Reset to Defaults
@@ -140,7 +140,7 @@ export default function TPRMConfiguration() {
       </div>
 
       {/* Tabs */}
-      <div className="flex gap-2 border-b border-surface-700 pb-px">
+      <div className="flex gap-2 border-b border-surface-200 pb-px">
         {tabs.map((tab) => (
           <button
             key={tab.key}
@@ -158,7 +158,7 @@ export default function TPRMConfiguration() {
       </div>
 
       {/* Tab Content */}
-      <div className="bg-surface-800 rounded-xl border border-surface-700 p-6">
+      <div className="bg-white rounded-xl border border-surface-200 p-6">
         {activeTab === 'tiers' && config && referenceData && (
           <TierFrequencyTab
             config={config}
@@ -339,7 +339,7 @@ function TierFrequencyTab({
       case 'green':
         return 'bg-emerald-500/20 border-emerald-500/30 text-emerald-600';
       default:
-        return 'bg-surface-700 border-surface-600 text-surface-700';
+        return 'bg-surface-200 border-surface-300 text-surface-700';
     }
   };
 
@@ -373,7 +373,7 @@ function TierFrequencyTab({
                 <SelectNative
                   value={getSelectValue(tier.key)}
                   onChange={(e) => handleFrequencyChange(tier.key, e.target.value)}
-                  className="px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white min-w-[180px]"
+                  className="px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white min-w-[180px]"
                 >
                   {referenceData.frequencyOptions.map((opt) => (
                     <option key={opt.value} value={opt.value}>
@@ -398,7 +398,7 @@ function TierFrequencyTab({
                       onChange={(e) =>
                         handleCustomMonthsChange(tier.key, parseInt(e.target.value) || 1)
                       }
-                      className="w-20 px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white text-center"
+                      className="w-20 px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white text-center"
                     />
                     <span className="text-sm text-surface-700">months</span>
                   </div>
@@ -409,14 +409,14 @@ function TierFrequencyTab({
         ))}
       </div>
       {/* Preview */}
-      <div className="p-4 bg-surface-700/50 rounded-lg">
+      <div className="p-4 bg-surface-200/50 rounded-lg">
         <h4 className="text-white font-medium mb-3">Review Schedule Summary</h4>
         <div className="grid grid-cols-4 gap-4 text-sm">
           {tiers.map((tier) => {
             const freq = tierMapping[tier.key as keyof typeof tierMapping];
             const months = parseFrequencyToMonths(freq);
             return (
-              <div key={tier.key} className="text-center p-3 bg-surface-800 rounded-lg">
+              <div key={tier.key} className="text-center p-3 bg-white rounded-lg">
                 <p className="text-surface-600 text-xs mb-1">{tier.label}</p>
                 <p className="text-white font-medium">{formatFrequencyLabel(freq)}</p>
                 <p className="text-surface-500 text-xs mt-1">
@@ -474,7 +474,7 @@ function VendorCategoriesTab({
       </div>
       <div className="space-y-3">
         {categories.map((cat) => (
-          <div key={cat.id} className="flex items-center gap-4 p-4 bg-surface-700/50 rounded-lg">
+          <div key={cat.id} className="flex items-center gap-4 p-4 bg-surface-200/50 rounded-lg">
             <div className="w-4 h-4 rounded" style={{ backgroundColor: cat.color }} />
             <div className="flex-1">
               <p className="text-white font-medium">{cat.name}</p>
@@ -489,7 +489,7 @@ function VendorCategoriesTab({
           </div>
         ))}
       </div>
-      <div className="pt-4 border-t border-surface-700">
+      <div className="pt-4 border-t border-surface-200">
         <h4 className="text-white font-medium mb-3">Add Category</h4>
         <div className="flex gap-4">
           <Input
@@ -497,14 +497,14 @@ function VendorCategoriesTab({
             placeholder="Category name"
             value={newCategory.name}
             onChange={(e) => setNewCategory((prev) => ({ ...prev, name: e.target.value }))}
-            className="flex-1 px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white placeholder:text-surface-500"
+            className="flex-1 px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white placeholder:text-surface-500"
           />
           <Input
             type="text"
             placeholder="Description"
             value={newCategory.description}
             onChange={(e) => setNewCategory((prev) => ({ ...prev, description: e.target.value }))}
-            className="flex-1 px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white placeholder:text-surface-500"
+            className="flex-1 px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white placeholder:text-surface-500"
           />
           <input
             type="color"
@@ -556,7 +556,7 @@ function AssessmentSettingsTab({
         </p>
       </div>
       <div className="space-y-4">
-        <label className="flex items-center justify-between p-4 bg-surface-700/50 rounded-lg">
+        <label className="flex items-center justify-between p-4 bg-surface-200/50 rounded-lg">
           <div>
             <p className="text-white">Require Document Upload</p>
             <p className="text-surface-600 text-sm">
@@ -567,11 +567,11 @@ function AssessmentSettingsTab({
             type="checkbox"
             checked={settings.requireDocumentUpload ?? false}
             onChange={(e) => handleChange('requireDocumentUpload', e.target.checked)}
-            className="rounded border-surface-600"
+            className="rounded border-surface-300"
           />
         </label>
 
-        <label className="flex items-center justify-between p-4 bg-surface-700/50 rounded-lg">
+        <label className="flex items-center justify-between p-4 bg-surface-200/50 rounded-lg">
           <div>
             <p className="text-white">Auto-Create Assessment on New Vendor</p>
             <p className="text-surface-600 text-sm">
@@ -582,11 +582,11 @@ function AssessmentSettingsTab({
             type="checkbox"
             checked={settings.autoCreateAssessmentOnNewVendor ?? false}
             onChange={(e) => handleChange('autoCreateAssessmentOnNewVendor', e.target.checked)}
-            className="rounded border-surface-600"
+            className="rounded border-surface-300"
           />
         </label>
 
-        <label className="flex items-center justify-between p-4 bg-surface-700/50 rounded-lg">
+        <label className="flex items-center justify-between p-4 bg-surface-200/50 rounded-lg">
           <div>
             <p className="text-white">Enable AI Analysis</p>
             <p className="text-surface-600 text-sm">
@@ -597,11 +597,11 @@ function AssessmentSettingsTab({
             type="checkbox"
             checked={settings.enableAIAnalysis ?? true}
             onChange={(e) => handleChange('enableAIAnalysis', e.target.checked)}
-            className="rounded border-surface-600"
+            className="rounded border-surface-300"
           />
         </label>
 
-        <label className="flex items-center justify-between p-4 bg-surface-700/50 rounded-lg">
+        <label className="flex items-center justify-between p-4 bg-surface-200/50 rounded-lg">
           <div>
             <p className="text-white">Notify on Overdue Review</p>
             <p className="text-surface-600 text-sm">
@@ -612,11 +612,11 @@ function AssessmentSettingsTab({
             type="checkbox"
             checked={settings.notifyOnOverdueReview ?? true}
             onChange={(e) => handleChange('notifyOnOverdueReview', e.target.checked)}
-            className="rounded border-surface-600"
+            className="rounded border-surface-300"
           />
         </label>
 
-        <div className="p-4 bg-surface-700/50 rounded-lg">
+        <div className="p-4 bg-surface-200/50 rounded-lg">
           <div className="flex items-center justify-between mb-2">
             <div>
               <p className="text-white">Overdue Reminder Days</p>
@@ -631,11 +631,11 @@ function AssessmentSettingsTab({
             onChange={(e) => handleChange('overdueReminderDays', parseInt(e.target.value))}
             min="1"
             max="90"
-            className="w-24 px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+            className="w-24 px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
           />
         </div>
 
-        <div className="p-4 bg-surface-700/50 rounded-lg">
+        <div className="p-4 bg-surface-200/50 rounded-lg">
           <div className="flex items-center justify-between mb-2">
             <div>
               <p className="text-white">Default Assessment Type</p>
@@ -647,7 +647,7 @@ function AssessmentSettingsTab({
           <SelectNative
             value={settings.defaultAssessmentType ?? 'standard'}
             onChange={(e) => handleChange('defaultAssessmentType', e.target.value)}
-            className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+            className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
           >
             <option value="standard">Standard Assessment</option>
             <option value="questionnaire">Questionnaire-Based</option>
@@ -713,7 +713,7 @@ function ContractSettingsTab({
         </p>
       </div>
       <div className="space-y-4">
-        <div className="p-4 bg-surface-700/50 rounded-lg">
+        <div className="p-4 bg-surface-200/50 rounded-lg">
           <div className="mb-2">
             <p className="text-white">Expiration Warning Days</p>
             <p className="text-surface-600 text-sm">
@@ -725,14 +725,14 @@ function ContractSettingsTab({
             value={warningDays}
             onChange={(e) => handleWarningDaysChange(e.target.value)}
             placeholder="90, 60, 30, 14, 7"
-            className="w-full px-4 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white placeholder:text-surface-500"
+            className="w-full px-4 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white placeholder:text-surface-500"
           />
           <p className="text-surface-500 text-xs mt-2">
             Current: {(settings.expirationWarningDays || []).join(', ')} days before expiration
           </p>
         </div>
 
-        <label className="flex items-center justify-between p-4 bg-surface-700/50 rounded-lg">
+        <label className="flex items-center justify-between p-4 bg-surface-200/50 rounded-lg">
           <div>
             <p className="text-white">Require Security Addendum</p>
             <p className="text-surface-600 text-sm">
@@ -743,11 +743,11 @@ function ContractSettingsTab({
             type="checkbox"
             checked={settings.requireSecurityAddendum ?? false}
             onChange={(e) => handleChange('requireSecurityAddendum', e.target.checked)}
-            className="rounded border-surface-600"
+            className="rounded border-surface-300"
           />
         </label>
 
-        <label className="flex items-center justify-between p-4 bg-surface-700/50 rounded-lg">
+        <label className="flex items-center justify-between p-4 bg-surface-200/50 rounded-lg">
           <div>
             <p className="text-white">Auto-Renewal Notification</p>
             <p className="text-surface-600 text-sm">
@@ -758,7 +758,7 @@ function ContractSettingsTab({
             type="checkbox"
             checked={settings.autoRenewNotification ?? true}
             onChange={(e) => handleChange('autoRenewNotification', e.target.checked)}
-            className="rounded border-surface-600"
+            className="rounded border-surface-300"
           />
         </label>
       </div>
@@ -857,7 +857,7 @@ function FeatureSettingsTab({
 
       <div className="space-y-4">
         {features.map((feature) => (
-          <div key={feature.key} className="p-4 bg-surface-700/50 rounded-lg">
+          <div key={feature.key} className="p-4 bg-surface-200/50 rounded-lg">
             <div className="flex items-start justify-between gap-4">
               <div className="flex-1">
                 <div className="flex items-center gap-3 mb-1">

--- a/frontend/src/pages/TestProcedures.tsx
+++ b/frontend/src/pages/TestProcedures.tsx
@@ -183,21 +183,21 @@ export default function TestProcedures() {
       {/* Stats */}
       {stats && (
         <div className="grid grid-cols-4 gap-4">
-          <div className="bg-surface-800 rounded-lg p-4 border border-surface-700">
+          <div className="bg-white rounded-lg p-4 border border-surface-200">
             <p className="text-surface-600 text-sm">Total Procedures</p>
             <p className="text-3xl font-bold text-white">{stats.total}</p>
           </div>
-          <div className="bg-surface-800 rounded-lg p-4 border border-surface-700">
+          <div className="bg-white rounded-lg p-4 border border-surface-200">
             <p className="text-surface-600 text-sm">Effectiveness Rate</p>
             <p className="text-3xl font-bold text-green-600">{stats.effectivenessRate}%</p>
           </div>
-          <div className="bg-surface-800 rounded-lg p-4 border border-surface-700">
+          <div className="bg-white rounded-lg p-4 border border-surface-200">
             <p className="text-surface-600 text-sm">Completed</p>
             <p className="text-3xl font-bold text-white">
               {stats.byStatus.find((s) => s.status === 'completed')?.count || 0}
             </p>
           </div>
-          <div className="bg-surface-800 rounded-lg p-4 border border-surface-700">
+          <div className="bg-white rounded-lg p-4 border border-surface-200">
             <p className="text-surface-600 text-sm">Pending</p>
             <p className="text-3xl font-bold text-yellow-600">
               {stats.byStatus.find((s) => s.status === 'pending')?.count || 0}
@@ -209,7 +209,7 @@ export default function TestProcedures() {
       {isLoading ? (
         <div className="animate-pulse space-y-4">
           {[1, 2, 3].map((i) => (
-            <div key={i} className="bg-surface-800 rounded-lg h-24" />
+            <div key={i} className="bg-white rounded-lg h-24" />
           ))}
         </div>
       ) : (
@@ -219,10 +219,7 @@ export default function TestProcedures() {
             const isRecording = recordingId === proc.id;
 
             return (
-              <div
-                key={proc.id}
-                className="bg-surface-800 rounded-lg border border-surface-700 p-4"
-              >
+              <div key={proc.id} className="bg-white rounded-lg border border-surface-200 p-4">
                 <div className="flex items-start justify-between">
                   <div className="flex items-start gap-4">
                     <div className="p-2 bg-brand-500/10 rounded-lg">
@@ -262,7 +259,7 @@ export default function TestProcedures() {
                 </div>
                 {/* Record Result Form */}
                 {isRecording && (
-                  <div className="mt-4 pt-4 border-t border-surface-700">
+                  <div className="mt-4 pt-4 border-t border-surface-200">
                     <div className="grid grid-cols-2 gap-4">
                       <div>
                         <label className="block text-sm font-medium text-surface-600 mb-1">
@@ -273,7 +270,7 @@ export default function TestProcedures() {
                           onChange={(e) =>
                             setResultForm({ ...resultForm, actualResult: e.target.value })
                           }
-                          className="w-full bg-surface-900 border border-surface-600 rounded-lg px-3 py-2 text-white"
+                          className="w-full bg-white border border-surface-300 rounded-lg px-3 py-2 text-white"
                           rows={3}
                         />
                       </div>
@@ -286,7 +283,7 @@ export default function TestProcedures() {
                           onChange={(e) =>
                             setResultForm({ ...resultForm, deviationsNoted: e.target.value })
                           }
-                          className="w-full bg-surface-900 border border-surface-600 rounded-lg px-3 py-2 text-white"
+                          className="w-full bg-white border border-surface-300 rounded-lg px-3 py-2 text-white"
                           rows={3}
                         />
                       </div>
@@ -301,7 +298,7 @@ export default function TestProcedures() {
                           onChange={(e) =>
                             setResultForm({ ...resultForm, conclusion: e.target.value })
                           }
-                          className="w-full bg-surface-900 border border-surface-600 rounded-lg px-3 py-2 text-white"
+                          className="w-full bg-white border border-surface-300 rounded-lg px-3 py-2 text-white"
                         >
                           <option value="effective">Effective</option>
                           <option value="partially_effective">Partially Effective</option>
@@ -319,7 +316,7 @@ export default function TestProcedures() {
                           onChange={(e) =>
                             setResultForm({ ...resultForm, conclusionRationale: e.target.value })
                           }
-                          className="w-full bg-surface-900 border border-surface-600 rounded-lg px-3 py-2 text-white"
+                          className="w-full bg-white border border-surface-300 rounded-lg px-3 py-2 text-white"
                         />
                       </div>
                     </div>
@@ -336,7 +333,7 @@ export default function TestProcedures() {
           })}
 
           {procedures.length === 0 && (
-            <div className="text-center py-12 bg-surface-800 rounded-lg border border-surface-700">
+            <div className="text-center py-12 bg-white rounded-lg border border-surface-200">
               <BeakerIcon className="h-12 w-12 text-surface-500 mx-auto mb-4" />
               <h3 className="text-lg font-medium text-white">No test procedures yet</h3>
               <p className="text-surface-600 mt-2">
@@ -352,7 +349,7 @@ export default function TestProcedures() {
           <h2 className="text-xl font-semibold text-white">Create Test Procedure</h2>
           <button
             onClick={() => setShowCreateModal(false)}
-            className="p-1 hover:bg-surface-700 rounded"
+            className="p-1 hover:bg-surface-200 rounded"
           >
             <XMarkIcon className="h-5 w-5 text-surface-600" />
           </button>
@@ -365,7 +362,7 @@ export default function TestProcedures() {
               type="text"
               value={createForm.title}
               onChange={(e) => setCreateForm((prev) => ({ ...prev, title: e.target.value }))}
-              className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+              className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
               placeholder="Procedure title"
             />
           </div>
@@ -376,7 +373,7 @@ export default function TestProcedures() {
               <SelectNative
                 value={createForm.testType}
                 onChange={(e) => setCreateForm((prev) => ({ ...prev, testType: e.target.value }))}
-                className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+                className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
               >
                 <option value="inquiry">Inquiry</option>
                 <option value="observation">Observation</option>
@@ -396,7 +393,7 @@ export default function TestProcedures() {
                     sampleSize: parseInt(e.target.value) || 0,
                   }))
                 }
-                className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white"
+                className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white"
                 min="1"
               />
             </div>
@@ -407,7 +404,7 @@ export default function TestProcedures() {
             <Textarea
               value={createForm.testMethod}
               onChange={(e) => setCreateForm((prev) => ({ ...prev, testMethod: e.target.value }))}
-              className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-white h-24"
+              className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-white h-24"
               placeholder="Describe the testing methodology..."
             />
           </div>

--- a/frontend/src/pages/TrainingAdmin.tsx
+++ b/frontend/src/pages/TrainingAdmin.tsx
@@ -290,7 +290,7 @@ export default function TrainingAdmin() {
       )}
 
       {/* Tabs */}
-      <div className="border-b border-gray-200 dark:border-surface-700">
+      <div className="border-b border-gray-200 dark:border-surface-200">
         <nav className="flex gap-6">
           {tabs.map((tab) => (
             <button
@@ -393,7 +393,7 @@ function StatCard({
   };
 
   return (
-    <div className="bg-white dark:bg-surface-800 rounded-xl border border-gray-200 dark:border-surface-700 p-4">
+    <div className="bg-white dark:bg-white rounded-xl border border-gray-200 dark:border-surface-200 p-4">
       <div className="flex items-center gap-3">
         <div className={`p-2 rounded-lg ${colorClasses[color]}`}>
           <Icon className="w-5 h-5" />
@@ -467,7 +467,7 @@ function CampaignsTab({
       </div>
 
       {campaigns.length === 0 ? (
-        <div className="text-center py-12 bg-white dark:bg-surface-800 rounded-xl border border-gray-200 dark:border-surface-700">
+        <div className="text-center py-12 bg-white dark:bg-white rounded-xl border border-gray-200 dark:border-surface-200">
           <PlayIcon className="w-12 h-12 mx-auto text-gray-400 dark:text-surface-500" />
           <h3 className="mt-4 text-lg font-medium text-gray-900 dark:text-white">
             No campaigns yet
@@ -481,7 +481,7 @@ function CampaignsTab({
           {campaigns.map((campaign) => (
             <div
               key={campaign.id}
-              className="bg-white dark:bg-surface-800 rounded-xl border border-gray-200 dark:border-surface-700 p-5"
+              className="bg-white dark:bg-white rounded-xl border border-gray-200 dark:border-surface-200 p-5"
             >
               <div className="flex items-start justify-between">
                 <div className="flex-1">
@@ -628,7 +628,7 @@ function ModulesTab({
         </div>
 
         {!allModules?.custom || allModules.custom.length === 0 ? (
-          <div className="text-center py-8 bg-white dark:bg-surface-800 rounded-xl border border-gray-200 dark:border-surface-700">
+          <div className="text-center py-8 bg-white dark:bg-white rounded-xl border border-gray-200 dark:border-surface-200">
             <DocumentArrowUpIcon className="w-10 h-10 mx-auto text-gray-400 dark:text-surface-500" />
             <p className="mt-3 text-gray-500 dark:text-surface-600">
               No custom modules yet. Click "Upload SCORM Package" to create custom training.
@@ -646,7 +646,7 @@ function ModulesTab({
             {allModules.custom.map((module) => (
               <div
                 key={module.id}
-                className="bg-white dark:bg-surface-800 rounded-xl border border-gray-200 dark:border-surface-700 p-4 hover:border-brand-500 hover:shadow-md transition-all"
+                className="bg-white dark:bg-white rounded-xl border border-gray-200 dark:border-surface-200 p-4 hover:border-brand-500 hover:shadow-md transition-all"
               >
                 <div
                   className="cursor-pointer"
@@ -682,7 +682,7 @@ function ModulesTab({
                   </div>
 
                   <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-surface-600 mb-3">
-                    <span className="px-2 py-0.5 bg-gray-100 dark:bg-surface-700 rounded">
+                    <span className="px-2 py-0.5 bg-gray-100 dark:bg-surface-200 rounded">
                       {module.category}
                     </span>
                     <span>{module.duration} min</span>
@@ -767,14 +767,14 @@ function ModulesTab({
                     isBuiltIn: true,
                   })
                 }
-                className="bg-white dark:bg-surface-800 rounded-xl border border-gray-200 dark:border-surface-700 p-4 cursor-pointer hover:border-brand-500 hover:shadow-md transition-all"
+                className="bg-white dark:bg-white rounded-xl border border-gray-200 dark:border-surface-200 p-4 cursor-pointer hover:border-brand-500 hover:shadow-md transition-all"
               >
                 <h4 className="font-medium text-gray-900 dark:text-white">{module.name}</h4>
                 <p className="text-sm text-gray-500 dark:text-surface-600 mt-1 line-clamp-2">
                   {details?.description || 'Click to view details'}
                 </p>
                 <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-surface-600 mt-3">
-                  <span className="px-2 py-0.5 bg-gray-100 dark:bg-surface-700 rounded">
+                  <span className="px-2 py-0.5 bg-gray-100 dark:bg-surface-200 rounded">
                     {module.category}
                   </span>
                   <span>{module.duration} min</span>
@@ -806,7 +806,7 @@ function StatsTab({ orgStats }: { orgStats: any }) {
 
   return (
     <div className="space-y-6">
-      <div className="bg-white dark:bg-surface-800 rounded-xl border border-gray-200 dark:border-surface-700 p-6">
+      <div className="bg-white dark:bg-white rounded-xl border border-gray-200 dark:border-surface-200 p-6">
         <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-4">
           Organization Training Statistics
         </h3>
@@ -944,14 +944,14 @@ function CampaignModal({
 
   return (
     <Dialog open onClose={onClose}>
-      <div className="p-6 border-b border-gray-200 dark:border-surface-700">
+      <div className="p-6 border-b border-gray-200 dark:border-surface-200">
         <div className="flex items-center justify-between">
           <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
             {campaign ? 'Edit Campaign' : 'Create Campaign'}
           </h2>
           <button
             onClick={onClose}
-            className="text-gray-500 hover:text-gray-700 dark:text-surface-600 dark:hover:text-surface-200"
+            className="text-gray-500 hover:text-gray-700 dark:text-surface-600 dark:hover:text-surface-800"
           >
             <XMarkIcon className="w-6 h-6" />
           </button>
@@ -968,7 +968,7 @@ function CampaignModal({
             type="text"
             value={formData.name}
             onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-            className="w-full px-3 py-2 border border-gray-300 dark:border-surface-600 rounded-lg bg-white dark:bg-surface-700 text-gray-900 dark:text-white"
+            className="w-full px-3 py-2 border border-gray-300 dark:border-surface-300 rounded-lg bg-white dark:bg-surface-200 text-gray-900 dark:text-white"
             required
           />
         </div>
@@ -982,7 +982,7 @@ function CampaignModal({
             value={formData.description}
             onChange={(e) => setFormData({ ...formData, description: e.target.value })}
             rows={3}
-            className="w-full px-3 py-2 border border-gray-300 dark:border-surface-600 rounded-lg bg-white dark:bg-surface-700 text-gray-900 dark:text-white"
+            className="w-full px-3 py-2 border border-gray-300 dark:border-surface-300 rounded-lg bg-white dark:bg-surface-200 text-gray-900 dark:text-white"
           />
         </div>
 
@@ -991,7 +991,7 @@ function CampaignModal({
           <label className="block text-sm font-medium text-gray-700 dark:text-surface-700 mb-2">
             Select Modules
           </label>
-          <div className="grid gap-2 max-h-48 overflow-y-auto border border-gray-200 dark:border-surface-600 rounded-lg p-3">
+          <div className="grid gap-2 max-h-48 overflow-y-auto border border-gray-200 dark:border-surface-300 rounded-lg p-3">
             {allModulesList.map((module) => (
               <label key={module.id} className="flex items-center gap-3 cursor-pointer">
                 <input
@@ -1015,7 +1015,7 @@ function CampaignModal({
             Target Roles
           </label>
           <div className="flex flex-wrap gap-2">
-            <label className="flex items-center gap-2 cursor-pointer px-3 py-2 border border-gray-200 dark:border-surface-600 rounded-lg">
+            <label className="flex items-center gap-2 cursor-pointer px-3 py-2 border border-gray-200 dark:border-surface-300 rounded-lg">
               <input
                 type="checkbox"
                 checked={formData.targetGroups.includes('all')}
@@ -1027,7 +1027,7 @@ function CampaignModal({
             {ROLES.map((role) => (
               <label
                 key={role.id}
-                className="flex items-center gap-2 cursor-pointer px-3 py-2 border border-gray-200 dark:border-surface-600 rounded-lg"
+                className="flex items-center gap-2 cursor-pointer px-3 py-2 border border-gray-200 dark:border-surface-300 rounded-lg"
               >
                 <input
                   type="checkbox"
@@ -1052,7 +1052,7 @@ function CampaignModal({
               type="date"
               value={formData.startDate}
               onChange={(e) => setFormData({ ...formData, startDate: e.target.value })}
-              className="w-full px-3 py-2 border border-gray-300 dark:border-surface-600 rounded-lg bg-white dark:bg-surface-700 text-gray-900 dark:text-white"
+              className="w-full px-3 py-2 border border-gray-300 dark:border-surface-300 rounded-lg bg-white dark:bg-surface-200 text-gray-900 dark:text-white"
               required
             />
           </div>
@@ -1064,7 +1064,7 @@ function CampaignModal({
               type="date"
               value={formData.endDate}
               onChange={(e) => setFormData({ ...formData, endDate: e.target.value })}
-              className="w-full px-3 py-2 border border-gray-300 dark:border-surface-600 rounded-lg bg-white dark:bg-surface-700 text-gray-900 dark:text-white"
+              className="w-full px-3 py-2 border border-gray-300 dark:border-surface-300 rounded-lg bg-white dark:bg-surface-200 text-gray-900 dark:text-white"
             />
           </div>
         </div>
@@ -1081,7 +1081,7 @@ function CampaignModal({
         </label>
 
         {/* Actions */}
-        <div className="flex justify-end gap-3 pt-4 border-t border-gray-200 dark:border-surface-700">
+        <div className="flex justify-end gap-3 pt-4 border-t border-gray-200 dark:border-surface-200">
           <Button variant="secondary" onClick={onClose}>
             Cancel
           </Button>
@@ -1141,14 +1141,14 @@ function ModuleModal({ module, onClose }: { module: CustomModule | null; onClose
 
   return (
     <Dialog open onClose={onClose}>
-      <div className="p-6 border-b border-gray-200 dark:border-surface-700">
+      <div className="p-6 border-b border-gray-200 dark:border-surface-200">
         <div className="flex items-center justify-between">
           <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
             {module ? 'Edit Module' : 'Create Module'}
           </h2>
           <button
             onClick={onClose}
-            className="text-gray-500 hover:text-gray-700 dark:text-surface-600 dark:hover:text-surface-200"
+            className="text-gray-500 hover:text-gray-700 dark:text-surface-600 dark:hover:text-surface-800"
           >
             <XMarkIcon className="w-6 h-6" />
           </button>
@@ -1165,7 +1165,7 @@ function ModuleModal({ module, onClose }: { module: CustomModule | null; onClose
             type="text"
             value={formData.name}
             onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-            className="w-full px-3 py-2 border border-gray-300 dark:border-surface-600 rounded-lg bg-white dark:bg-surface-700 text-gray-900 dark:text-white"
+            className="w-full px-3 py-2 border border-gray-300 dark:border-surface-300 rounded-lg bg-white dark:bg-surface-200 text-gray-900 dark:text-white"
             required
           />
         </div>
@@ -1179,7 +1179,7 @@ function ModuleModal({ module, onClose }: { module: CustomModule | null; onClose
             value={formData.description}
             onChange={(e) => setFormData({ ...formData, description: e.target.value })}
             rows={3}
-            className="w-full px-3 py-2 border border-gray-300 dark:border-surface-600 rounded-lg bg-white dark:bg-surface-700 text-gray-900 dark:text-white"
+            className="w-full px-3 py-2 border border-gray-300 dark:border-surface-300 rounded-lg bg-white dark:bg-surface-200 text-gray-900 dark:text-white"
           />
         </div>
 
@@ -1192,7 +1192,7 @@ function ModuleModal({ module, onClose }: { module: CustomModule | null; onClose
             <SelectNative
               value={formData.category}
               onChange={(e) => setFormData({ ...formData, category: e.target.value })}
-              className="w-full px-3 py-2 border border-gray-300 dark:border-surface-600 rounded-lg bg-white dark:bg-surface-700 text-gray-900 dark:text-white"
+              className="w-full px-3 py-2 border border-gray-300 dark:border-surface-300 rounded-lg bg-white dark:bg-surface-200 text-gray-900 dark:text-white"
             >
               {CATEGORIES.map((cat) => (
                 <option key={cat.id} value={cat.id}>
@@ -1208,7 +1208,7 @@ function ModuleModal({ module, onClose }: { module: CustomModule | null; onClose
             <SelectNative
               value={formData.difficulty}
               onChange={(e) => setFormData({ ...formData, difficulty: e.target.value })}
-              className="w-full px-3 py-2 border border-gray-300 dark:border-surface-600 rounded-lg bg-white dark:bg-surface-700 text-gray-900 dark:text-white"
+              className="w-full px-3 py-2 border border-gray-300 dark:border-surface-300 rounded-lg bg-white dark:bg-surface-200 text-gray-900 dark:text-white"
             >
               {DIFFICULTIES.map((diff) => (
                 <option key={diff.id} value={diff.id}>
@@ -1229,7 +1229,7 @@ function ModuleModal({ module, onClose }: { module: CustomModule | null; onClose
             value={formData.duration}
             onChange={(e) => setFormData({ ...formData, duration: parseInt(e.target.value) || 30 })}
             min={1}
-            className="w-full px-3 py-2 border border-gray-300 dark:border-surface-600 rounded-lg bg-white dark:bg-surface-700 text-gray-900 dark:text-white"
+            className="w-full px-3 py-2 border border-gray-300 dark:border-surface-300 rounded-lg bg-white dark:bg-surface-200 text-gray-900 dark:text-white"
           />
         </div>
 
@@ -1245,7 +1245,7 @@ function ModuleModal({ module, onClose }: { module: CustomModule | null; onClose
         </label>
 
         {/* Actions */}
-        <div className="flex justify-end gap-3 pt-4 border-t border-gray-200 dark:border-surface-700">
+        <div className="flex justify-end gap-3 pt-4 border-t border-gray-200 dark:border-surface-200">
           <Button variant="secondary" onClick={onClose}>
             Cancel
           </Button>
@@ -1296,14 +1296,14 @@ function UploadScormModal({ moduleId, onClose }: { moduleId: string; onClose: ()
 
   return (
     <Dialog open onClose={onClose}>
-      <div className="p-6 border-b border-gray-200 dark:border-surface-700">
+      <div className="p-6 border-b border-gray-200 dark:border-surface-200">
         <div className="flex items-center justify-between">
           <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
             Upload SCORM Package
           </h2>
           <button
             onClick={onClose}
-            className="text-gray-500 hover:text-gray-700 dark:text-surface-600 dark:hover:text-surface-200"
+            className="text-gray-500 hover:text-gray-700 dark:text-surface-600 dark:hover:text-surface-800"
           >
             <XMarkIcon className="w-6 h-6" />
           </button>
@@ -1323,7 +1323,7 @@ function UploadScormModal({ moduleId, onClose }: { moduleId: string; onClose: ()
           className={`border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-colors ${
             isDragging
               ? 'border-brand-500 bg-brand-500/5'
-              : 'border-gray-300 dark:border-surface-600 hover:border-brand-500'
+              : 'border-gray-300 dark:border-surface-300 hover:border-brand-500'
           }`}
         >
           <ArrowUpTrayIcon className="w-10 h-10 mx-auto text-gray-400 dark:text-surface-500" />
@@ -1341,7 +1341,7 @@ function UploadScormModal({ moduleId, onClose }: { moduleId: string; onClose: ()
 
         {/* Selected File */}
         {file && (
-          <div className="flex items-center gap-3 p-3 bg-gray-50 dark:bg-surface-700 rounded-lg">
+          <div className="flex items-center gap-3 p-3 bg-gray-50 dark:bg-surface-200 rounded-lg">
             <FolderIcon className="w-5 h-5 text-brand-500" />
             <div className="flex-1 min-w-0">
               <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
@@ -1358,7 +1358,7 @@ function UploadScormModal({ moduleId, onClose }: { moduleId: string; onClose: ()
         )}
 
         {/* Actions */}
-        <div className="flex justify-end gap-3 pt-4 border-t border-gray-200 dark:border-surface-700">
+        <div className="flex justify-end gap-3 pt-4 border-t border-gray-200 dark:border-surface-200">
           <Button variant="secondary" onClick={onClose}>
             Cancel
           </Button>
@@ -1397,7 +1397,7 @@ function ModuleDetailModal({
 
   return (
     <Dialog open onClose={onClose}>
-      <div className="p-6 border-b border-gray-200 dark:border-surface-700">
+      <div className="p-6 border-b border-gray-200 dark:border-surface-200">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
             <div
@@ -1416,7 +1416,7 @@ function ModuleDetailModal({
           </div>
           <button
             onClick={onClose}
-            className="text-gray-500 hover:text-gray-700 dark:text-surface-600 dark:hover:text-surface-200"
+            className="text-gray-500 hover:text-gray-700 dark:text-surface-600 dark:hover:text-surface-800"
           >
             <XMarkIcon className="w-6 h-6" />
           </button>
@@ -1426,13 +1426,13 @@ function ModuleDetailModal({
       <div className="p-6 space-y-5">
         {/* Module Info */}
         <div className="flex flex-wrap gap-3">
-          <span className="px-3 py-1 bg-gray-100 dark:bg-surface-700 rounded-full text-sm text-gray-700 dark:text-surface-700">
+          <span className="px-3 py-1 bg-gray-100 dark:bg-surface-200 rounded-full text-sm text-gray-700 dark:text-surface-700">
             {categoryLabel}
           </span>
-          <span className="px-3 py-1 bg-gray-100 dark:bg-surface-700 rounded-full text-sm text-gray-700 dark:text-surface-700">
+          <span className="px-3 py-1 bg-gray-100 dark:bg-surface-200 rounded-full text-sm text-gray-700 dark:text-surface-700">
             {module.duration} minutes
           </span>
-          <span className="px-3 py-1 bg-gray-100 dark:bg-surface-700 rounded-full text-sm text-gray-700 dark:text-surface-700 capitalize">
+          <span className="px-3 py-1 bg-gray-100 dark:bg-surface-200 rounded-full text-sm text-gray-700 dark:text-surface-700 capitalize">
             {difficultyLabel}
           </span>
         </div>
@@ -1465,7 +1465,7 @@ function ModuleDetailModal({
         )}
 
         {/* Close Button */}
-        <div className="flex justify-end pt-4 border-t border-gray-200 dark:border-surface-700">
+        <div className="flex justify-end pt-4 border-t border-gray-200 dark:border-surface-200">
           <Button onClick={onClose}>Close</Button>
         </div>
       </div>
@@ -1545,7 +1545,7 @@ function UploadNewScormModal({ onClose }: { onClose: () => void }) {
 
   return (
     <Dialog open onClose={onClose}>
-      <div className="p-6 border-b border-gray-200 dark:border-surface-700">
+      <div className="p-6 border-b border-gray-200 dark:border-surface-200">
         <div className="flex items-center justify-between">
           <div>
             <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
@@ -1559,7 +1559,7 @@ function UploadNewScormModal({ onClose }: { onClose: () => void }) {
           </div>
           <button
             onClick={onClose}
-            className="text-gray-500 hover:text-gray-700 dark:text-surface-600 dark:hover:text-surface-200"
+            className="text-gray-500 hover:text-gray-700 dark:text-surface-600 dark:hover:text-surface-800"
           >
             <XMarkIcon className="w-6 h-6" />
           </button>
@@ -1580,7 +1580,7 @@ function UploadNewScormModal({ onClose }: { onClose: () => void }) {
             className={`border-2 border-dashed rounded-lg p-12 text-center cursor-pointer transition-colors ${
               isDragging
                 ? 'border-brand-500 bg-brand-500/5'
-                : 'border-gray-300 dark:border-surface-600 hover:border-brand-500'
+                : 'border-gray-300 dark:border-surface-300 hover:border-brand-500'
             }`}
           >
             <ArrowUpTrayIcon className="w-12 h-12 mx-auto text-gray-400 dark:text-surface-500" />
@@ -1599,7 +1599,7 @@ function UploadNewScormModal({ onClose }: { onClose: () => void }) {
             />
           </div>
 
-          <div className="flex justify-end pt-4 border-t border-gray-200 dark:border-surface-700">
+          <div className="flex justify-end pt-4 border-t border-gray-200 dark:border-surface-200">
             <Button variant="secondary" onClick={onClose}>
               Cancel
             </Button>
@@ -1639,7 +1639,7 @@ function UploadNewScormModal({ onClose }: { onClose: () => void }) {
               type="text"
               value={formData.name}
               onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-              className="w-full px-3 py-2 border border-gray-300 dark:border-surface-600 rounded-lg bg-white dark:bg-surface-700 text-gray-900 dark:text-white"
+              className="w-full px-3 py-2 border border-gray-300 dark:border-surface-300 rounded-lg bg-white dark:bg-surface-200 text-gray-900 dark:text-white"
               required
             />
           </div>
@@ -1654,7 +1654,7 @@ function UploadNewScormModal({ onClose }: { onClose: () => void }) {
               onChange={(e) => setFormData({ ...formData, description: e.target.value })}
               rows={3}
               placeholder="Describe what this training module covers..."
-              className="w-full px-3 py-2 border border-gray-300 dark:border-surface-600 rounded-lg bg-white dark:bg-surface-700 text-gray-900 dark:text-white"
+              className="w-full px-3 py-2 border border-gray-300 dark:border-surface-300 rounded-lg bg-white dark:bg-surface-200 text-gray-900 dark:text-white"
             />
           </div>
 
@@ -1667,7 +1667,7 @@ function UploadNewScormModal({ onClose }: { onClose: () => void }) {
               <SelectNative
                 value={formData.category}
                 onChange={(e) => setFormData({ ...formData, category: e.target.value })}
-                className="w-full px-3 py-2 border border-gray-300 dark:border-surface-600 rounded-lg bg-white dark:bg-surface-700 text-gray-900 dark:text-white"
+                className="w-full px-3 py-2 border border-gray-300 dark:border-surface-300 rounded-lg bg-white dark:bg-surface-200 text-gray-900 dark:text-white"
               >
                 {CATEGORIES.map((cat) => (
                   <option key={cat.id} value={cat.id}>
@@ -1683,7 +1683,7 @@ function UploadNewScormModal({ onClose }: { onClose: () => void }) {
               <SelectNative
                 value={formData.difficulty}
                 onChange={(e) => setFormData({ ...formData, difficulty: e.target.value })}
-                className="w-full px-3 py-2 border border-gray-300 dark:border-surface-600 rounded-lg bg-white dark:bg-surface-700 text-gray-900 dark:text-white"
+                className="w-full px-3 py-2 border border-gray-300 dark:border-surface-300 rounded-lg bg-white dark:bg-surface-200 text-gray-900 dark:text-white"
               >
                 {DIFFICULTIES.map((diff) => (
                   <option key={diff.id} value={diff.id}>
@@ -1706,7 +1706,7 @@ function UploadNewScormModal({ onClose }: { onClose: () => void }) {
                 setFormData({ ...formData, duration: parseInt(e.target.value) || 30 })
               }
               min={1}
-              className="w-full px-3 py-2 border border-gray-300 dark:border-surface-600 rounded-lg bg-white dark:bg-surface-700 text-gray-900 dark:text-white"
+              className="w-full px-3 py-2 border border-gray-300 dark:border-surface-300 rounded-lg bg-white dark:bg-surface-200 text-gray-900 dark:text-white"
             />
           </div>
 
@@ -1724,7 +1724,7 @@ function UploadNewScormModal({ onClose }: { onClose: () => void }) {
           </label>
 
           {/* Actions */}
-          <div className="flex justify-between gap-3 pt-4 border-t border-gray-200 dark:border-surface-700">
+          <div className="flex justify-between gap-3 pt-4 border-t border-gray-200 dark:border-surface-200">
             <Button
               type="button"
               variant="ghost"

--- a/frontend/src/pages/TrustAnalytics.tsx
+++ b/frontend/src/pages/TrustAnalytics.tsx
@@ -48,15 +48,15 @@ export default function TrustAnalytics() {
   if (isLoading) {
     return (
       <div className="space-y-6">
-        <div className="h-8 bg-surface-700 rounded w-48 animate-pulse" />
+        <div className="h-8 bg-surface-200 rounded w-48 animate-pulse" />
         <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
           {[1, 2, 3, 4].map((i) => (
-            <div key={i} className="h-32 bg-surface-800 rounded-xl animate-pulse" />
+            <div key={i} className="h-32 bg-white rounded-xl animate-pulse" />
           ))}
         </div>
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-          <div className="h-80 bg-surface-800 rounded-xl animate-pulse" />
-          <div className="h-80 bg-surface-800 rounded-xl animate-pulse" />
+          <div className="h-80 bg-white rounded-xl animate-pulse" />
+          <div className="h-80 bg-white rounded-xl animate-pulse" />
         </div>
       </div>
     );
@@ -90,7 +90,7 @@ export default function TrustAnalytics() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold text-surface-100">Trust Analytics</h1>
+          <h1 className="text-3xl font-bold text-surface-900">Trust Analytics</h1>
           <p className="mt-1 text-surface-600">
             Insights into questionnaire performance and knowledge base usage
           </p>
@@ -131,8 +131,8 @@ export default function TrustAnalytics() {
       {/* Charts Row */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Questions by Status */}
-        <div className="bg-surface-900 border border-surface-800 rounded-xl p-6">
-          <h3 className="text-lg font-semibold text-surface-100 mb-4">Questions by Status</h3>
+        <div className="bg-white border border-surface-200 rounded-xl p-6">
+          <h3 className="text-lg font-semibold text-surface-900 mb-4">Questions by Status</h3>
           <LazyRechartsWrapper height={250}>
             {(Recharts) =>
               analytics?.questionsByStatus ? (
@@ -185,8 +185,8 @@ export default function TrustAnalytics() {
         </div>
 
         {/* Questionnaires by Priority */}
-        <div className="bg-surface-900 border border-surface-800 rounded-xl p-6">
-          <h3 className="text-lg font-semibold text-surface-100 mb-4">
+        <div className="bg-white border border-surface-200 rounded-xl p-6">
+          <h3 className="text-lg font-semibold text-surface-900 mb-4">
             Questionnaires by Priority
           </h3>
           <LazyRechartsWrapper height={250}>
@@ -231,10 +231,10 @@ export default function TrustAnalytics() {
       {/* Response Time & Completion Trend */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Average Response Time by Priority */}
-        <div className="bg-surface-900 border border-surface-800 rounded-xl p-6">
+        <div className="bg-white border border-surface-200 rounded-xl p-6">
           <div className="flex items-center gap-2 mb-4">
             <ClockIcon className="w-5 h-5 text-surface-600" />
-            <h3 className="text-lg font-semibold text-surface-100">Average Response Time</h3>
+            <h3 className="text-lg font-semibold text-surface-900">Average Response Time</h3>
           </div>
           <div className="space-y-4">
             {analytics?.responseTimeByPriority?.map((item: any) => (
@@ -244,10 +244,10 @@ export default function TrustAnalytics() {
                     className="w-3 h-3 rounded-full"
                     style={{ backgroundColor: PRIORITY_COLORS[item.priority] || '#6B7280' }}
                   />
-                  <span className="text-surface-200 capitalize">{item.priority}</span>
+                  <span className="text-surface-800 capitalize">{item.priority}</span>
                 </div>
                 <div className="text-right">
-                  <span className="text-surface-100 font-semibold">
+                  <span className="text-surface-900 font-semibold">
                     {formatHours(item.avgHours)}
                   </span>
                   <span className="text-xs text-surface-500 ml-2">({item.count} completed)</span>
@@ -258,10 +258,10 @@ export default function TrustAnalytics() {
         </div>
 
         {/* Completion Trend */}
-        <div className="bg-surface-900 border border-surface-800 rounded-xl p-6">
+        <div className="bg-white border border-surface-200 rounded-xl p-6">
           <div className="flex items-center gap-2 mb-4">
             <ArrowTrendingUpIcon className="w-5 h-5 text-surface-600" />
-            <h3 className="text-lg font-semibold text-surface-100">Completion Trend</h3>
+            <h3 className="text-lg font-semibold text-surface-900">Completion Trend</h3>
           </div>
           <LazyRechartsWrapper height={200}>
             {(Recharts) =>
@@ -313,23 +313,23 @@ export default function TrustAnalytics() {
       </div>
 
       {/* Top Knowledge Base Entries */}
-      <div className="bg-surface-900 border border-surface-800 rounded-xl p-6">
+      <div className="bg-white border border-surface-200 rounded-xl p-6">
         <div className="flex items-center gap-2 mb-4">
           <BookOpenIcon className="w-5 h-5 text-surface-600" />
-          <h3 className="text-lg font-semibold text-surface-100">
+          <h3 className="text-lg font-semibold text-surface-900">
             Most Used Knowledge Base Entries
           </h3>
         </div>
         {analytics?.topKbEntries && analytics.topKbEntries.length > 0 ? (
-          <div className="divide-y divide-surface-700">
+          <div className="divide-y divide-surface-200">
             {analytics.topKbEntries.map((entry: any, index: number) => (
               <div key={entry.id} className="flex items-center justify-between py-3">
                 <div className="flex items-center gap-3">
-                  <span className="w-6 h-6 flex items-center justify-center bg-surface-700 text-surface-600 text-sm font-bold rounded">
+                  <span className="w-6 h-6 flex items-center justify-center bg-surface-200 text-surface-600 text-sm font-bold rounded">
                     {index + 1}
                   </span>
                   <div>
-                    <p className="text-surface-100 font-medium">{entry.title}</p>
+                    <p className="text-surface-900 font-medium">{entry.title}</p>
                     {entry.category && (
                       <span className="text-xs text-surface-500 capitalize">{entry.category}</span>
                     )}
@@ -379,14 +379,14 @@ function StatCard({
   };
 
   return (
-    <div className="bg-surface-900 border border-surface-800 rounded-xl p-5">
+    <div className="bg-white border border-surface-200 rounded-xl p-5">
       <div className="flex items-center gap-3 mb-3">
         <div className={clsx('p-2 rounded-lg', colorClasses[color])}>
           <Icon className="w-5 h-5" />
         </div>
         <span className="text-sm text-surface-600">{title}</span>
       </div>
-      <p className="text-3xl font-bold text-surface-100">{value}</p>
+      <p className="text-3xl font-bold text-surface-900">{value}</p>
       {subtitle && <p className="text-xs text-surface-500 mt-1">{subtitle}</p>}
     </div>
   );

--- a/frontend/src/pages/TrustCenter.tsx
+++ b/frontend/src/pages/TrustCenter.tsx
@@ -181,7 +181,7 @@ export default function TrustCenter() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold text-gray-800 dark:text-surface-100">
+          <h1 className="text-3xl font-bold text-gray-800 dark:text-surface-900">
             Trust Center Content
           </h1>
           <p className="mt-1 text-gray-500 dark:text-surface-600">
@@ -191,14 +191,14 @@ export default function TrustCenter() {
         <div className="flex gap-2">
           <Link
             to="/trust-center/settings"
-            className="flex items-center gap-2 px-4 py-2 bg-white dark:bg-surface-800 text-gray-700 dark:text-surface-200 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-100 dark:bg-surface-700 transition-colors"
+            className="flex items-center gap-2 px-4 py-2 bg-white dark:bg-white text-gray-700 dark:text-surface-800 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-100 dark:bg-surface-200 transition-colors"
           >
             <Cog6ToothIcon className="w-5 h-5" />
             Settings
           </Link>
           <button
             onClick={() => setShowPreview(true)}
-            className="flex items-center gap-2 px-4 py-2 bg-white dark:bg-surface-800 text-gray-700 dark:text-surface-200 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-100 dark:bg-surface-700 transition-colors"
+            className="flex items-center gap-2 px-4 py-2 bg-white dark:bg-white text-gray-700 dark:text-surface-800 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-100 dark:bg-surface-200 transition-colors"
           >
             <EyeIcon className="w-5 h-5" />
             Preview
@@ -243,26 +243,26 @@ export default function TrustCenter() {
 
       {/* Stats */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <div className="bg-gray-50 dark:bg-surface-900 border border-gray-200 dark:border-surface-800 rounded-lg p-4">
-          <div className="text-2xl font-bold text-gray-800 dark:text-surface-100">
+        <div className="bg-gray-50 dark:bg-white border border-gray-200 dark:border-surface-200 rounded-lg p-4">
+          <div className="text-2xl font-bold text-gray-800 dark:text-surface-900">
             {contents.length}
           </div>
           <div className="text-sm text-gray-500 dark:text-surface-600">Total Content Items</div>
         </div>
-        <div className="bg-gray-50 dark:bg-surface-900 border border-gray-200 dark:border-surface-800 rounded-lg p-4">
+        <div className="bg-gray-50 dark:bg-white border border-gray-200 dark:border-surface-200 rounded-lg p-4">
           <div className="text-2xl font-bold text-green-600">{publishedCount}</div>
           <div className="text-sm text-gray-500 dark:text-surface-600">Published</div>
         </div>
-        <div className="bg-gray-50 dark:bg-surface-900 border border-gray-200 dark:border-surface-800 rounded-lg p-4">
+        <div className="bg-gray-50 dark:bg-white border border-gray-200 dark:border-surface-200 rounded-lg p-4">
           <div className="text-2xl font-bold text-amber-600 dark:text-yellow-600">{draftCount}</div>
           <div className="text-sm text-gray-500 dark:text-surface-600">Drafts</div>
         </div>
       </div>
 
       {/* Content Management */}
-      <div className="bg-gray-50 dark:bg-surface-900 border border-gray-200 dark:border-surface-800 rounded-lg overflow-hidden">
+      <div className="bg-gray-50 dark:bg-white border border-gray-200 dark:border-surface-200 rounded-lg overflow-hidden">
         {/* Section Tabs */}
-        <div className="border-b border-gray-200 dark:border-surface-800">
+        <div className="border-b border-gray-200 dark:border-surface-200">
           <nav className="flex overflow-x-auto">
             {sections.map((section) => {
               const Icon = section.icon;
@@ -274,14 +274,14 @@ export default function TrustCenter() {
                   onClick={() => setActiveSection(section.id)}
                   className={`flex items-center gap-2 px-5 py-4 text-sm font-medium border-b-2 transition-colors whitespace-nowrap ${
                     activeSection === section.id
-                      ? 'border-brand-500 text-brand-400 bg-white dark:bg-surface-800/50'
-                      : 'border-transparent text-gray-500 dark:text-surface-600 hover:text-gray-600 dark:text-surface-700 hover:bg-white dark:bg-surface-800/30'
+                      ? 'border-brand-500 text-brand-400 bg-white dark:bg-white/50'
+                      : 'border-transparent text-gray-500 dark:text-surface-600 hover:text-gray-600 dark:text-surface-700 hover:bg-white dark:bg-white/30'
                   }`}
                 >
                   <Icon className="w-5 h-5" />
                   {section.name}
                   {hasContent && (
-                    <span className="px-1.5 py-0.5 text-xs bg-gray-100 dark:bg-surface-700 text-gray-600 dark:text-surface-700 rounded">
+                    <span className="px-1.5 py-0.5 text-xs bg-gray-100 dark:bg-surface-200 text-gray-600 dark:text-surface-700 rounded">
                       {sectionContents.length}
                     </span>
                   )}
@@ -295,7 +295,7 @@ export default function TrustCenter() {
         <div className="p-6">
           <div className="flex items-center justify-between mb-6">
             <div>
-              <h3 className="text-lg font-semibold text-gray-800 dark:text-surface-100">
+              <h3 className="text-lg font-semibold text-gray-800 dark:text-surface-900">
                 {sections.find((s) => s.id === activeSection)?.name}
               </h3>
               <p className="text-sm text-gray-500 dark:text-surface-600">
@@ -317,7 +317,7 @@ export default function TrustCenter() {
           {/* Content List */}
           <div className="space-y-3">
             {getSectionContents(activeSection).length === 0 ? (
-              <div className="text-center py-16 bg-white dark:bg-surface-800/30 rounded-lg border-2 border-dashed border-gray-200 dark:border-surface-700">
+              <div className="text-center py-16 bg-white dark:bg-white/30 rounded-lg border-2 border-dashed border-gray-200 dark:border-surface-200">
                 <div className="text-surface-500 mb-4">
                   {(() => {
                     const Icon = sections.find((s) => s.id === activeSection)?.icon || GlobeAltIcon;
@@ -342,12 +342,12 @@ export default function TrustCenter() {
               getSectionContents(activeSection).map((content) => (
                 <div
                   key={content.id}
-                  className="bg-white dark:bg-surface-800 border border-gray-200 dark:border-surface-700 rounded-lg p-4"
+                  className="bg-white dark:bg-white border border-gray-200 dark:border-surface-200 rounded-lg p-4"
                 >
                   <div className="flex items-start justify-between">
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2 mb-2">
-                        <h4 className="text-gray-800 dark:text-surface-100 font-medium truncate">
+                        <h4 className="text-gray-800 dark:text-surface-900 font-medium truncate">
                           {content.title}
                         </h4>
                         {content.isPublished ? (
@@ -371,7 +371,7 @@ export default function TrustCenter() {
                         onClick={() => toggleContentPublish(content)}
                         className={`px-3 py-1.5 text-xs rounded transition-colors ${
                           content.isPublished
-                            ? 'bg-gray-100 dark:bg-surface-700 text-gray-700 dark:text-surface-200 hover:bg-gray-200 dark:hover:bg-surface-600'
+                            ? 'bg-gray-100 dark:bg-surface-200 text-gray-700 dark:text-surface-800 hover:bg-gray-200 dark:hover:bg-surface-600'
                             : 'bg-green-500/20 text-green-600 hover:bg-green-500/30'
                         }`}
                       >
@@ -382,7 +382,7 @@ export default function TrustCenter() {
                           setEditingContent(content);
                           setShowContentModal(true);
                         }}
-                        className="px-3 py-1.5 text-xs bg-gray-100 dark:bg-surface-700 text-gray-700 dark:text-surface-200 rounded hover:bg-gray-200 dark:hover:bg-surface-600 transition-colors"
+                        className="px-3 py-1.5 text-xs bg-gray-100 dark:bg-surface-200 text-gray-700 dark:text-surface-800 rounded hover:bg-gray-200 dark:hover:bg-surface-600 transition-colors"
                       >
                         Edit
                       </button>
@@ -448,7 +448,7 @@ function ContentModal({ section, content, onSave, onClose }: ContentModalProps) 
 
   return (
     <Dialog open onClose={onClose}>
-      <h2 className="text-2xl font-bold text-gray-800 dark:text-surface-100 mb-4">
+      <h2 className="text-2xl font-bold text-gray-800 dark:text-surface-900 mb-4">
         {content ? 'Edit Content' : 'Add New Content'}
       </h2>
       <form onSubmit={handleSubmit} className="space-y-4">
@@ -461,7 +461,7 @@ function ContentModal({ section, content, onSave, onClose }: ContentModalProps) 
             value={title}
             onChange={(e) => setTitle(e.target.value)}
             required
-            className="w-full px-3 py-2 bg-white dark:bg-surface-800 border border-gray-200 dark:border-surface-700 rounded-lg text-gray-800 dark:text-surface-100 focus:outline-none focus:border-brand-500"
+            className="w-full px-3 py-2 bg-white dark:bg-white border border-gray-200 dark:border-surface-200 rounded-lg text-gray-800 dark:text-surface-900 focus:outline-none focus:border-brand-500"
             placeholder="Enter title..."
           />
         </div>
@@ -475,7 +475,7 @@ function ContentModal({ section, content, onSave, onClose }: ContentModalProps) 
             onChange={(e) => setContentText(e.target.value)}
             required
             rows={8}
-            className="w-full px-3 py-2 bg-white dark:bg-surface-800 border border-gray-200 dark:border-surface-700 rounded-lg text-gray-800 dark:text-surface-100 focus:outline-none focus:border-brand-500"
+            className="w-full px-3 py-2 bg-white dark:bg-white border border-gray-200 dark:border-surface-200 rounded-lg text-gray-800 dark:text-surface-900 focus:outline-none focus:border-brand-500"
             placeholder="Enter content..."
           />
         </div>
@@ -489,7 +489,7 @@ function ContentModal({ section, content, onSave, onClose }: ContentModalProps) 
               type="number"
               value={order}
               onChange={(e) => setOrder(parseInt(e.target.value))}
-              className="w-full px-3 py-2 bg-white dark:bg-surface-800 border border-gray-200 dark:border-surface-700 rounded-lg text-gray-800 dark:text-surface-100 focus:outline-none focus:border-brand-500"
+              className="w-full px-3 py-2 bg-white dark:bg-white border border-gray-200 dark:border-surface-200 rounded-lg text-gray-800 dark:text-surface-900 focus:outline-none focus:border-brand-500"
             />
             <p className="text-xs text-surface-500 mt-1">Lower numbers appear first</p>
           </div>
@@ -500,7 +500,7 @@ function ContentModal({ section, content, onSave, onClose }: ContentModalProps) 
                 type="checkbox"
                 checked={isPublished}
                 onChange={(e) => setIsPublished(e.target.checked)}
-                className="w-4 h-4 bg-white dark:bg-surface-800 border-gray-200 dark:border-surface-700 rounded text-brand-600 focus:ring-brand-500"
+                className="w-4 h-4 bg-white dark:bg-white border-gray-200 dark:border-surface-200 rounded text-brand-600 focus:ring-brand-500"
               />
               <span className="text-sm text-gray-600 dark:text-surface-700">
                 Publish immediately
@@ -509,11 +509,11 @@ function ContentModal({ section, content, onSave, onClose }: ContentModalProps) 
           </div>
         </div>
 
-        <div className="flex justify-end gap-2 pt-4 border-t border-gray-200 dark:border-surface-800">
+        <div className="flex justify-end gap-2 pt-4 border-t border-gray-200 dark:border-surface-200">
           <button
             type="button"
             onClick={onClose}
-            className="px-4 py-2 bg-white dark:bg-surface-800 text-gray-800 dark:text-surface-100 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-100 dark:bg-surface-700 transition-colors"
+            className="px-4 py-2 bg-white dark:bg-white text-gray-800 dark:text-surface-900 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-100 dark:bg-surface-200 transition-colors"
           >
             Cancel
           </button>

--- a/frontend/src/pages/TrustCenterSettings.tsx
+++ b/frontend/src/pages/TrustCenterSettings.tsx
@@ -87,7 +87,7 @@ export default function TrustCenterSettings() {
     <div className="space-y-6">
       {/* Header */}
       <div>
-        <h1 className="text-3xl font-bold text-surface-100">Trust Center Settings</h1>
+        <h1 className="text-3xl font-bold text-surface-900">Trust Center Settings</h1>
         <p className="mt-1 text-surface-600">Configure your public-facing security trust center</p>
       </div>
 
@@ -122,14 +122,14 @@ export default function TrustCenterSettings() {
               onChange={(e) => updateConfig({ isEnabled: e.target.checked })}
               className="sr-only peer"
             />
-            <div className="w-14 h-7 bg-surface-700 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-6 after:w-6 after:transition-all peer-checked:bg-green-600"></div>
+            <div className="w-14 h-7 bg-surface-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-6 after:w-6 after:transition-all peer-checked:bg-green-600"></div>
           </label>
         </div>
       </div>
 
       {/* Tabs */}
-      <div className="bg-surface-900 border border-surface-800 rounded-lg overflow-hidden">
-        <div className="border-b border-surface-800">
+      <div className="bg-white border border-surface-200 rounded-lg overflow-hidden">
+        <div className="border-b border-surface-200">
           <nav className="flex">
             {tabs.map((tab) => {
               const Icon = tab.icon;
@@ -139,8 +139,8 @@ export default function TrustCenterSettings() {
                   onClick={() => setActiveTab(tab.id)}
                   className={`flex items-center gap-2 px-6 py-4 text-sm font-medium border-b-2 transition-colors ${
                     activeTab === tab.id
-                      ? 'border-brand-500 text-brand-400 bg-surface-800/50'
-                      : 'border-transparent text-surface-600 hover:text-surface-700 hover:bg-surface-800/30'
+                      ? 'border-brand-500 text-brand-400 bg-white/50'
+                      : 'border-transparent text-surface-600 hover:text-surface-700 hover:bg-white/30'
                   }`}
                 >
                   <Icon className="w-5 h-5" />
@@ -161,7 +161,7 @@ export default function TrustCenterSettings() {
 
       {/* Save indicator */}
       {saving && (
-        <div className="fixed bottom-4 right-4 bg-surface-800 text-surface-200 px-4 py-2 rounded-lg shadow-lg">
+        <div className="fixed bottom-4 right-4 bg-white text-surface-800 px-4 py-2 rounded-lg shadow-lg">
           Saving...
         </div>
       )}
@@ -180,7 +180,7 @@ function GeneralSettings({
   return (
     <div className="space-y-6">
       <div>
-        <h3 className="text-lg font-medium text-surface-100 mb-4">Contact Information</h3>
+        <h3 className="text-lg font-medium text-surface-900 mb-4">Contact Information</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
             <label className="block text-sm font-medium text-surface-600 mb-1">
@@ -190,7 +190,7 @@ function GeneralSettings({
               type="email"
               value={config.securityEmail || ''}
               onChange={(e) => onUpdate({ securityEmail: e.target.value })}
-              className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               placeholder="security@company.com"
             />
             <p className="text-xs text-surface-500 mt-1">Public email for security inquiries</p>
@@ -201,15 +201,15 @@ function GeneralSettings({
               type="url"
               value={config.supportUrl || ''}
               onChange={(e) => onUpdate({ supportUrl: e.target.value })}
-              className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               placeholder="https://support.company.com"
             />
             <p className="text-xs text-surface-500 mt-1">Link to your support portal</p>
           </div>
         </div>
       </div>
-      <div className="pt-6 border-t border-surface-800">
-        <h3 className="text-lg font-medium text-surface-100 mb-4">Section Visibility</h3>
+      <div className="pt-6 border-t border-surface-200">
+        <h3 className="text-lg font-medium text-surface-900 mb-4">Section Visibility</h3>
         <p className="text-sm text-surface-600 mb-4">
           Choose which sections to display on your public trust center
         </p>
@@ -235,24 +235,24 @@ function GeneralSettings({
           ].map((section) => (
             <label
               key={section.key}
-              className="flex items-start gap-3 p-3 bg-surface-800/50 rounded-lg cursor-pointer hover:bg-surface-800 transition-colors"
+              className="flex items-start gap-3 p-3 bg-white/50 rounded-lg cursor-pointer hover:bg-white transition-colors"
             >
               <input
                 type="checkbox"
                 checked={config[section.key as keyof TrustCenterConfig] as boolean}
                 onChange={(e) => onUpdate({ [section.key]: e.target.checked })}
-                className="mt-1 w-4 h-4 bg-surface-800 border-surface-700 rounded text-brand-600 focus:ring-brand-500"
+                className="mt-1 w-4 h-4 bg-white border-surface-200 rounded text-brand-600 focus:ring-brand-500"
               />
               <div>
-                <span className="text-sm font-medium text-surface-200">{section.label}</span>
+                <span className="text-sm font-medium text-surface-800">{section.label}</span>
                 <p className="text-xs text-surface-500">{section.description}</p>
               </div>
             </label>
           ))}
         </div>
       </div>
-      <div className="pt-6 border-t border-surface-800">
-        <h3 className="text-lg font-medium text-surface-100 mb-4">Quick Links</h3>
+      <div className="pt-6 border-t border-surface-200">
+        <h3 className="text-lg font-medium text-surface-900 mb-4">Quick Links</h3>
         <div className="flex flex-wrap gap-3">
           <a
             href="/trust-center/public"
@@ -265,7 +265,7 @@ function GeneralSettings({
           </a>
           <a
             href="/trust-center"
-            className="inline-flex items-center gap-2 px-4 py-2 bg-surface-700 text-surface-200 rounded-lg hover:bg-surface-600 transition-colors"
+            className="inline-flex items-center gap-2 px-4 py-2 bg-surface-200 text-surface-800 rounded-lg hover:bg-surface-600 transition-colors"
           >
             Manage Content
           </a>
@@ -286,7 +286,7 @@ function BrandingSettings({
   return (
     <div className="space-y-6">
       <div>
-        <h3 className="text-lg font-medium text-surface-100 mb-4">Company Information</h3>
+        <h3 className="text-lg font-medium text-surface-900 mb-4">Company Information</h3>
         <div className="space-y-4">
           <div>
             <label className="block text-sm font-medium text-surface-600 mb-1">Company Name</label>
@@ -294,7 +294,7 @@ function BrandingSettings({
               type="text"
               value={config.companyName}
               onChange={(e) => onUpdate({ companyName: e.target.value })}
-              className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               placeholder="Your Company Name"
             />
           </div>
@@ -306,7 +306,7 @@ function BrandingSettings({
               value={config.description || ''}
               onChange={(e) => onUpdate({ description: e.target.value })}
               rows={3}
-              className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               placeholder="Describe your security posture and commitment to security..."
             />
             <p className="text-xs text-surface-500 mt-1">
@@ -315,8 +315,8 @@ function BrandingSettings({
           </div>
         </div>
       </div>
-      <div className="pt-6 border-t border-surface-800">
-        <h3 className="text-lg font-medium text-surface-100 mb-4">Visual Branding</h3>
+      <div className="pt-6 border-t border-surface-200">
+        <h3 className="text-lg font-medium text-surface-900 mb-4">Visual Branding</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
             <label className="block text-sm font-medium text-surface-600 mb-1">Logo URL</label>
@@ -324,7 +324,7 @@ function BrandingSettings({
               type="url"
               value={config.logoUrl || ''}
               onChange={(e) => onUpdate({ logoUrl: e.target.value })}
-              className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               placeholder="https://example.com/logo.png"
             />
             <p className="text-xs text-surface-500 mt-1">Recommended: 200x50px, PNG or SVG</p>
@@ -336,13 +336,13 @@ function BrandingSettings({
                 type="color"
                 value={config.primaryColor || '#6366f1'}
                 onChange={(e) => onUpdate({ primaryColor: e.target.value })}
-                className="w-12 h-10 bg-surface-800 border border-surface-700 rounded-lg cursor-pointer"
+                className="w-12 h-10 bg-white border border-surface-200 rounded-lg cursor-pointer"
               />
               <Input
                 type="text"
                 value={config.primaryColor || '#6366f1'}
                 onChange={(e) => onUpdate({ primaryColor: e.target.value })}
-                className="flex-1 px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="flex-1 px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
                 placeholder="#6366f1"
               />
             </div>
@@ -351,8 +351,8 @@ function BrandingSettings({
         </div>
       </div>
       {/* Preview */}
-      <div className="pt-6 border-t border-surface-800">
-        <h3 className="text-lg font-medium text-surface-100 mb-4">Preview</h3>
+      <div className="pt-6 border-t border-surface-200">
+        <h3 className="text-lg font-medium text-surface-900 mb-4">Preview</h3>
         <div className="bg-white rounded-lg p-8 text-center">
           {config.logoUrl && (
             <img src={config.logoUrl} alt={config.companyName} className="h-12 mx-auto mb-4" />
@@ -389,7 +389,7 @@ function DomainSettings({
   return (
     <div className="space-y-6">
       <div>
-        <h3 className="text-lg font-medium text-surface-100 mb-2">Custom Domain</h3>
+        <h3 className="text-lg font-medium text-surface-900 mb-2">Custom Domain</h3>
         <p className="text-sm text-surface-600 mb-4">
           Host your Trust Center on your own domain for a seamless brand experience
         </p>
@@ -404,7 +404,7 @@ function DomainSettings({
                 type="text"
                 value={domainInput}
                 onChange={(e) => setDomainInput(e.target.value)}
-                className="flex-1 px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="flex-1 px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
                 placeholder="trust.yourcompany.com"
               />
               <button
@@ -421,8 +421,8 @@ function DomainSettings({
         </div>
       </div>
       {config.customDomain && (
-        <div className="bg-surface-800/50 rounded-lg p-6 border border-surface-700">
-          <h4 className="text-md font-medium text-surface-200 mb-4 flex items-center gap-2">
+        <div className="bg-white/50 rounded-lg p-6 border border-surface-200">
+          <h4 className="text-md font-medium text-surface-800 mb-4 flex items-center gap-2">
             <LinkIcon className="w-5 h-5 text-brand-400" />
             DNS Configuration Required
           </h4>
@@ -433,7 +433,7 @@ function DomainSettings({
                 1
               </span>
               <div>
-                <p className="text-surface-200">Log in to your domain registrar or DNS provider</p>
+                <p className="text-surface-800">Log in to your domain registrar or DNS provider</p>
                 <p className="text-surface-500 text-xs mt-1">
                   Common providers: Cloudflare, GoDaddy, Namecheap, Route53
                 </p>
@@ -444,8 +444,8 @@ function DomainSettings({
                 2
               </span>
               <div>
-                <p className="text-surface-200">Add a CNAME record with these values:</p>
-                <div className="mt-2 bg-surface-900 rounded-lg p-4 space-y-2">
+                <p className="text-surface-800">Add a CNAME record with these values:</p>
+                <div className="mt-2 bg-white rounded-lg p-4 space-y-2">
                   <div className="flex justify-between">
                     <span className="text-surface-600">Type:</span>
                     <code className="text-brand-400">CNAME</code>
@@ -471,7 +471,7 @@ function DomainSettings({
                 3
               </span>
               <div>
-                <p className="text-surface-200">Wait for DNS propagation</p>
+                <p className="text-surface-800">Wait for DNS propagation</p>
                 <p className="text-surface-500 text-xs mt-1">
                   This can take up to 24-48 hours, but usually completes within minutes
                 </p>
@@ -482,7 +482,7 @@ function DomainSettings({
                 4
               </span>
               <div>
-                <p className="text-surface-200">
+                <p className="text-surface-800">
                   SSL certificate will be automatically provisioned
                 </p>
                 <p className="text-surface-500 text-xs mt-1">
@@ -492,7 +492,7 @@ function DomainSettings({
             </li>
           </ol>
 
-          <div className="mt-6 pt-4 border-t border-surface-700">
+          <div className="mt-6 pt-4 border-t border-surface-200">
             <a
               href={`https://${config.customDomain}`}
               target="_blank"
@@ -506,7 +506,7 @@ function DomainSettings({
         </div>
       )}
       {!config.customDomain && (
-        <div className="bg-surface-800/30 rounded-lg p-6 border border-dashed border-surface-700 text-center">
+        <div className="bg-white/30 rounded-lg p-6 border border-dashed border-surface-200 text-center">
           <LinkIcon className="w-12 h-12 text-surface-600 mx-auto mb-3" />
           <p className="text-surface-600">Enter a custom domain above to see setup instructions</p>
         </div>
@@ -556,18 +556,18 @@ function EmbedSettings({ config }: { config: TrustCenterConfig }) {
       <div>
         <div className="flex items-center gap-2 mb-2">
           <CodeBracketIcon className="w-5 h-5 text-brand-400" />
-          <h3 className="text-lg font-medium text-surface-100">Full Page Embed (iframe)</h3>
+          <h3 className="text-lg font-medium text-surface-900">Full Page Embed (iframe)</h3>
         </div>
         <p className="text-sm text-surface-600 mb-4">
           Embed your complete Trust Center on any webpage
         </p>
         <div className="relative">
-          <pre className="p-4 bg-surface-800 rounded-lg text-sm text-surface-700 overflow-x-auto">
+          <pre className="p-4 bg-white rounded-lg text-sm text-surface-700 overflow-x-auto">
             {iframeCode}
           </pre>
           <button
             onClick={() => copyToClipboard(iframeCode, 'iframe code')}
-            className="absolute top-2 right-2 flex items-center gap-1 px-3 py-1.5 text-xs bg-surface-700 text-surface-700 rounded hover:bg-surface-600 transition-colors"
+            className="absolute top-2 right-2 flex items-center gap-1 px-3 py-1.5 text-xs bg-surface-200 text-surface-700 rounded hover:bg-surface-600 transition-colors"
           >
             <ClipboardDocumentIcon className="w-4 h-4" />
             Copy
@@ -575,21 +575,21 @@ function EmbedSettings({ config }: { config: TrustCenterConfig }) {
         </div>
       </div>
       {/* Button Link */}
-      <div className="pt-6 border-t border-surface-800">
+      <div className="pt-6 border-t border-surface-200">
         <div className="flex items-center gap-2 mb-2">
           <LinkIcon className="w-5 h-5 text-brand-400" />
-          <h3 className="text-lg font-medium text-surface-100">Security Button</h3>
+          <h3 className="text-lg font-medium text-surface-900">Security Button</h3>
         </div>
         <p className="text-sm text-surface-600 mb-4">
           Add a branded button that links to your Trust Center
         </p>
         <div className="relative">
-          <pre className="p-4 bg-surface-800 rounded-lg text-sm text-surface-700 overflow-x-auto">
+          <pre className="p-4 bg-white rounded-lg text-sm text-surface-700 overflow-x-auto">
             {buttonCode}
           </pre>
           <button
             onClick={() => copyToClipboard(buttonCode.replace(/\n/g, ''), 'button code')}
-            className="absolute top-2 right-2 flex items-center gap-1 px-3 py-1.5 text-xs bg-surface-700 text-surface-700 rounded hover:bg-surface-600 transition-colors"
+            className="absolute top-2 right-2 flex items-center gap-1 px-3 py-1.5 text-xs bg-surface-200 text-surface-700 rounded hover:bg-surface-600 transition-colors"
           >
             <ClipboardDocumentIcon className="w-4 h-4" />
             Copy
@@ -597,7 +597,7 @@ function EmbedSettings({ config }: { config: TrustCenterConfig }) {
         </div>
 
         {/* Button Preview */}
-        <div className="mt-4 p-4 bg-surface-800/50 rounded-lg">
+        <div className="mt-4 p-4 bg-white/50 rounded-lg">
           <p className="text-xs text-surface-500 mb-3">Preview:</p>
           <a
             href={trustCenterUrl}
@@ -630,10 +630,10 @@ function EmbedSettings({ config }: { config: TrustCenterConfig }) {
         </div>
       </div>
       {/* Direct Link */}
-      <div className="pt-6 border-t border-surface-800">
+      <div className="pt-6 border-t border-surface-200">
         <div className="flex items-center gap-2 mb-2">
           <GlobeAltIcon className="w-5 h-5 text-brand-400" />
-          <h3 className="text-lg font-medium text-surface-100">Direct Link</h3>
+          <h3 className="text-lg font-medium text-surface-900">Direct Link</h3>
         </div>
         <p className="text-sm text-surface-600 mb-4">
           Share this URL directly with customers or partners
@@ -643,11 +643,11 @@ function EmbedSettings({ config }: { config: TrustCenterConfig }) {
             type="text"
             readOnly
             value={trustCenterUrl}
-            className="flex-1 px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-700 text-sm"
+            className="flex-1 px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-700 text-sm"
           />
           <button
             onClick={() => copyToClipboard(trustCenterUrl, 'URL')}
-            className="flex items-center gap-1 px-4 py-2 bg-surface-700 text-surface-200 rounded-lg hover:bg-surface-600 transition-colors"
+            className="flex items-center gap-1 px-4 py-2 bg-surface-200 text-surface-800 rounded-lg hover:bg-surface-600 transition-colors"
           >
             <ClipboardDocumentIcon className="w-4 h-4" />
             Copy

--- a/frontend/src/pages/TrustConfiguration.tsx
+++ b/frontend/src/pages/TrustConfiguration.tsx
@@ -88,8 +88,8 @@ export default function TrustConfiguration() {
     return (
       <div className="space-y-6">
         <div className="animate-pulse">
-          <div className="h-8 bg-surface-700 rounded w-48 mb-4" />
-          <div className="h-64 bg-surface-800 rounded" />
+          <div className="h-8 bg-surface-200 rounded w-48 mb-4" />
+          <div className="h-64 bg-white rounded" />
         </div>
       </div>
     );
@@ -100,7 +100,7 @@ export default function TrustConfiguration() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold text-surface-100">Trust Configuration</h1>
+          <h1 className="text-3xl font-bold text-surface-900">Trust Configuration</h1>
           <p className="mt-1 text-surface-600">
             Configure SLAs, assignments, and features for the Trust module
           </p>
@@ -118,7 +118,7 @@ export default function TrustConfiguration() {
       </div>
 
       {/* Tabs */}
-      <div className="border-b border-surface-700">
+      <div className="border-b border-surface-200">
         <nav className="flex gap-6">
           {TABS.map((tab) => (
             <button
@@ -128,7 +128,7 @@ export default function TrustConfiguration() {
                 'flex items-center gap-2 px-1 py-3 text-sm font-medium border-b-2 transition-colors',
                 activeTab === tab.id
                   ? 'border-brand-500 text-brand-400'
-                  : 'border-transparent text-surface-600 hover:text-surface-200'
+                  : 'border-transparent text-surface-600 hover:text-surface-800'
               )}
             >
               <tab.icon className="w-4 h-4" />
@@ -139,7 +139,7 @@ export default function TrustConfiguration() {
       </div>
 
       {/* Tab Content */}
-      <div className="bg-surface-900 border border-surface-800 rounded-xl p-6">
+      <div className="bg-white border border-surface-200 rounded-xl p-6">
         {activeTab === 'sla' && config && (
           <SlaSettingsTab
             config={config}
@@ -225,7 +225,7 @@ function SlaSettingsTab({
   return (
     <div className="space-y-6">
       <div>
-        <h3 className="text-lg font-semibold text-surface-100 mb-2">SLA Targets by Priority</h3>
+        <h3 className="text-lg font-semibold text-surface-900 mb-2">SLA Targets by Priority</h3>
         <p className="text-sm text-surface-600">
           Define target response times for questionnaires based on priority level. The warning
           threshold triggers "At Risk" status.
@@ -233,7 +233,7 @@ function SlaSettingsTab({
       </div>
       <div className="space-y-4">
         {priorities.map((priority) => (
-          <div key={priority} className="bg-surface-800 rounded-lg p-4">
+          <div key={priority} className="bg-white rounded-lg p-4">
             <div className="flex items-center gap-3 mb-4">
               <span
                 className={clsx(
@@ -244,7 +244,7 @@ function SlaSettingsTab({
                       ? 'bg-orange-500/20 text-orange-600'
                       : priority === 'medium'
                         ? 'bg-yellow-500/20 text-yellow-600'
-                        : 'bg-surface-700 text-surface-700'
+                        : 'bg-surface-200 text-surface-700'
                 )}
               >
                 {priority}
@@ -267,7 +267,7 @@ function SlaSettingsTab({
                   onChange={(e) =>
                     handleChange(priority, 'targetHours', parseInt(e.target.value) || 1)
                   }
-                  className="w-full px-3 py-2 bg-surface-900 border border-surface-600 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                  className="w-full px-3 py-2 bg-white border border-surface-300 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
                 />
               </div>
               <div>
@@ -282,7 +282,7 @@ function SlaSettingsTab({
                   onChange={(e) =>
                     handleChange(priority, 'warningHours', parseInt(e.target.value) || 1)
                   }
-                  className="w-full px-3 py-2 bg-surface-900 border border-surface-600 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                  className="w-full px-3 py-2 bg-white border border-surface-300 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
                 />
               </div>
             </div>
@@ -294,7 +294,7 @@ function SlaSettingsTab({
                 <div className="flex-1" />
                 <span>{formatHoursToLabel(settings[priority].targetHours)}</span>
               </div>
-              <div className="h-3 bg-surface-700 rounded-full overflow-hidden flex">
+              <div className="h-3 bg-surface-200 rounded-full overflow-hidden flex">
                 <div
                   className="bg-green-500/60 h-full"
                   style={{
@@ -356,24 +356,24 @@ function AssignmentSettingsTab({
   return (
     <div className="space-y-6">
       <div>
-        <h3 className="text-lg font-semibold text-surface-100 mb-2">Assignment Settings</h3>
+        <h3 className="text-lg font-semibold text-surface-900 mb-2">Assignment Settings</h3>
         <p className="text-sm text-surface-600">
           Configure how questionnaires and questions are assigned to team members.
         </p>
       </div>
 
       <div className="space-y-4">
-        <label className="flex items-center gap-3 p-4 bg-surface-800 rounded-lg cursor-pointer">
+        <label className="flex items-center gap-3 p-4 bg-white rounded-lg cursor-pointer">
           <input
             type="checkbox"
             checked={settings.enableAutoAssignment}
             onChange={(e) =>
               setSettings((prev) => ({ ...prev, enableAutoAssignment: e.target.checked }))
             }
-            className="w-5 h-5 rounded border-surface-600 text-brand-500 focus:ring-brand-500 focus:ring-offset-surface-900"
+            className="w-5 h-5 rounded border-surface-300 text-brand-500 focus:ring-brand-500 focus:ring-offset-surface-50"
           />
           <div>
-            <p className="font-medium text-surface-100">Enable Auto-Assignment</p>
+            <p className="font-medium text-surface-900">Enable Auto-Assignment</p>
             <p className="text-sm text-surface-600">
               Automatically assign new questionnaires to team members based on workload
             </p>
@@ -409,58 +409,58 @@ function KbSettingsTab({
   return (
     <div className="space-y-6">
       <div>
-        <h3 className="text-lg font-semibold text-surface-100 mb-2">Knowledge Base Settings</h3>
+        <h3 className="text-lg font-semibold text-surface-900 mb-2">Knowledge Base Settings</h3>
         <p className="text-sm text-surface-600">
           Configure how the knowledge base works for answer suggestions and quality control.
         </p>
       </div>
 
       <div className="space-y-4">
-        <label className="flex items-center gap-3 p-4 bg-surface-800 rounded-lg cursor-pointer">
+        <label className="flex items-center gap-3 p-4 bg-white rounded-lg cursor-pointer">
           <input
             type="checkbox"
             checked={settings.requireApprovalForNewEntries}
             onChange={(e) =>
               setSettings((prev) => ({ ...prev, requireApprovalForNewEntries: e.target.checked }))
             }
-            className="w-5 h-5 rounded border-surface-600 text-brand-500 focus:ring-brand-500 focus:ring-offset-surface-900"
+            className="w-5 h-5 rounded border-surface-300 text-brand-500 focus:ring-brand-500 focus:ring-offset-surface-50"
           />
           <div>
-            <p className="font-medium text-surface-100">Require Approval for New Entries</p>
+            <p className="font-medium text-surface-900">Require Approval for New Entries</p>
             <p className="text-sm text-surface-600">
               New knowledge base entries must be approved before they can be used
             </p>
           </div>
         </label>
 
-        <label className="flex items-center gap-3 p-4 bg-surface-800 rounded-lg cursor-pointer">
+        <label className="flex items-center gap-3 p-4 bg-white rounded-lg cursor-pointer">
           <input
             type="checkbox"
             checked={settings.autoSuggestFromKB}
             onChange={(e) =>
               setSettings((prev) => ({ ...prev, autoSuggestFromKB: e.target.checked }))
             }
-            className="w-5 h-5 rounded border-surface-600 text-brand-500 focus:ring-brand-500 focus:ring-offset-surface-900"
+            className="w-5 h-5 rounded border-surface-300 text-brand-500 focus:ring-brand-500 focus:ring-offset-surface-50"
           />
           <div>
-            <p className="font-medium text-surface-100">Auto-Suggest from Knowledge Base</p>
+            <p className="font-medium text-surface-900">Auto-Suggest from Knowledge Base</p>
             <p className="text-sm text-surface-600">
               Automatically show relevant KB entries when answering questions
             </p>
           </div>
         </label>
 
-        <label className="flex items-center gap-3 p-4 bg-surface-800 rounded-lg cursor-pointer">
+        <label className="flex items-center gap-3 p-4 bg-white rounded-lg cursor-pointer">
           <input
             type="checkbox"
             checked={settings.trackUsageMetrics}
             onChange={(e) =>
               setSettings((prev) => ({ ...prev, trackUsageMetrics: e.target.checked }))
             }
-            className="w-5 h-5 rounded border-surface-600 text-brand-500 focus:ring-brand-500 focus:ring-offset-surface-900"
+            className="w-5 h-5 rounded border-surface-300 text-brand-500 focus:ring-brand-500 focus:ring-offset-surface-50"
           />
           <div>
-            <p className="font-medium text-surface-100">Track Usage Metrics</p>
+            <p className="font-medium text-surface-900">Track Usage Metrics</p>
             <p className="text-sm text-surface-600">
               Track how often KB entries are used to identify popular answers
             </p>
@@ -496,43 +496,43 @@ function TrustCenterSettingsTab({
   return (
     <div className="space-y-6">
       <div>
-        <h3 className="text-lg font-semibold text-surface-100 mb-2">Trust Center Settings</h3>
+        <h3 className="text-lg font-semibold text-surface-900 mb-2">Trust Center Settings</h3>
         <p className="text-sm text-surface-600">
           Configure your public-facing trust center portal.
         </p>
       </div>
       <div className="space-y-4">
-        <label className="flex items-center gap-3 p-4 bg-surface-800 rounded-lg cursor-pointer">
+        <label className="flex items-center gap-3 p-4 bg-white rounded-lg cursor-pointer">
           <input
             type="checkbox"
             checked={settings.enabled}
             onChange={(e) => setSettings((prev) => ({ ...prev, enabled: e.target.checked }))}
-            className="w-5 h-5 rounded border-surface-600 text-brand-500 focus:ring-brand-500 focus:ring-offset-surface-900"
+            className="w-5 h-5 rounded border-surface-300 text-brand-500 focus:ring-brand-500 focus:ring-offset-surface-50"
           />
           <div>
-            <p className="font-medium text-surface-100">Enable Trust Center</p>
+            <p className="font-medium text-surface-900">Enable Trust Center</p>
             <p className="text-sm text-surface-600">Make your trust center publicly accessible</p>
           </div>
         </label>
 
-        <label className="flex items-center gap-3 p-4 bg-surface-800 rounded-lg cursor-pointer">
+        <label className="flex items-center gap-3 p-4 bg-white rounded-lg cursor-pointer">
           <input
             type="checkbox"
             checked={settings.allowAnonymousAccess}
             onChange={(e) =>
               setSettings((prev) => ({ ...prev, allowAnonymousAccess: e.target.checked }))
             }
-            className="w-5 h-5 rounded border-surface-600 text-brand-500 focus:ring-brand-500 focus:ring-offset-surface-900"
+            className="w-5 h-5 rounded border-surface-300 text-brand-500 focus:ring-brand-500 focus:ring-offset-surface-50"
           />
           <div>
-            <p className="font-medium text-surface-100">Allow Anonymous Access</p>
+            <p className="font-medium text-surface-900">Allow Anonymous Access</p>
             <p className="text-sm text-surface-600">
               Allow visitors to view the trust center without logging in
             </p>
           </div>
         </label>
 
-        <div className="p-4 bg-surface-800 rounded-lg">
+        <div className="p-4 bg-white rounded-lg">
           <label className="block text-sm font-medium text-surface-600 mb-2">
             Custom Domain (optional)
           </label>
@@ -543,7 +543,7 @@ function TrustCenterSettingsTab({
               setSettings((prev) => ({ ...prev, customDomain: e.target.value || null }))
             }
             placeholder="trust.yourcompany.com"
-            className="w-full px-3 py-2 bg-surface-900 border border-surface-600 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+            className="w-full px-3 py-2 bg-white border border-surface-300 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
           />
           <p className="text-xs text-surface-500 mt-1">
             Point a CNAME record to your trust center URL
@@ -578,7 +578,7 @@ function AiSettingsTab({
   return (
     <div className="space-y-6">
       <div>
-        <h3 className="text-lg font-semibold text-surface-100 mb-2">AI Features</h3>
+        <h3 className="text-lg font-semibold text-surface-900 mb-2">AI Features</h3>
         <p className="text-sm text-surface-600">
           Enable optional AI-powered features to assist trust analysts.
         </p>
@@ -598,15 +598,15 @@ function AiSettingsTab({
       )}
 
       <div className="space-y-4">
-        <label className="flex items-center gap-3 p-4 bg-surface-800 rounded-lg cursor-pointer">
+        <label className="flex items-center gap-3 p-4 bg-white rounded-lg cursor-pointer">
           <input
             type="checkbox"
             checked={settings.enabled}
             onChange={(e) => setSettings((prev) => ({ ...prev, enabled: e.target.checked }))}
-            className="w-5 h-5 rounded border-surface-600 text-brand-500 focus:ring-brand-500 focus:ring-offset-surface-900"
+            className="w-5 h-5 rounded border-surface-300 text-brand-500 focus:ring-brand-500 focus:ring-offset-surface-50"
           />
           <div>
-            <p className="font-medium text-surface-100">Enable AI Features</p>
+            <p className="font-medium text-surface-900">Enable AI Features</p>
             <p className="text-sm text-surface-600">
               Turn on AI-powered assistance for the Trust module
             </p>
@@ -615,34 +615,34 @@ function AiSettingsTab({
 
         {settings.enabled && (
           <>
-            <label className="flex items-center gap-3 p-4 bg-surface-800 rounded-lg cursor-pointer">
+            <label className="flex items-center gap-3 p-4 bg-white rounded-lg cursor-pointer">
               <input
                 type="checkbox"
                 checked={settings.autoCategorizationEnabled}
                 onChange={(e) =>
                   setSettings((prev) => ({ ...prev, autoCategorizationEnabled: e.target.checked }))
                 }
-                className="w-5 h-5 rounded border-surface-600 text-brand-500 focus:ring-brand-500 focus:ring-offset-surface-900"
+                className="w-5 h-5 rounded border-surface-300 text-brand-500 focus:ring-brand-500 focus:ring-offset-surface-50"
               />
               <div>
-                <p className="font-medium text-surface-100">Auto-Categorization</p>
+                <p className="font-medium text-surface-900">Auto-Categorization</p>
                 <p className="text-sm text-surface-600">
                   Automatically categorize incoming questions (Security, Privacy, Compliance, etc.)
                 </p>
               </div>
             </label>
 
-            <label className="flex items-center gap-3 p-4 bg-surface-800 rounded-lg cursor-pointer">
+            <label className="flex items-center gap-3 p-4 bg-white rounded-lg cursor-pointer">
               <input
                 type="checkbox"
                 checked={settings.answerSuggestionsEnabled}
                 onChange={(e) =>
                   setSettings((prev) => ({ ...prev, answerSuggestionsEnabled: e.target.checked }))
                 }
-                className="w-5 h-5 rounded border-surface-600 text-brand-500 focus:ring-brand-500 focus:ring-offset-surface-900"
+                className="w-5 h-5 rounded border-surface-300 text-brand-500 focus:ring-brand-500 focus:ring-offset-surface-50"
               />
               <div>
-                <p className="font-medium text-surface-100">AI Answer Suggestions</p>
+                <p className="font-medium text-surface-900">AI Answer Suggestions</p>
                 <p className="text-sm text-surface-600">
                   Generate draft answers using AI based on your knowledge base
                 </p>

--- a/frontend/src/pages/UserManagement.tsx
+++ b/frontend/src/pages/UserManagement.tsx
@@ -147,25 +147,25 @@ export default function UserManagement() {
       </div>
       {/* Stats Cards */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-        <div className="bg-surface-800 rounded-lg p-4 border border-surface-700">
+        <div className="bg-white rounded-lg p-4 border border-surface-200">
           <div className="text-surface-600 text-sm">Total Users</div>
           <div className="text-2xl font-bold text-white mt-1">{statsData?.total || 0}</div>
         </div>
-        <div className="bg-surface-800 rounded-lg p-4 border border-surface-700">
+        <div className="bg-white rounded-lg p-4 border border-surface-200">
           <div className="text-surface-600 text-sm">Active Users</div>
           <div className="text-2xl font-bold text-emerald-600 mt-1">{statsData?.active || 0}</div>
         </div>
-        <div className="bg-surface-800 rounded-lg p-4 border border-surface-700">
+        <div className="bg-white rounded-lg p-4 border border-surface-200">
           <div className="text-surface-600 text-sm">Inactive Users</div>
           <div className="text-2xl font-bold text-red-600 mt-1">{statsData?.inactive || 0}</div>
         </div>
-        <div className="bg-surface-800 rounded-lg p-4 border border-surface-700">
+        <div className="bg-white rounded-lg p-4 border border-surface-200">
           <div className="text-surface-600 text-sm">Permission Groups</div>
           <div className="text-2xl font-bold text-brand-400 mt-1">{groups.length}</div>
         </div>
       </div>
       {/* Filters */}
-      <div className="bg-surface-800 rounded-lg p-4 border border-surface-700">
+      <div className="bg-white rounded-lg p-4 border border-surface-200">
         <div className="flex flex-wrap gap-4">
           <div className="flex-1 min-w-64">
             <div className="relative">
@@ -175,14 +175,14 @@ export default function UserManagement() {
                 placeholder="Search users by name or email..."
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
-                className="w-full bg-surface-900 border border-surface-600 rounded-lg pl-10 pr-4 py-2 text-white placeholder:text-surface-500 focus:outline-none focus:ring-2 focus:ring-brand-500"
+                className="w-full bg-white border border-surface-300 rounded-lg pl-10 pr-4 py-2 text-white placeholder:text-surface-500 focus:outline-none focus:ring-2 focus:ring-brand-500"
               />
             </div>
           </div>
           <SelectNative
             value={statusFilter}
             onChange={(e) => setStatusFilter(e.target.value)}
-            className="bg-surface-900 border border-surface-600 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+            className="bg-white border border-surface-300 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
           >
             <option value="">All Statuses</option>
             <option value="active">Active</option>
@@ -191,7 +191,7 @@ export default function UserManagement() {
           <SelectNative
             value={roleFilter}
             onChange={(e) => setRoleFilter(e.target.value)}
-            className="bg-surface-900 border border-surface-600 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+            className="bg-white border border-surface-300 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
           >
             <option value="">All Roles</option>
             <option value="admin">Admin</option>
@@ -202,9 +202,9 @@ export default function UserManagement() {
         </div>
       </div>
       {/* Users Table */}
-      <div className="bg-surface-800 rounded-lg border border-surface-700 overflow-hidden">
+      <div className="bg-white rounded-lg border border-surface-200 overflow-hidden">
         <table className="w-full">
-          <thead className="bg-surface-900">
+          <thead className="bg-white">
             <tr>
               <th className="text-left text-surface-600 font-medium px-4 py-3">User</th>
               <th className="text-left text-surface-600 font-medium px-4 py-3">Role</th>
@@ -214,7 +214,7 @@ export default function UserManagement() {
               <th className="text-right text-surface-600 font-medium px-4 py-3">Actions</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-surface-700">
+          <tbody className="divide-y divide-surface-200">
             {usersLoading ? (
               <tr>
                 <td colSpan={6} className="px-4 py-8 text-center text-surface-600">
@@ -229,7 +229,7 @@ export default function UserManagement() {
               </tr>
             ) : (
               users.map((user: User) => (
-                <tr key={user.id} className="hover:bg-surface-700/50">
+                <tr key={user.id} className="hover:bg-surface-200/50">
                   <td className="px-4 py-3">
                     <div className="flex items-center gap-3">
                       <div className="w-10 h-10 rounded-full bg-brand-500/20 flex items-center justify-center text-brand-400 font-medium">
@@ -256,7 +256,7 @@ export default function UserManagement() {
                         user.groups.slice(0, 2).map((group) => (
                           <span
                             key={group.id}
-                            className="px-2 py-0.5 bg-surface-600 rounded text-xs text-surface-200"
+                            className="px-2 py-0.5 bg-surface-600 rounded text-xs text-surface-800"
                           >
                             {group.name}
                           </span>
@@ -286,7 +286,7 @@ export default function UserManagement() {
                           setSelectedUser(user);
                           setShowGroupsModal(true);
                         }}
-                        className="p-2 text-surface-600 hover:text-white hover:bg-surface-700 rounded-lg transition-colors"
+                        className="p-2 text-surface-600 hover:text-white hover:bg-surface-200 rounded-lg transition-colors"
                         title="Manage Groups"
                       >
                         <UserGroupIcon className="w-5 h-5" />
@@ -296,7 +296,7 @@ export default function UserManagement() {
                           setSelectedUser(user);
                           setShowPermissionsModal(true);
                         }}
-                        className="p-2 text-surface-600 hover:text-white hover:bg-surface-700 rounded-lg transition-colors"
+                        className="p-2 text-surface-600 hover:text-white hover:bg-surface-200 rounded-lg transition-colors"
                         title="View Permissions"
                       >
                         <ShieldCheckIcon className="w-5 h-5" />
@@ -304,7 +304,7 @@ export default function UserManagement() {
                       {user.status === 'active' ? (
                         <button
                           onClick={() => deactivateMutation.mutate(user.id)}
-                          className="p-2 text-surface-600 hover:text-red-600 hover:bg-surface-700 rounded-lg transition-colors"
+                          className="p-2 text-surface-600 hover:text-red-600 hover:bg-surface-200 rounded-lg transition-colors"
                           title="Deactivate User"
                         >
                           <NoSymbolIcon className="w-5 h-5" />
@@ -312,7 +312,7 @@ export default function UserManagement() {
                       ) : (
                         <button
                           onClick={() => reactivateMutation.mutate(user.id)}
-                          className="p-2 text-surface-600 hover:text-emerald-600 hover:bg-surface-700 rounded-lg transition-colors"
+                          className="p-2 text-surface-600 hover:text-emerald-600 hover:bg-surface-200 rounded-lg transition-colors"
                           title="Reactivate User"
                         >
                           <CheckIcon className="w-5 h-5" />
@@ -335,7 +335,7 @@ export default function UserManagement() {
             setSelectedUser(null);
           }}
         >
-          <div className="p-4 border-b border-surface-700 flex items-center justify-between">
+          <div className="p-4 border-b border-surface-200 flex items-center justify-between">
             <h2 className="text-lg font-semibold text-white">
               Manage Groups - {selectedUser.displayName}
             </h2>
@@ -362,7 +362,7 @@ export default function UserManagement() {
                     className={`p-3 rounded-lg border cursor-pointer transition-colors ${
                       isMember
                         ? 'bg-brand-500/20 border-brand-500'
-                        : 'bg-surface-700 border-surface-600 hover:border-surface-500'
+                        : 'bg-surface-200 border-surface-300 hover:border-surface-500'
                     }`}
                     onClick={() => {
                       if (isMember) {
@@ -432,7 +432,7 @@ function PermissionsModal({ user, onClose }: { user: User; onClose: () => void }
 
   return (
     <Dialog open onClose={onClose}>
-      <div className="p-4 border-b border-surface-700 flex items-center justify-between">
+      <div className="p-4 border-b border-surface-200 flex items-center justify-between">
         <h2 className="text-lg font-semibold text-white">Permissions - {user.displayName}</h2>
         <button onClick={onClose} className="p-1 text-surface-600 hover:text-white">
           <XMarkIcon className="w-5 h-5" />
@@ -453,7 +453,7 @@ function PermissionsModal({ user, onClose }: { user: User; onClose: () => void }
                   permissionsData?.groups?.map((group: any) => (
                     <span
                       key={group.id}
-                      className="px-3 py-1 bg-surface-700 rounded-full text-sm text-white"
+                      className="px-3 py-1 bg-surface-200 rounded-full text-sm text-white"
                     >
                       {group.name}
                     </span>
@@ -470,7 +470,7 @@ function PermissionsModal({ user, onClose }: { user: User; onClose: () => void }
                   <span className="text-surface-500">No permissions</span>
                 ) : (
                   permissionsData?.effectivePermissions?.map((perm: any, idx: number) => (
-                    <div key={idx} className="bg-surface-700 rounded-lg p-3">
+                    <div key={idx} className="bg-surface-200 rounded-lg p-3">
                       <div className="flex items-center justify-between mb-2">
                         <span className="text-white font-medium capitalize">
                           {perm.resource.replace('_', ' ')}
@@ -489,7 +489,7 @@ function PermissionsModal({ user, onClose }: { user: User; onClose: () => void }
                         {perm.actions.map((action: string) => (
                           <span
                             key={action}
-                            className="px-2 py-0.5 bg-surface-600 rounded text-xs text-surface-200"
+                            className="px-2 py-0.5 bg-surface-600 rounded text-xs text-surface-800"
                           >
                             {action}
                           </span>
@@ -517,7 +517,7 @@ function PermissionsModal({ user, onClose }: { user: User; onClose: () => void }
                   {permissionsData?.overrides?.map((override: any, idx: number) => (
                     <div
                       key={idx}
-                      className="flex items-center justify-between bg-surface-700 rounded px-3 py-2"
+                      className="flex items-center justify-between bg-surface-200 rounded px-3 py-2"
                     >
                       <span className="text-white">{override.permission}</span>
                       <span

--- a/frontend/src/pages/VendorDetail.tsx
+++ b/frontend/src/pages/VendorDetail.tsx
@@ -155,12 +155,12 @@ export default function VendorDetail() {
         <div className="flex items-center gap-4">
           <button
             onClick={() => navigate('/vendors')}
-            className="p-2 text-surface-600 hover:text-surface-100 hover:bg-surface-800 rounded-lg transition-colors"
+            className="p-2 text-surface-600 hover:text-surface-900 hover:bg-white rounded-lg transition-colors"
           >
             <ArrowLeftIcon className="w-5 h-5" />
           </button>
           <div>
-            <h1 className="text-3xl font-bold text-surface-100">
+            <h1 className="text-3xl font-bold text-surface-900">
               {id === 'new' ? 'New Vendor' : vendor?.name || 'Vendor Details'}
             </h1>
             {vendor?.vendorId && <p className="mt-1 text-surface-600">{vendor.vendorId}</p>}
@@ -280,10 +280,10 @@ function VendorForm({
 
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
-      <div className="bg-surface-900 border border-surface-800 rounded-lg p-6 space-y-6">
+      <div className="bg-white border border-surface-200 rounded-lg p-6 space-y-6">
         {/* Basic Information */}
         <div>
-          <h3 className="text-lg font-medium text-surface-100 mb-4">Basic Information</h3>
+          <h3 className="text-lg font-medium text-surface-900 mb-4">Basic Information</h3>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
               <label className="block text-sm font-medium text-surface-700 mb-1">
@@ -294,7 +294,7 @@ function VendorForm({
                 required
                 value={formData.name}
                 onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               />
             </div>
 
@@ -304,7 +304,7 @@ function VendorForm({
                 type="text"
                 value={formData.legalName}
                 onChange={(e) => setFormData({ ...formData, legalName: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               />
             </div>
 
@@ -314,7 +314,7 @@ function VendorForm({
                 required
                 value={formData.category}
                 onChange={(e) => setFormData({ ...formData, category: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               >
                 <option value="software_vendor">Software Vendor</option>
                 <option value="cloud_provider">Cloud Provider</option>
@@ -330,7 +330,7 @@ function VendorForm({
                 required
                 value={formData.tier}
                 onChange={(e) => setFormData({ ...formData, tier: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               >
                 <option value="tier_1">Tier 1 (Critical)</option>
                 <option value="tier_2">Tier 2 (High)</option>
@@ -345,7 +345,7 @@ function VendorForm({
                 required
                 value={formData.status}
                 onChange={(e) => setFormData({ ...formData, status: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               >
                 <option value="active">Active</option>
                 <option value="inactive">Inactive</option>
@@ -361,7 +361,7 @@ function VendorForm({
                 type="url"
                 value={formData.website}
                 onChange={(e) => setFormData({ ...formData, website: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               />
             </div>
           </div>
@@ -369,7 +369,7 @@ function VendorForm({
 
         {/* Contact Information */}
         <div>
-          <h3 className="text-lg font-medium text-surface-100 mb-4">Primary Contact</h3>
+          <h3 className="text-lg font-medium text-surface-900 mb-4">Primary Contact</h3>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             <div>
               <label className="block text-sm font-medium text-surface-700 mb-1">
@@ -379,7 +379,7 @@ function VendorForm({
                 type="text"
                 value={formData.primaryContact}
                 onChange={(e) => setFormData({ ...formData, primaryContact: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               />
             </div>
 
@@ -389,7 +389,7 @@ function VendorForm({
                 type="email"
                 value={formData.primaryContactEmail}
                 onChange={(e) => setFormData({ ...formData, primaryContactEmail: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               />
             </div>
 
@@ -399,7 +399,7 @@ function VendorForm({
                 type="tel"
                 value={formData.primaryContactPhone}
                 onChange={(e) => setFormData({ ...formData, primaryContactPhone: e.target.value })}
-                className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
               />
             </div>
           </div>
@@ -413,7 +413,7 @@ function VendorForm({
               value={formData.description}
               onChange={(e) => setFormData({ ...formData, description: e.target.value })}
               rows={3}
-              className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
             />
           </div>
 
@@ -423,7 +423,7 @@ function VendorForm({
               value={formData.notes}
               onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
               rows={3}
-              className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:border-brand-500"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
             />
           </div>
         </div>
@@ -488,7 +488,7 @@ function VendorView({
               ? 'bg-red-500/10 border-red-500/30'
               : daysUntilReview !== null && daysUntilReview <= 30
                 ? 'bg-yellow-500/10 border-yellow-500/30'
-                : 'bg-surface-800 border-surface-700'
+                : 'bg-white border-surface-200'
           )}
         >
           <div className="flex items-center gap-3">
@@ -512,7 +512,7 @@ function VendorView({
                     ? 'text-red-600'
                     : daysUntilReview !== null && daysUntilReview <= 30
                       ? 'text-yellow-600'
-                      : 'text-surface-200'
+                      : 'text-surface-800'
                 )}
               >
                 {isOverdue
@@ -553,8 +553,8 @@ function VendorView({
       )}
 
       {/* Basic Information */}
-      <div className="bg-surface-900 border border-surface-800 rounded-lg p-6">
-        <h3 className="text-lg font-medium text-surface-100 mb-4">Basic Information</h3>
+      <div className="bg-white border border-surface-200 rounded-lg p-6">
+        <h3 className="text-lg font-medium text-surface-900 mb-4">Basic Information</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <InfoField label="Vendor Name" value={vendor.name} />
           <InfoField label="Legal Name" value={vendor.legalName} />
@@ -572,8 +572,8 @@ function VendorView({
 
       {/* Contact Information */}
       {(vendor.primaryContact || vendor.primaryContactEmail || vendor.primaryContactPhone) && (
-        <div className="bg-surface-900 border border-surface-800 rounded-lg p-6">
-          <h3 className="text-lg font-medium text-surface-100 mb-4">Primary Contact</h3>
+        <div className="bg-white border border-surface-200 rounded-lg p-6">
+          <h3 className="text-lg font-medium text-surface-900 mb-4">Primary Contact</h3>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             <InfoField label="Name" value={vendor.primaryContact} />
             <InfoField label="Email" value={vendor.primaryContactEmail} />
@@ -583,11 +583,11 @@ function VendorView({
       )}
 
       {/* Documents Section with AI Analysis */}
-      <div className="bg-surface-900 border border-surface-800 rounded-lg p-6">
+      <div className="bg-white border border-surface-200 rounded-lg p-6">
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center gap-2">
             <DocumentTextIcon className="w-5 h-5 text-surface-600" />
-            <h3 className="text-lg font-medium text-surface-100">Documents</h3>
+            <h3 className="text-lg font-medium text-surface-900">Documents</h3>
           </div>
         </div>
 
@@ -596,12 +596,12 @@ function VendorView({
             {extendedVendor.documents.map((doc) => (
               <div
                 key={doc.id}
-                className="flex items-center justify-between p-3 bg-surface-800/50 rounded-lg"
+                className="flex items-center justify-between p-3 bg-white/50 rounded-lg"
               >
                 <div className="flex items-center gap-3">
                   <DocumentTextIcon className="w-5 h-5 text-surface-600" />
                   <div>
-                    <p className="text-sm font-medium text-surface-200">{doc.title}</p>
+                    <p className="text-sm font-medium text-surface-800">{doc.title}</p>
                     <p className="text-xs text-surface-600">{doc.documentType.replace('_', ' ')}</p>
                   </div>
                 </div>
@@ -628,10 +628,10 @@ function VendorView({
         )}
 
         {/* Demo SOC 2 Analysis Section */}
-        <div className="mt-4 pt-4 border-t border-surface-700">
+        <div className="mt-4 pt-4 border-t border-surface-200">
           <div className="flex items-center gap-2 mb-3">
             <SparklesIcon className="w-5 h-5 text-purple-600" />
-            <h4 className="font-medium text-surface-200">AI-Powered SOC 2 Analysis</h4>
+            <h4 className="font-medium text-surface-800">AI-Powered SOC 2 Analysis</h4>
           </div>
           <p className="text-sm text-surface-600 mb-3">
             Upload a SOC 2 Type II report to automatically extract exceptions, CUECs, and control
@@ -692,16 +692,16 @@ function VendorView({
 
       {/* Description */}
       {vendor.description && (
-        <div className="bg-surface-900 border border-surface-800 rounded-lg p-6">
-          <h3 className="text-lg font-medium text-surface-100 mb-4">Description</h3>
+        <div className="bg-white border border-surface-200 rounded-lg p-6">
+          <h3 className="text-lg font-medium text-surface-900 mb-4">Description</h3>
           <p className="text-surface-700">{vendor.description}</p>
         </div>
       )}
 
       {/* Notes */}
       {vendor.notes && (
-        <div className="bg-surface-900 border border-surface-800 rounded-lg p-6">
-          <h3 className="text-lg font-medium text-surface-100 mb-4">Notes</h3>
+        <div className="bg-white border border-surface-200 rounded-lg p-6">
+          <h3 className="text-lg font-medium text-surface-900 mb-4">Notes</h3>
           <p className="text-surface-700 whitespace-pre-wrap">{vendor.notes}</p>
         </div>
       )}
@@ -727,7 +727,7 @@ function InfoField({
   return (
     <div>
       <dt className="text-sm font-medium text-surface-600 mb-1">{label}</dt>
-      <dd className={`text-sm text-surface-100 ${capitalize ? 'capitalize' : ''}`}>
+      <dd className={`text-sm text-surface-900 ${capitalize ? 'capitalize' : ''}`}>
         {href ? (
           <a
             href={href}

--- a/frontend/src/pages/VendorNew.tsx
+++ b/frontend/src/pages/VendorNew.tsx
@@ -118,12 +118,12 @@ export default function VendorNew() {
       <div>
         <Link
           to="/vendors"
-          className="inline-flex items-center text-sm text-surface-600 hover:text-surface-100 mb-4"
+          className="inline-flex items-center text-sm text-surface-600 hover:text-surface-900 mb-4"
         >
           <ArrowLeftIcon className="w-4 h-4 mr-1" />
           Back to Vendors
         </Link>
-        <h1 className="text-2xl font-bold text-surface-100">Add New Vendor</h1>
+        <h1 className="text-2xl font-bold text-surface-900">Add New Vendor</h1>
         <p className="text-surface-600 mt-1">Register a new third-party vendor</p>
       </div>
       {/* Form */}
@@ -271,7 +271,7 @@ export default function VendorNew() {
         </div>
 
         {/* Actions */}
-        <div className="flex items-center justify-end gap-3 pt-4 border-t border-surface-700">
+        <div className="flex items-center justify-end gap-3 pt-4 border-t border-surface-200">
           <Button type="button" variant="secondary" onClick={() => navigate('/vendors')}>
             Cancel
           </Button>

--- a/frontend/src/pages/Vendors.tsx
+++ b/frontend/src/pages/Vendors.tsx
@@ -47,7 +47,7 @@ export default function Vendors() {
       <div className="space-y-6">
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-3xl font-bold text-surface-100">Vendors</h1>
+            <h1 className="text-3xl font-bold text-surface-900">Vendors</h1>
             <p className="mt-1 text-surface-600">
               Manage third-party vendor relationships and profiles
             </p>
@@ -63,7 +63,7 @@ export default function Vendors() {
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
         <div>
-          <h1 className="text-3xl font-bold text-surface-100">Vendors</h1>
+          <h1 className="text-3xl font-bold text-surface-900">Vendors</h1>
           <p className="mt-1 text-surface-600">
             Manage third-party vendor relationships and profiles
           </p>
@@ -96,7 +96,7 @@ export default function Vendors() {
       </div>
       {/* Vendors List */}
       {vendors.length === 0 ? (
-        <div className="bg-surface-900 border border-surface-800 rounded-lg p-12 text-center">
+        <div className="bg-white border border-surface-200 rounded-lg p-12 text-center">
           <BuildingOfficeIcon className="w-12 h-12 text-surface-600 mx-auto mb-4" />
           <h3 className="text-lg font-medium text-surface-700 mb-2">No vendors yet</h3>
           <p className="text-surface-500 mb-6">Get started by adding your first vendor</p>
@@ -108,9 +108,9 @@ export default function Vendors() {
           </Button>
         </div>
       ) : (
-        <div className="bg-surface-900 border border-surface-800 rounded-lg overflow-hidden">
+        <div className="bg-white border border-surface-200 rounded-lg overflow-hidden">
           <table className="w-full">
-            <thead className="bg-surface-800 border-b border-surface-700">
+            <thead className="bg-white border-b border-surface-200">
               <tr>
                 <th className="px-6 py-3 text-left text-xs font-medium text-surface-600 uppercase tracking-wider">
                   Vendor
@@ -129,16 +129,16 @@ export default function Vendors() {
                 </th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-surface-800">
+            <tbody className="divide-y divide-surface-200">
               {vendors.map((vendor: Vendor) => (
                 <tr
                   key={vendor.id}
                   onClick={() => navigate(`/vendors/${vendor.id}`)}
-                  className="hover:bg-surface-800 cursor-pointer transition-colors"
+                  className="hover:bg-white cursor-pointer transition-colors"
                 >
                   <td className="px-6 py-4">
                     <div>
-                      <div className="text-sm font-medium text-surface-100">{vendor.name}</div>
+                      <div className="text-sm font-medium text-surface-900">{vendor.name}</div>
                       <div className="text-sm text-surface-500">{vendor.vendorId}</div>
                     </div>
                   </td>
@@ -146,7 +146,7 @@ export default function Vendors() {
                     {vendor.category.replace('_', ' ')}
                   </td>
                   <td className="px-6 py-4">
-                    <span className="inline-flex px-2 py-1 text-xs font-medium rounded-full bg-surface-700 text-surface-700 capitalize">
+                    <span className="inline-flex px-2 py-1 text-xs font-medium rounded-full bg-surface-200 text-surface-700 capitalize">
                       {vendor.tier.replace('_', ' ')}
                     </span>
                   </td>
@@ -162,7 +162,7 @@ export default function Vendors() {
                                 ? 'bg-yellow-500/20 text-yellow-600'
                                 : vendor.inherentRiskScore === 'low'
                                   ? 'bg-green-500/20 text-green-600'
-                                  : 'bg-surface-700 text-surface-700'
+                                  : 'bg-surface-200 text-surface-700'
                         }`}
                       >
                         {vendor.inherentRiskScore}
@@ -177,7 +177,7 @@ export default function Vendors() {
                         vendor.status === 'active'
                           ? 'bg-green-500/20 text-green-600'
                           : vendor.status === 'inactive'
-                            ? 'bg-surface-700 text-surface-600'
+                            ? 'bg-surface-200 text-surface-600'
                             : 'bg-yellow-500/20 text-yellow-600'
                       }`}
                     >

--- a/frontend/src/pages/WorkspaceList.tsx
+++ b/frontend/src/pages/WorkspaceList.tsx
@@ -66,7 +66,7 @@ function CreateWorkspaceModal({
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="e.g., Product A, Enterprise Edition"
-              className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-foreground placeholder-muted-foreground focus:outline-none focus:ring-2 focus:ring-brand-500"
+              className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-foreground placeholder-muted-foreground focus:outline-none focus:ring-2 focus:ring-brand-500"
               required
             />
           </div>
@@ -79,7 +79,7 @@ function CreateWorkspaceModal({
               onChange={(e) => setDescription(e.target.value)}
               placeholder="Brief description of this workspace..."
               rows={2}
-              className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-foreground placeholder-muted-foreground focus:outline-none focus:ring-2 focus:ring-brand-500 resize-none"
+              className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-foreground placeholder-muted-foreground focus:outline-none focus:ring-2 focus:ring-brand-500 resize-none"
             />
           </div>
         </div>
@@ -181,7 +181,7 @@ export default function WorkspaceList() {
             compliance tracking, while sharing a common control library across your organization.
           </p>
 
-          <div className="bg-surface-800 rounded-lg p-6 text-left mb-8">
+          <div className="bg-white rounded-lg p-6 text-left mb-8">
             <h3 className="font-semibold text-foreground mb-4">What you get with workspaces:</h3>
             <ul className="space-y-3 text-sm text-muted-foreground">
               <li className="flex items-start gap-3">
@@ -238,25 +238,25 @@ export default function WorkspaceList() {
       {/* Org-level Stats */}
       {orgDashboard && (
         <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
-          <div className="bg-surface-800 rounded-lg p-4 border border-surface-700">
+          <div className="bg-white rounded-lg p-4 border border-surface-200">
             <p className="text-sm text-muted-foreground">Total Workspaces</p>
             <p className="text-2xl font-bold text-foreground mt-1">
               {orgDashboard.workspaces?.length || 0}
             </p>
           </div>
-          <div className="bg-surface-800 rounded-lg p-4 border border-surface-700">
+          <div className="bg-white rounded-lg p-4 border border-surface-200">
             <p className="text-sm text-muted-foreground">Avg Compliance Score</p>
             <p className="text-2xl font-bold text-brand-400 mt-1">
               {orgDashboard.avgComplianceScore || 0}%
             </p>
           </div>
-          <div className="bg-surface-800 rounded-lg p-4 border border-surface-700">
+          <div className="bg-white rounded-lg p-4 border border-surface-200">
             <p className="text-sm text-muted-foreground">Total Controls</p>
             <p className="text-2xl font-bold text-foreground mt-1">
               {orgDashboard.totals?.controls || 0}
             </p>
           </div>
-          <div className="bg-surface-800 rounded-lg p-4 border border-surface-700">
+          <div className="bg-white rounded-lg p-4 border border-surface-200">
             <p className="text-sm text-muted-foreground">Total Risks</p>
             <p className="text-2xl font-bold text-foreground mt-1">
               {orgDashboard.totals?.risks || 0}
@@ -272,7 +272,7 @@ export default function WorkspaceList() {
           placeholder="Search workspaces..."
           value={search}
           onChange={(e) => setSearch(e.target.value)}
-          className="w-full pl-10 pr-4 py-2 bg-surface-800 border border-surface-700 rounded-lg text-foreground placeholder-muted-foreground focus:outline-none focus:ring-2 focus:ring-brand-500"
+          className="w-full pl-10 pr-4 py-2 bg-white border border-surface-200 rounded-lg text-foreground placeholder-muted-foreground focus:outline-none focus:ring-2 focus:ring-brand-500"
         />
       </div>
       {/* Workspaces Grid */}
@@ -282,10 +282,10 @@ export default function WorkspaceList() {
           return (
             <div
               key={workspace.id}
-              className={`bg-surface-800 rounded-lg p-5 border transition-all cursor-pointer hover:border-brand-500/50 ${
+              className={`bg-white rounded-lg p-5 border transition-all cursor-pointer hover:border-brand-500/50 ${
                 currentWorkspace?.id === workspace.id
                   ? 'border-brand-500 ring-1 ring-brand-500/30'
-                  : 'border-surface-700'
+                  : 'border-surface-200'
               }`}
               onClick={() => {
                 setCurrentWorkspace(workspace);
@@ -315,17 +315,17 @@ export default function WorkspaceList() {
 
               {/* Workspace Stats */}
               <div className="grid grid-cols-3 gap-2 mb-4 text-center">
-                <div className="bg-surface-700/50 rounded p-2">
+                <div className="bg-surface-200/50 rounded p-2">
                   <p className="text-xs text-muted-foreground">Controls</p>
                   <p className="text-sm font-medium text-foreground">
                     {stats?.stats?.controls || 0}
                   </p>
                 </div>
-                <div className="bg-surface-700/50 rounded p-2">
+                <div className="bg-surface-200/50 rounded p-2">
                   <p className="text-xs text-muted-foreground">Risks</p>
                   <p className="text-sm font-medium text-foreground">{stats?.stats?.risks || 0}</p>
                 </div>
-                <div className="bg-surface-700/50 rounded p-2">
+                <div className="bg-surface-200/50 rounded p-2">
                   <p className="text-xs text-muted-foreground">Score</p>
                   <p className="text-sm font-medium text-brand-400">
                     {stats?.complianceScore || 0}%
@@ -334,7 +334,7 @@ export default function WorkspaceList() {
               </div>
 
               {/* Actions */}
-              <div className="flex items-center justify-between pt-3 border-t border-surface-700">
+              <div className="flex items-center justify-between pt-3 border-t border-surface-200">
                 <span className="text-xs text-muted-foreground">
                   {workspace.memberCount || 0} members
                 </span>
@@ -344,7 +344,7 @@ export default function WorkspaceList() {
                       e.stopPropagation();
                       navigate(`/settings/workspaces/${workspace.id}`);
                     }}
-                    className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-surface-700 rounded"
+                    className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-surface-200 rounded"
                   >
                     <Cog6ToothIcon className="w-4 h-4" />
                   </button>

--- a/frontend/src/pages/WorkspaceSettings.tsx
+++ b/frontend/src/pages/WorkspaceSettings.tsx
@@ -89,7 +89,7 @@ function AddMemberModal({
             <SelectNative
               value={selectedUserId}
               onChange={(e) => setSelectedUserId(e.target.value)}
-              className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-foreground focus:outline-none focus:ring-2 focus:ring-brand-500"
+              className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-foreground focus:outline-none focus:ring-2 focus:ring-brand-500"
               required
             >
               <option value="">Select a user...</option>
@@ -110,7 +110,7 @@ function AddMemberModal({
             <SelectNative
               value={selectedRole}
               onChange={(e) => setSelectedRole(e.target.value)}
-              className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-foreground focus:outline-none focus:ring-2 focus:ring-brand-500"
+              className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-foreground focus:outline-none focus:ring-2 focus:ring-brand-500"
             >
               {WORKSPACE_ROLES.map((role) => (
                 <option key={role.value} value={role.value}>
@@ -250,7 +250,7 @@ export default function WorkspaceSettings() {
       <div className="flex items-center gap-4 mb-6">
         <button
           onClick={() => navigate('/settings/workspaces')}
-          className="p-2 text-muted-foreground hover:text-foreground hover:bg-surface-800 rounded-lg"
+          className="p-2 text-muted-foreground hover:text-foreground hover:bg-white rounded-lg"
         >
           <ArrowLeftIcon className="w-5 h-5" />
         </button>
@@ -260,7 +260,7 @@ export default function WorkspaceSettings() {
         </div>
       </div>
       {/* Basic Information */}
-      <section className="bg-surface-800 rounded-lg p-6 border border-surface-700 mb-6">
+      <section className="bg-white rounded-lg p-6 border border-surface-200 mb-6">
         <h2 className="text-lg font-semibold text-foreground mb-4 flex items-center gap-2">
           <BuildingOfficeIcon className="w-5 h-5" />
           Basic Information
@@ -274,7 +274,7 @@ export default function WorkspaceSettings() {
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-foreground focus:outline-none focus:ring-2 focus:ring-brand-500"
+              className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-foreground focus:outline-none focus:ring-2 focus:ring-brand-500"
             />
           </div>
           <div>
@@ -283,7 +283,7 @@ export default function WorkspaceSettings() {
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               rows={3}
-              className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-foreground focus:outline-none focus:ring-2 focus:ring-brand-500 resize-none"
+              className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-foreground focus:outline-none focus:ring-2 focus:ring-brand-500 resize-none"
             />
           </div>
           <div>
@@ -292,7 +292,7 @@ export default function WorkspaceSettings() {
               type="text"
               value={workspace.slug}
               disabled
-              className="w-full px-3 py-2 bg-surface-700/50 border border-surface-600 rounded-lg text-muted-foreground cursor-not-allowed"
+              className="w-full px-3 py-2 bg-surface-200/50 border border-surface-300 rounded-lg text-muted-foreground cursor-not-allowed"
             />
             <p className="text-xs text-muted-foreground mt-1">
               The slug cannot be changed after creation.
@@ -310,7 +310,7 @@ export default function WorkspaceSettings() {
         </div>
       </section>
       {/* Members */}
-      <section className="bg-surface-800 rounded-lg p-6 border border-surface-700 mb-6">
+      <section className="bg-white rounded-lg p-6 border border-surface-200 mb-6">
         <div className="flex items-center justify-between mb-4">
           <h2 className="text-lg font-semibold text-foreground">Members</h2>
           <button
@@ -326,7 +326,7 @@ export default function WorkspaceSettings() {
           {workspace.members?.map((member: WorkspaceMember) => (
             <div
               key={member.id}
-              className="flex items-center justify-between p-3 bg-surface-700/50 rounded-lg"
+              className="flex items-center justify-between p-3 bg-surface-200/50 rounded-lg"
             >
               <div className="flex items-center gap-3">
                 <div className="w-8 h-8 rounded-full bg-brand-600 flex items-center justify-center text-white text-sm font-medium">
@@ -345,7 +345,7 @@ export default function WorkspaceSettings() {
                   onChange={(e) =>
                     updateMemberMutation.mutate({ userId: member.userId, role: e.target.value })
                   }
-                  className="px-2 py-1 text-sm bg-surface-700 border border-surface-600 rounded text-foreground focus:outline-none"
+                  className="px-2 py-1 text-sm bg-surface-200 border border-surface-300 rounded text-foreground focus:outline-none"
                 >
                   {WORKSPACE_ROLES.map((role) => (
                     <option key={role.value} value={role.value}>


### PR DESCRIPTION
## Summary

Reintroduces dark mode on top of the light-first design system foundation
established in PR #317, leveraging Tailwind's class-based dark mode
(\`darkMode: 'class'\`). Adding the \`dark\` class to \`<html>\` flips every
primitive's \`dark:\` variant. Light remains the default.

## What's in

**Tokens + base styles** (\`src/index.css\`)
- Paired \`:root\` light tokens with \`.dark\` dark tokens for the
  --background/--foreground/--card/--primary/--accent/--border/--ring set.
- \`body\`, \`html\` \`color-scheme\`, \`*:focus-visible\` ring offsets,
  \`::selection\`, scrollbar, table, and \`[cmdk-*]\` selectors all get
  dark variants.
- Legacy \`@layer components\` classes (\`.btn-*\`, \`.badge-*\`, \`.card\`,
  \`.input\`, \`.label\`, \`.stat-*\`, \`.progress-*\`) gain dark counterparts.

**ThemeContext** (\`src/contexts/ThemeContext.tsx\`)
- Three modes: \`light\` / \`dark\` / \`system\`. Persists to localStorage.
- Listens to \`prefers-color-scheme\` when in \`system\` mode.
- Applies the resolved class to \`<html>\` (not \`<body>\`) so
  \`color-scheme\` picks it up for scrollbars and native form controls.
- Wired into the provider tree in \`main.tsx\`.

**Primitive \`dark:\` variants** — every primitive in \`src/components/ui/\`:
Button, Card (+ slots), Badge, CategoryChip (via paired palette in
\`lib/categoryStyle.ts\`), DataTable (rows, headers, hover, mobile cards),
Dialog, Drawer (backdrop + panel + footer), EmptyState, FilterBar,
Input (+ rightSlot icons), Kbd, Label/FieldHint, Modal (legacy),
PageHeader, Select (both Listbox and Combobox modes), SelectNative (with
a light/dark chevron SVG), Skeleton (via \`skeleton-shimmer .dark\`
gradient), StatCard tones, Tabs, Textarea, Tooltip.

**Theme picker UI**
- AccountSettings → Appearance tab: Light / Dark / System cards.
- DesignSystem showcase (\`/design-system\`): inline ThemeToggle in the
  page header so reviewers can preview every primitive without leaving
  the page.

## Lint rule update

Rule 4 (\"text-300/400 unreadable on cream\") gains a \`(?<!:)\`
negative-lookbehind so \`dark:text-brand-300\` (a bright color on the
dark surface) doesn't false-flag. In dark mode the 300/400 shades are
the canonical bright text colors.

## CI status (local)

- \`npx tsc --noEmit\` — ✅ clean
- \`npm run lint\` — ✅ 0 errors, 0 warnings
- \`npm run build\` — ✅
- \`npm test\` — ✅ all unit tests pass

## Test plan

- [ ] CI passes
- [ ] Visit \`/design-system\` and toggle Light / Dark / System; verify
      every primitive section renders correctly in both modes
- [ ] Open AccountSettings → Appearance and switch themes; reload page
      and confirm the choice persists
- [ ] In \`system\` mode, toggle OS appearance and confirm the app
      follows
- [ ] Spot-check a few pages (Dashboard, Controls, Risks) in dark mode
- [ ] Open a Dialog and a Drawer in dark mode; confirm backdrop, panel,
      header/footer borders all look right