### PR TITLE
feat(design-system): add CommandMenu primitive + migrate CommandPalette

### DIFF
--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -1,9 +1,7 @@
-import { useState, useEffect, useCallback, useMemo, useRef, Fragment } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Dialog, Transition, Combobox } from '@headlessui/react';
 import { useQuery } from '@tanstack/react-query';
 import {
-  MagnifyingGlassIcon,
   ShieldCheckIcon,
   DocumentTextIcon,
   FolderOpenIcon,
@@ -22,17 +20,14 @@ import {
 } from '@heroicons/react/24/outline';
 import { controlsApi, policiesApi, risksApi, vendorsApi } from '@/lib/api';
 import { useBrandingConfig } from '@/contexts/BrandingContext';
-import clsx from 'clsx';
+import { CommandMenu, type CommandMenuGroup } from '@/components/ui';
 
-interface CommandItem {
-  id: string;
-  name: string;
-  description?: string;
-  icon: React.ComponentType<{ className?: string }>;
+type Category = 'navigation' | 'actions' | 'search' | 'settings';
+
+interface CommandData {
   action: () => void;
-  category: 'navigation' | 'actions' | 'search' | 'settings';
+  category: Category;
   keywords?: string[];
-  shortcut?: string;
 }
 
 interface CommandPaletteProps {
@@ -44,9 +39,7 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
   const navigate = useNavigate();
   const branding = useBrandingConfig();
   const [query, setQuery] = useState('');
-  const inputRef = useRef<HTMLInputElement>(null);
 
-  // Search for entities when query has 2+ characters
   const { data: searchResults } = useQuery({
     queryKey: ['command-search', query],
     queryFn: async () => {
@@ -76,431 +69,303 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
     enabled: query.length >= 2,
   });
 
-  // Base commands
-  const baseCommands: CommandItem[] = useMemo(
+  type Item = {
+    id: string;
+    label: string;
+    description?: string;
+    icon?: React.ComponentType<{ className?: string }>;
+    shortcut?: string;
+    data: CommandData;
+  };
+
+  const baseCommands: Item[] = useMemo(
     () => [
-      // Navigation
       {
         id: 'nav-dashboard',
-        name: 'Go to Dashboard',
+        label: 'Go to Dashboard',
         icon: HomeIcon,
-        action: () => navigate('/'),
-        category: 'navigation',
-        keywords: ['home'],
+        data: { action: () => navigate('/'), category: 'navigation', keywords: ['home'] },
       },
       {
         id: 'nav-controls',
-        name: 'Go to Controls',
+        label: 'Go to Controls',
         icon: ShieldCheckIcon,
-        action: () => navigate('/controls'),
-        category: 'navigation',
+        data: { action: () => navigate('/controls'), category: 'navigation' },
       },
       {
         id: 'nav-risks',
-        name: 'Go to Risks',
+        label: 'Go to Risks',
         icon: ExclamationTriangleIcon,
-        action: () => navigate('/risks'),
-        category: 'navigation',
+        data: { action: () => navigate('/risks'), category: 'navigation' },
       },
       {
         id: 'nav-policies',
-        name: 'Go to Policies',
+        label: 'Go to Policies',
         icon: DocumentTextIcon,
-        action: () => navigate('/policies'),
-        category: 'navigation',
+        data: { action: () => navigate('/policies'), category: 'navigation' },
       },
       {
         id: 'nav-evidence',
-        name: 'Go to Evidence',
+        label: 'Go to Evidence',
         icon: FolderOpenIcon,
-        action: () => navigate('/evidence'),
-        category: 'navigation',
+        data: { action: () => navigate('/evidence'), category: 'navigation' },
       },
       {
         id: 'nav-vendors',
-        name: 'Go to Vendors',
+        label: 'Go to Vendors',
         icon: BuildingOfficeIcon,
-        action: () => navigate('/vendors'),
-        category: 'navigation',
-        keywords: ['tprm', 'third party'],
+        data: {
+          action: () => navigate('/vendors'),
+          category: 'navigation',
+          keywords: ['tprm', 'third party'],
+        },
       },
       {
         id: 'nav-frameworks',
-        name: 'Go to Frameworks',
+        label: 'Go to Frameworks',
         icon: ChartBarIcon,
-        action: () => navigate('/frameworks'),
-        category: 'navigation',
-        keywords: ['compliance', 'soc2', 'iso'],
+        data: {
+          action: () => navigate('/frameworks'),
+          category: 'navigation',
+          keywords: ['compliance', 'soc2', 'iso'],
+        },
       },
       {
         id: 'nav-audits',
-        name: 'Go to Audits',
+        label: 'Go to Audits',
         icon: ClipboardDocumentCheckIcon,
-        action: () => navigate('/audits'),
-        category: 'navigation',
+        data: { action: () => navigate('/audits'), category: 'navigation' },
       },
       {
         id: 'nav-calendar',
-        name: 'Go to Calendar',
+        label: 'Go to Calendar',
         icon: CalendarDaysIcon,
-        action: () => navigate('/compliance-calendar'),
-        category: 'navigation',
-        keywords: ['schedule', 'events'],
+        data: {
+          action: () => navigate('/compliance-calendar'),
+          category: 'navigation',
+          keywords: ['schedule', 'events'],
+        },
       },
       {
         id: 'nav-reports',
-        name: 'Go to Risk Reports',
+        label: 'Go to Risk Reports',
         icon: ChartBarIcon,
-        action: () => navigate('/risk-reports'),
-        category: 'navigation',
+        data: { action: () => navigate('/risk-reports'), category: 'navigation' },
       },
       {
         id: 'nav-training',
-        name: 'Go to Training',
+        label: 'Go to Training',
         icon: AcademicCapIcon,
-        action: () => navigate('/tools/awareness'),
-        category: 'navigation',
-        keywords: ['security awareness'],
+        data: {
+          action: () => navigate('/tools/awareness'),
+          category: 'navigation',
+          keywords: ['security awareness'],
+        },
       },
       {
         id: 'nav-users',
-        name: 'Go to Users',
+        label: 'Go to Users',
         icon: UserGroupIcon,
-        action: () => navigate('/users'),
-        category: 'navigation',
+        data: { action: () => navigate('/users'), category: 'navigation' },
       },
 
-      // Actions
       {
         id: 'action-new-control',
-        name: 'Create New Control',
+        label: 'Create New Control',
         icon: PlusIcon,
-        action: () => navigate('/controls/new'),
-        category: 'actions',
-        keywords: ['add control'],
+        data: {
+          action: () => navigate('/controls/new'),
+          category: 'actions',
+          keywords: ['add control'],
+        },
       },
       {
         id: 'action-new-risk',
-        name: 'Create New Risk',
+        label: 'Create New Risk',
         icon: PlusIcon,
-        action: () => navigate('/risks/new'),
-        category: 'actions',
-        keywords: ['add risk', 'register risk'],
+        data: {
+          action: () => navigate('/risks/new'),
+          category: 'actions',
+          keywords: ['add risk', 'register risk'],
+        },
       },
       {
         id: 'action-upload-evidence',
-        name: 'Upload Evidence',
+        label: 'Upload Evidence',
         icon: ArrowUpTrayIcon,
-        action: () => navigate('/evidence/new'),
-        category: 'actions',
-        keywords: ['add evidence'],
+        data: {
+          action: () => navigate('/evidence/new'),
+          category: 'actions',
+          keywords: ['add evidence'],
+        },
       },
       {
         id: 'action-new-vendor',
-        name: 'Add New Vendor',
+        label: 'Add New Vendor',
         icon: PlusIcon,
-        action: () => navigate('/vendors/new'),
-        category: 'actions',
+        data: { action: () => navigate('/vendors/new'), category: 'actions' },
       },
       {
         id: 'action-new-policy',
-        name: 'Create New Policy',
+        label: 'Create New Policy',
         icon: PlusIcon,
-        action: () => navigate('/policies/new'),
-        category: 'actions',
+        data: { action: () => navigate('/policies/new'), category: 'actions' },
       },
 
-      // Settings
       {
         id: 'settings-profile',
-        name: 'Profile Settings',
+        label: 'Profile Settings',
         icon: Cog6ToothIcon,
-        action: () => navigate('/settings'),
-        category: 'settings',
+        data: { action: () => navigate('/settings'), category: 'settings' },
       },
       {
         id: 'settings-notifications',
-        name: 'Notification Settings',
+        label: 'Notification Settings',
         icon: BellIcon,
-        action: () => navigate('/notification-settings'),
-        category: 'settings',
+        data: { action: () => navigate('/notification-settings'), category: 'settings' },
       },
       {
         id: 'settings-permissions',
-        name: 'Permission Groups',
+        label: 'Permission Groups',
         icon: UserGroupIcon,
-        action: () => navigate('/permission-groups'),
-        category: 'settings',
+        data: { action: () => navigate('/permission-groups'), category: 'settings' },
       },
     ],
     [navigate]
   );
 
-  // Build search result commands
-  const searchCommands: CommandItem[] = useMemo(() => {
+  const searchItems: Item[] = useMemo(() => {
     if (!searchResults) return [];
 
-    const commands: CommandItem[] = [];
+    const items: Item[] = [];
 
     searchResults.controls?.forEach((control: any) => {
-      commands.push({
+      items.push({
         id: `control-${control.id}`,
-        name: control.title,
+        label: control.title,
         description: control.controlId,
         icon: ShieldCheckIcon,
-        action: () => navigate(`/controls/${control.id}`),
-        category: 'search',
+        data: { action: () => navigate(`/controls/${control.id}`), category: 'search' },
       });
     });
 
     searchResults.policies?.forEach((policy: any) => {
-      commands.push({
+      items.push({
         id: `policy-${policy.id}`,
-        name: policy.title,
+        label: policy.title,
         description: policy.status,
         icon: DocumentTextIcon,
-        action: () => navigate(`/policies/${policy.id}`),
-        category: 'search',
+        data: { action: () => navigate(`/policies/${policy.id}`), category: 'search' },
       });
     });
 
     searchResults.risks?.forEach((risk: any) => {
-      commands.push({
+      items.push({
         id: `risk-${risk.id}`,
-        name: risk.title,
+        label: risk.title,
         description: risk.riskLevel,
         icon: ExclamationTriangleIcon,
-        action: () => navigate(`/risks/${risk.id}`),
-        category: 'search',
+        data: { action: () => navigate(`/risks/${risk.id}`), category: 'search' },
       });
     });
 
     searchResults.vendors?.forEach((vendor: any) => {
-      commands.push({
+      items.push({
         id: `vendor-${vendor.id}`,
-        name: vendor.name,
+        label: vendor.name,
         description: vendor.tier ? `Tier ${vendor.tier}` : undefined,
         icon: BuildingOfficeIcon,
-        action: () => navigate(`/vendors/${vendor.id}`),
-        category: 'search',
+        data: { action: () => navigate(`/vendors/${vendor.id}`), category: 'search' },
       });
     });
 
-    return commands;
+    return items;
   }, [searchResults, navigate]);
 
-  // Filter and combine commands
   const filteredCommands = useMemo(() => {
     const lowerQuery = query.toLowerCase();
 
-    // If there's a search query, prioritize search results
     if (query.length >= 2) {
       const filtered = baseCommands.filter(
         (cmd) =>
-          cmd.name.toLowerCase().includes(lowerQuery) ||
-          cmd.keywords?.some((k) => k.toLowerCase().includes(lowerQuery))
+          cmd.label.toLowerCase().includes(lowerQuery) ||
+          cmd.data.keywords?.some((k) => k.toLowerCase().includes(lowerQuery))
       );
-      return [...searchCommands, ...filtered];
+      return [...searchItems, ...filtered];
     }
 
-    // Otherwise show all base commands
     if (!query) return baseCommands;
 
     return baseCommands.filter(
       (cmd) =>
-        cmd.name.toLowerCase().includes(lowerQuery) ||
-        cmd.keywords?.some((k) => k.toLowerCase().includes(lowerQuery))
+        cmd.label.toLowerCase().includes(lowerQuery) ||
+        cmd.data.keywords?.some((k) => k.toLowerCase().includes(lowerQuery))
     );
-  }, [query, baseCommands, searchCommands]);
+  }, [query, baseCommands, searchItems]);
 
-  // Group commands by category
-  const groupedCommands = useMemo(() => {
-    const groups: Record<string, CommandItem[]> = {};
+  const groups: CommandMenuGroup<CommandData>[] = useMemo(() => {
+    const categoryOrder: Category[] = ['search', 'navigation', 'actions', 'settings'];
+    const labels: Record<Category, string> = {
+      search: 'Search Results',
+      navigation: 'Navigation',
+      actions: 'Actions',
+      settings: 'Settings',
+    };
 
-    filteredCommands.forEach((cmd) => {
-      if (!groups[cmd.category]) {
-        groups[cmd.category] = [];
-      }
-      groups[cmd.category].push(cmd);
-    });
-
-    return groups;
+    return categoryOrder
+      .map((cat) => ({
+        id: cat,
+        label: labels[cat],
+        items: filteredCommands.filter((cmd) => cmd.data.category === cat),
+      }))
+      .filter((g) => g.items.length > 0);
   }, [filteredCommands]);
 
-  const categoryLabels: Record<string, string> = {
-    search: 'Search Results',
-    navigation: 'Navigation',
-    actions: 'Actions',
-    settings: 'Settings',
-  };
-
-  // Handle command selection
   const handleSelect = useCallback(
-    (command: CommandItem | null) => {
-      if (command) {
-        command.action();
-        onClose();
-        setQuery('');
-      }
+    (item: { data?: CommandData }) => {
+      if (!item.data) return;
+      item.data.action();
+      onClose();
+      setQuery('');
     },
     [onClose]
   );
 
-  // Focus input when opened
   useEffect(() => {
-    if (isOpen) {
-      setTimeout(() => inputRef.current?.focus(), 100);
-    }
-  }, [isOpen]);
-
-  // Reset query when closed
-  useEffect(() => {
-    if (!isOpen) {
-      setQuery('');
-    }
+    if (!isOpen) setQuery('');
   }, [isOpen]);
 
   return (
-    <Transition.Root show={isOpen} as={Fragment}>
-      <Dialog as="div" className="relative z-50" onClose={onClose}>
-        <Transition.Child
-          as={Fragment}
-          enter="ease-out duration-200"
-          enterFrom="opacity-0"
-          enterTo="opacity-100"
-          leave="ease-in duration-150"
-          leaveFrom="opacity-100"
-          leaveTo="opacity-0"
-        >
-          <div className="fixed inset-0 bg-black/60 backdrop-blur-sm" />
-        </Transition.Child>
-
-        <div className="fixed inset-0 overflow-y-auto p-4 sm:p-6 md:p-20">
-          <Transition.Child
-            as={Fragment}
-            enter="ease-out duration-200"
-            enterFrom="opacity-0 scale-95"
-            enterTo="opacity-100 scale-100"
-            leave="ease-in duration-150"
-            leaveFrom="opacity-100 scale-100"
-            leaveTo="opacity-0 scale-95"
-          >
-            <Dialog.Panel className="mx-auto max-w-2xl transform overflow-hidden rounded-xl bg-white border border-surface-200 shadow-2xl transition-all">
-              <Combobox onChange={handleSelect}>
-                {/* Search Input */}
-                <div className="relative">
-                  <MagnifyingGlassIcon
-                    className="pointer-events-none absolute left-4 top-3.5 h-5 w-5 text-surface-600"
-                    aria-hidden="true"
-                  />
-                  <Combobox.Input
-                    ref={inputRef}
-                    className="h-12 w-full border-0 bg-transparent pl-11 pr-4 text-white placeholder:text-surface-500 focus:ring-0 text-base"
-                    placeholder="Search or type a command..."
-                    onChange={(e) => setQuery(e.target.value)}
-                    value={query}
-                  />
-                  <div className="absolute right-4 top-3 text-xs text-surface-500 hidden sm:flex items-center gap-1">
-                    <kbd className="px-1.5 py-0.5 bg-surface-200 rounded text-surface-600">Esc</kbd>
-                    <span>to close</span>
-                  </div>
-                </div>
-
-                {/* Results */}
-                {filteredCommands.length > 0 && (
-                  <Combobox.Options
-                    static
-                    className="max-h-96 scroll-py-2 overflow-y-auto border-t border-surface-200"
-                  >
-                    {Object.entries(groupedCommands).map(([category, commands]) => (
-                      <div key={category}>
-                        <div className="px-4 py-2 text-xs font-semibold text-surface-500 uppercase tracking-wider bg-white/50">
-                          {categoryLabels[category] || category}
-                        </div>
-                        {commands.map((command) => (
-                          <Combobox.Option
-                            key={command.id}
-                            value={command}
-                            className={({ active }) =>
-                              clsx(
-                                'flex items-center gap-3 px-4 py-3 cursor-pointer',
-                                active ? 'bg-surface-200' : ''
-                              )
-                            }
-                          >
-                            {({ active }) => (
-                              <>
-                                <command.icon
-                                  className={clsx(
-                                    'w-5 h-5 flex-shrink-0',
-                                    active ? 'text-brand-400' : 'text-surface-600'
-                                  )}
-                                />
-                                <div className="flex-1 min-w-0">
-                                  <p
-                                    className={clsx(
-                                      'text-sm font-medium truncate',
-                                      active ? 'text-white' : 'text-surface-800'
-                                    )}
-                                  >
-                                    {command.name}
-                                  </p>
-                                  {command.description && (
-                                    <p className="text-xs text-surface-500 truncate">
-                                      {command.description}
-                                    </p>
-                                  )}
-                                </div>
-                                {command.shortcut && (
-                                  <kbd className="px-2 py-1 text-xs bg-surface-200 rounded text-surface-600">
-                                    {command.shortcut}
-                                  </kbd>
-                                )}
-                              </>
-                            )}
-                          </Combobox.Option>
-                        ))}
-                      </div>
-                    ))}
-                  </Combobox.Options>
-                )}
-
-                {/* Empty state */}
-                {query && filteredCommands.length === 0 && (
-                  <div className="px-6 py-14 text-center border-t border-surface-200">
-                    <MagnifyingGlassIcon className="mx-auto h-8 w-8 text-surface-500" />
-                    <p className="mt-4 text-sm text-surface-600">No results found for "{query}"</p>
-                    <p className="mt-2 text-xs text-surface-500">
-                      Try searching for controls, policies, risks, or use a command
-                    </p>
-                  </div>
-                )}
-
-                {/* Footer */}
-                <div className="flex items-center justify-between border-t border-surface-200 px-4 py-2 text-xs text-surface-500">
-                  <div className="flex items-center gap-4">
-                    <span className="flex items-center gap-1">
-                      <kbd className="px-1.5 py-0.5 bg-surface-200 rounded">↑</kbd>
-                      <kbd className="px-1.5 py-0.5 bg-surface-200 rounded">↓</kbd>
-                      navigate
-                    </span>
-                    <span className="flex items-center gap-1">
-                      <kbd className="px-1.5 py-0.5 bg-surface-200 rounded">↵</kbd>
-                      select
-                    </span>
-                  </div>
-                  <span>{branding.platformName}</span>
-                </div>
-              </Combobox>
-            </Dialog.Panel>
-          </Transition.Child>
-        </div>
-      </Dialog>
-    </Transition.Root>
+    <CommandMenu<CommandData>
+      open={isOpen}
+      onClose={onClose}
+      query={query}
+      onQueryChange={setQuery}
+      groups={groups}
+      onSelect={handleSelect}
+      placeholder="Search or type a command..."
+      emptyTitle="No results found"
+      emptyDescription="Try searching for controls, policies, risks, or use a command"
+      footer={
+        <>
+          <div className="flex items-center gap-4">
+            <span className="flex items-center gap-1">
+              <kbd className="px-1.5 py-0.5 bg-surface-200 dark:bg-surface-800 rounded">↑</kbd>
+              <kbd className="px-1.5 py-0.5 bg-surface-200 dark:bg-surface-800 rounded">↓</kbd>
+              navigate
+            </span>
+            <span className="flex items-center gap-1">
+              <kbd className="px-1.5 py-0.5 bg-surface-200 dark:bg-surface-800 rounded">↵</kbd>
+              select
+            </span>
+          </div>
+          <span>{branding.platformName}</span>
+        </>
+      }
+    />
   );
 }
 
-// Hook to manage command palette state
 export function useCommandPalette() {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -508,10 +373,8 @@ export function useCommandPalette() {
   const close = useCallback(() => setIsOpen(false), []);
   const toggle = useCallback(() => setIsOpen((prev) => !prev), []);
 
-  // Global keyboard shortcut
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      // Cmd/Ctrl + K to open
       if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
         e.preventDefault();
         toggle();

--- a/frontend/src/components/ui/CommandMenu.tsx
+++ b/frontend/src/components/ui/CommandMenu.tsx
@@ -1,0 +1,204 @@
+import { Fragment, ReactNode, useEffect, useRef } from 'react';
+import { Combobox, Dialog as HUIDialog, Transition } from '@headlessui/react';
+import { Search } from 'lucide-react';
+import { cn } from '@/lib/cn';
+
+export interface CommandMenuItem<T = unknown> {
+  id: string;
+  label: string;
+  description?: string;
+  icon?: React.ComponentType<{ className?: string }>;
+  shortcut?: string;
+  data?: T;
+}
+
+export interface CommandMenuGroup<T = unknown> {
+  id: string;
+  label: string;
+  items: CommandMenuItem<T>[];
+}
+
+export interface CommandMenuProps<T = unknown> {
+  open: boolean;
+  onClose: () => void;
+  query: string;
+  onQueryChange: (q: string) => void;
+  groups: CommandMenuGroup<T>[];
+  onSelect: (item: CommandMenuItem<T>) => void;
+  placeholder?: string;
+  emptyTitle?: string;
+  emptyDescription?: string;
+  footer?: ReactNode;
+}
+
+export function CommandMenu<T>({
+  open,
+  onClose,
+  query,
+  onQueryChange,
+  groups,
+  onSelect,
+  placeholder = 'Search…',
+  emptyTitle = 'No results',
+  emptyDescription,
+  footer,
+}: CommandMenuProps<T>) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      const t = setTimeout(() => inputRef.current?.focus(), 50);
+      return () => clearTimeout(t);
+    }
+  }, [open]);
+
+  const flatCount = groups.reduce((n, g) => n + g.items.length, 0);
+
+  return (
+    <Transition.Root show={open} as={Fragment}>
+      <HUIDialog as="div" className="relative z-[100]" onClose={onClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-200"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-150"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-white/40 backdrop-blur-sm dark:bg-black/60" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 overflow-y-auto p-4 sm:p-6 md:p-20">
+          <Transition.Child
+            as={Fragment}
+            enter="ease-out duration-200"
+            enterFrom="opacity-0 scale-95"
+            enterTo="opacity-100 scale-100"
+            leave="ease-in duration-150"
+            leaveFrom="opacity-100 scale-100"
+            leaveTo="opacity-0 scale-95"
+          >
+            <HUIDialog.Panel className="mx-auto max-w-2xl transform overflow-hidden rounded-xl bg-white border border-surface-200 shadow-2xl transition-all dark:bg-surface-900 dark:border-surface-800">
+              <Combobox<CommandMenuItem<T>>
+                onChange={(item) => {
+                  if (item) {
+                    onSelect(item);
+                  }
+                }}
+              >
+                <div className="relative">
+                  <Search
+                    className="pointer-events-none absolute left-4 top-3.5 h-5 w-5 text-surface-500 dark:text-surface-400"
+                    aria-hidden="true"
+                  />
+                  <Combobox.Input
+                    ref={inputRef}
+                    className="h-12 w-full border-0 bg-transparent pl-11 pr-4 text-surface-900 placeholder:text-surface-500 focus:ring-0 text-base dark:text-surface-100 dark:placeholder:text-surface-500"
+                    placeholder={placeholder}
+                    onChange={(e) => onQueryChange(e.target.value)}
+                    value={query}
+                    displayValue={() => query}
+                  />
+                  <div className="absolute right-4 top-3 text-xs text-surface-500 dark:text-surface-400 hidden sm:flex items-center gap-1">
+                    <kbd className="px-1.5 py-0.5 bg-surface-200 dark:bg-surface-800 rounded text-surface-600 dark:text-surface-300">
+                      Esc
+                    </kbd>
+                    <span>to close</span>
+                  </div>
+                </div>
+
+                {flatCount > 0 && (
+                  <Combobox.Options
+                    static
+                    className="max-h-96 scroll-py-2 overflow-y-auto border-t border-surface-200 dark:border-surface-800"
+                  >
+                    {groups.map((group) =>
+                      group.items.length === 0 ? null : (
+                        <div key={group.id}>
+                          <div className="px-4 py-2 text-xs font-semibold text-surface-500 dark:text-surface-400 uppercase tracking-wider bg-surface-50/60 dark:bg-surface-950/40">
+                            {group.label}
+                          </div>
+                          {group.items.map((item) => (
+                            <Combobox.Option
+                              key={item.id}
+                              value={item}
+                              className={({ active }) =>
+                                cn(
+                                  'flex items-center gap-3 px-4 py-3 cursor-pointer',
+                                  active && 'bg-surface-100 dark:bg-surface-800'
+                                )
+                              }
+                            >
+                              {({ active }) => (
+                                <>
+                                  {item.icon && (
+                                    <item.icon
+                                      className={cn(
+                                        'w-5 h-5 flex-shrink-0',
+                                        active
+                                          ? 'text-brand-600 dark:text-brand-300'
+                                          : 'text-surface-500 dark:text-surface-400'
+                                      )}
+                                    />
+                                  )}
+                                  <div className="flex-1 min-w-0">
+                                    <p
+                                      className={cn(
+                                        'text-sm font-medium truncate',
+                                        active
+                                          ? 'text-surface-900 dark:text-surface-50'
+                                          : 'text-surface-800 dark:text-surface-100'
+                                      )}
+                                    >
+                                      {item.label}
+                                    </p>
+                                    {item.description && (
+                                      <p className="text-xs text-surface-500 dark:text-surface-400 truncate">
+                                        {item.description}
+                                      </p>
+                                    )}
+                                  </div>
+                                  {item.shortcut && (
+                                    <kbd className="px-2 py-1 text-xs bg-surface-200 dark:bg-surface-800 rounded text-surface-600 dark:text-surface-300">
+                                      {item.shortcut}
+                                    </kbd>
+                                  )}
+                                </>
+                              )}
+                            </Combobox.Option>
+                          ))}
+                        </div>
+                      )
+                    )}
+                  </Combobox.Options>
+                )}
+
+                {query && flatCount === 0 && (
+                  <div className="px-6 py-14 text-center border-t border-surface-200 dark:border-surface-800">
+                    <Search className="mx-auto h-8 w-8 text-surface-500 dark:text-surface-400" />
+                    <p className="mt-4 text-sm text-surface-700 dark:text-surface-200">
+                      {emptyTitle}
+                      {query && <> for &ldquo;{query}&rdquo;</>}
+                    </p>
+                    {emptyDescription && (
+                      <p className="mt-2 text-xs text-surface-500 dark:text-surface-400">
+                        {emptyDescription}
+                      </p>
+                    )}
+                  </div>
+                )}
+
+                {footer && (
+                  <div className="flex items-center justify-between border-t border-surface-200 dark:border-surface-800 px-4 py-2 text-xs text-surface-500 dark:text-surface-400">
+                    {footer}
+                  </div>
+                )}
+              </Combobox>
+            </HUIDialog.Panel>
+          </Transition.Child>
+        </div>
+      </HUIDialog>
+    </Transition.Root>
+  );
+}

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -60,3 +60,6 @@ export type { StatCardProps, StatCardTone } from './StatCard';
 
 export { DataTable } from './DataTable';
 export type { DataTableProps, DataTableColumn } from './DataTable';
+
+export { CommandMenu } from './CommandMenu';
+export type { CommandMenuProps, CommandMenuItem, CommandMenuGroup } from './CommandMenu';


### PR DESCRIPTION
## Summary
- Adds **`CommandMenu`** primitive in `frontend/src/components/ui/` that wraps the Combobox + Dialog + grouped-options + footer pattern previously inlined in `CommandPalette`.
- Migrates `CommandPalette` to use the new primitive — same behavior, fewer lines, ~290 lines of JSX → declarative groups.
- Picks up design-system dark surfaces (`surface-900` panel, `surface-800` hover, `surface-200/800` kbd) that the hand-rolled version was missing.

This closes the last open use of raw `@headlessui/react` Combobox + Dialog outside the `ui/` directory.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean (no new design-system rule violations)
- [x] `npm test` — 397 / 397 pass
- [ ] Cmd/Ctrl-K still opens, searches across controls/policies/risks/vendors, keyboard nav still works
- [ ] Visual check in dark mode that the panel/items/footer/kbd-chips look correct