### PR TITLE
feat(design-system): dark-mode coverage sweep + lint rules

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -93,6 +93,36 @@ const designSystemRules = [
     selector: 'JSXOpeningElement[name.name="textarea"]',
     message: 'Use <Textarea> from @/components/ui instead of raw <textarea>.',
   },
+  // 11–14. Dark-mode coverage. Each rule requires that when a light-mode-only
+  //   utility class appears in a JSX className literal, a matching `dark:*`
+  //   sibling appears in the *same* string. The regex uses a negative
+  //   lookahead for the dark prefix and a positive lookahead for the bare
+  //   token; ternary branches that compose their own className inside `${}`
+  //   are checked separately because each branch is its own Literal.
+  {
+    selector:
+      'JSXAttribute[name.name="className"] Literal[value=/^(?!.*\\bdark:bg-)(?=.*(?<![:\\w-])bg-white(?![\\w-])).*$/]',
+    message:
+      'Dark-mode coverage: bare `bg-white` requires a `dark:bg-surface-*` sibling on the same className. (Use `dark:bg-surface-900` for cards, `dark:bg-surface-800` for hover overlays.)',
+  },
+  {
+    selector:
+      'JSXAttribute[name.name="className"] Literal[value=/^(?!.*\\bdark:bg-)(?=.*(?<![:\\w-])bg-gray-[0-9]+).*$/]',
+    message:
+      'Dark-mode coverage: bare `bg-gray-*` requires a `dark:bg-surface-*` sibling. Prefer `bg-surface-*` tokens over `bg-gray-*` to begin with.',
+  },
+  {
+    selector:
+      'JSXAttribute[name.name="className"] Literal[value=/^(?!.*\\bdark:text-)(?=.*(?<![:\\w-])text-gray-[0-9]+).*$/]',
+    message:
+      'Dark-mode coverage: bare `text-gray-*` requires a `dark:text-surface-*` sibling. Prefer `text-surface-*` tokens over `text-gray-*` to begin with.',
+  },
+  {
+    selector:
+      'JSXAttribute[name.name="className"] Literal[value=/^(?!.*\\bdark:border-)(?=.*(?<![:\\w-])border-gray-[0-9]+).*$/]',
+    message:
+      'Dark-mode coverage: bare `border-gray-*` requires a `dark:border-surface-*` sibling. Prefer `border-surface-*` tokens over `border-gray-*` to begin with.',
+  },
 ];
 
 export default [

--- a/frontend/src/components/ActionItemsWidget.tsx
+++ b/frontend/src/components/ActionItemsWidget.tsx
@@ -115,7 +115,7 @@ export function ActionItemsWidget({
 
   if (isLoading) {
     return (
-      <div className="bg-white border border-surface-200 rounded-xl p-6">
+      <div className="bg-white border border-surface-200 rounded-xl p-6 dark:bg-surface-900">
         <div className="animate-pulse space-y-4">
           <div className="h-6 bg-surface-200 rounded w-1/3" />
           <div className="space-y-3">
@@ -129,7 +129,7 @@ export function ActionItemsWidget({
   }
 
   return (
-    <div className="bg-white border border-surface-200 rounded-xl">
+    <div className="bg-white border border-surface-200 rounded-xl dark:bg-surface-900">
       {/* Header */}
       <div className="flex items-center justify-between p-4 border-b border-surface-200">
         <div>

--- a/frontend/src/components/ActivityFeed.tsx
+++ b/frontend/src/components/ActivityFeed.tsx
@@ -143,7 +143,12 @@ export function ActivityFeed({
 
   if (isLoading) {
     return (
-      <div className={clsx('bg-white rounded-xl border border-surface-200', className)}>
+      <div
+        className={clsx(
+          'bg-white rounded-xl border border-surface-200 dark:bg-surface-900',
+          className
+        )}
+      >
         {showHeader && (
           <div className="px-4 py-3 border-b border-surface-200">
             <div className="h-5 bg-surface-200 rounded w-32 animate-pulse" />
@@ -165,7 +170,12 @@ export function ActivityFeed({
   }
 
   return (
-    <div className={clsx('bg-white rounded-xl border border-surface-200', className)}>
+    <div
+      className={clsx(
+        'bg-white rounded-xl border border-surface-200 dark:bg-surface-900',
+        className
+      )}
+    >
       {showHeader && (
         <div className="px-4 py-3 border-b border-surface-200 flex items-center justify-between">
           <h3 className="font-medium text-white">Recent Activity</h3>
@@ -279,7 +289,9 @@ export function ActivityFeed({
 
 // Compact version for sidebars
 export function CompactActivityFeed({ limit = 5 }: { limit?: number }) {
-  return <ActivityFeed limit={limit} compact showHeader className="bg-white/50" />;
+  return (
+    <ActivityFeed limit={limit} compact showHeader className="bg-white/50 dark:bg-surface-900/50" />
+  );
 }
 
 export default ActivityFeed;

--- a/frontend/src/components/AdvancedFilters.tsx
+++ b/frontend/src/components/AdvancedFilters.tsx
@@ -218,7 +218,7 @@ export function AdvancedFilters({ fields, onApply, storageKey, className }: Adva
         leftIcon={<FunnelIcon className="w-4 h-4" />}
         rightIcon={
           activeFilterCount > 0 ? (
-            <span className="ml-1 px-1.5 py-0.5 text-xs bg-white/20 rounded-full">
+            <span className="ml-1 px-1.5 py-0.5 text-xs bg-white/20 rounded-full dark:bg-surface-900/20">
               {activeFilterCount}
             </span>
           ) : (
@@ -234,7 +234,7 @@ export function AdvancedFilters({ fields, onApply, storageKey, className }: Adva
       {isOpen && (
         <>
           <div className="fixed inset-0 z-40" onClick={() => setIsOpen(false)} />
-          <div className="absolute right-0 mt-2 w-[480px] bg-white border border-surface-200 rounded-xl shadow-xl z-50 overflow-hidden">
+          <div className="absolute right-0 mt-2 w-[480px] bg-white border border-surface-200 rounded-xl shadow-xl z-50 overflow-hidden dark:bg-surface-900">
             {/* Header */}
             <div className="p-4 border-b border-surface-200 flex items-center justify-between">
               <h3 className="font-medium text-white">Advanced Filters</h3>
@@ -258,7 +258,7 @@ export function AdvancedFilters({ fields, onApply, storageKey, className }: Adva
 
             {/* Presets */}
             {presets.length > 0 && (
-              <div className="p-3 border-b border-surface-200 bg-white/50">
+              <div className="p-3 border-b border-surface-200 bg-white/50 dark:bg-surface-900/50">
                 <p className="text-xs text-surface-500 mb-2">Saved Filters</p>
                 <div className="flex flex-wrap gap-2">
                   {presets.map((preset) => (

--- a/frontend/src/components/BulkActions.tsx
+++ b/frontend/src/components/BulkActions.tsx
@@ -164,7 +164,7 @@ export function BulkActionsBar({
 
   return (
     <>
-      <div className="sticky top-0 z-40 bg-white border border-surface-200 rounded-lg p-3 flex items-center justify-between shadow-lg animate-slide-down">
+      <div className="sticky top-0 z-40 bg-white border border-surface-200 rounded-lg p-3 flex items-center justify-between shadow-lg animate-slide-down dark:bg-surface-900">
         <div className="flex items-center gap-4">
           <button
             onClick={onClear}
@@ -259,7 +259,7 @@ export function StatusUpdateDropdown({
       {isOpen && (
         <>
           <div className="fixed inset-0 z-40" onClick={() => setIsOpen(false)} />
-          <div className="absolute right-0 mt-2 w-48 bg-white border border-surface-200 rounded-lg shadow-xl z-50 overflow-hidden">
+          <div className="absolute right-0 mt-2 w-48 bg-white border border-surface-200 rounded-lg shadow-xl z-50 overflow-hidden dark:bg-surface-900">
             {options.map((option) => (
               <button
                 key={option.value}

--- a/frontend/src/components/BulkUploadModal.tsx
+++ b/frontend/src/components/BulkUploadModal.tsx
@@ -163,7 +163,7 @@ export default function BulkUploadModal({ isOpen, onClose }: BulkUploadModalProp
         <div className="fixed inset-0 bg-black/70 backdrop-blur-sm" onClick={handleClose} />
 
         {/* Modal */}
-        <div className="relative w-full max-w-2xl bg-white rounded-xl shadow-2xl border border-surface-200">
+        <div className="relative w-full max-w-2xl bg-white rounded-xl shadow-2xl border border-surface-200 dark:bg-surface-900">
           {/* Header */}
           <div className="flex items-center justify-between p-6 border-b border-surface-200">
             <div>
@@ -172,7 +172,7 @@ export default function BulkUploadModal({ isOpen, onClose }: BulkUploadModalProp
             </div>
             <button
               onClick={handleClose}
-              className="p-2 text-surface-600 hover:text-surface-800 hover:bg-white rounded-lg transition-colors"
+              className="p-2 text-surface-600 hover:text-surface-800 hover:bg-white rounded-lg transition-colors dark:bg-surface-900 dark:hover:bg-surface-800"
             >
               <XMarkIcon className="w-5 h-5" />
             </button>
@@ -199,19 +199,19 @@ export default function BulkUploadModal({ isOpen, onClose }: BulkUploadModalProp
                 </div>
 
                 <div className="grid grid-cols-4 gap-4">
-                  <div className="bg-white rounded-lg p-4 text-center">
+                  <div className="bg-white rounded-lg p-4 text-center dark:bg-surface-900">
                     <div className="text-2xl font-bold text-green-600">{result.created}</div>
                     <div className="text-sm text-surface-600">Created</div>
                   </div>
-                  <div className="bg-white rounded-lg p-4 text-center">
+                  <div className="bg-white rounded-lg p-4 text-center dark:bg-surface-900">
                     <div className="text-2xl font-bold text-blue-600">{result.updated}</div>
                     <div className="text-sm text-surface-600">Updated</div>
                   </div>
-                  <div className="bg-white rounded-lg p-4 text-center">
+                  <div className="bg-white rounded-lg p-4 text-center dark:bg-surface-900">
                     <div className="text-2xl font-bold text-surface-600">{result.skipped}</div>
                     <div className="text-sm text-surface-600">Skipped</div>
                   </div>
-                  <div className="bg-white rounded-lg p-4 text-center">
+                  <div className="bg-white rounded-lg p-4 text-center dark:bg-surface-900">
                     <div className="text-2xl font-bold text-red-600">
                       {result.errors?.length || 0}
                     </div>
@@ -249,7 +249,7 @@ export default function BulkUploadModal({ isOpen, onClose }: BulkUploadModalProp
                       'flex-1 py-2 px-4 rounded-lg border transition-colors',
                       uploadMode === 'csv'
                         ? 'bg-brand-600 border-brand-500 text-white'
-                        : 'bg-white border-surface-200 text-surface-700 hover:border-surface-300'
+                        : 'bg-white border-surface-200 text-surface-700 hover:border-surface-300 dark:bg-surface-900'
                     )}
                   >
                     CSV Format
@@ -260,7 +260,7 @@ export default function BulkUploadModal({ isOpen, onClose }: BulkUploadModalProp
                       'flex-1 py-2 px-4 rounded-lg border transition-colors',
                       uploadMode === 'json'
                         ? 'bg-brand-600 border-brand-500 text-white'
-                        : 'bg-white border-surface-200 text-surface-700 hover:border-surface-300'
+                        : 'bg-white border-surface-200 text-surface-700 hover:border-surface-300 dark:bg-surface-900'
                     )}
                   >
                     JSON Format
@@ -334,7 +334,7 @@ export default function BulkUploadModal({ isOpen, onClose }: BulkUploadModalProp
                         setSkipExisting(e.target.checked);
                         if (e.target.checked) setUpdateExisting(false);
                       }}
-                      className="w-4 h-4 rounded border-surface-300 bg-white text-brand-500 focus:ring-brand-500"
+                      className="w-4 h-4 rounded border-surface-300 bg-white text-brand-500 focus:ring-brand-500 dark:bg-surface-900"
                     />
                     <span className="text-surface-700">Skip existing controls</span>
                   </label>
@@ -346,14 +346,14 @@ export default function BulkUploadModal({ isOpen, onClose }: BulkUploadModalProp
                         setUpdateExisting(e.target.checked);
                         if (e.target.checked) setSkipExisting(false);
                       }}
-                      className="w-4 h-4 rounded border-surface-300 bg-white text-brand-500 focus:ring-brand-500"
+                      className="w-4 h-4 rounded border-surface-300 bg-white text-brand-500 focus:ring-brand-500 dark:bg-surface-900"
                     />
                     <span className="text-surface-700">Update existing controls</span>
                   </label>
                 </div>
 
                 {/* Template download */}
-                <div className="bg-white rounded-lg p-4">
+                <div className="bg-white rounded-lg p-4 dark:bg-surface-900">
                   <div className="flex items-center justify-between">
                     <div>
                       <h4 className="font-medium text-surface-800">Need a template?</h4>

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -385,7 +385,7 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
             leaveFrom="opacity-100 scale-100"
             leaveTo="opacity-0 scale-95"
           >
-            <Dialog.Panel className="mx-auto max-w-2xl transform overflow-hidden rounded-xl bg-white border border-surface-200 shadow-2xl transition-all">
+            <Dialog.Panel className="mx-auto max-w-2xl transform overflow-hidden rounded-xl bg-white border border-surface-200 shadow-2xl transition-all dark:bg-surface-900">
               <Combobox onChange={handleSelect}>
                 {/* Search Input */}
                 <div className="relative">
@@ -414,7 +414,7 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
                   >
                     {Object.entries(groupedCommands).map(([category, commands]) => (
                       <div key={category}>
-                        <div className="px-4 py-2 text-xs font-semibold text-surface-500 uppercase tracking-wider bg-white/50">
+                        <div className="px-4 py-2 text-xs font-semibold text-surface-500 uppercase tracking-wider bg-white/50 dark:bg-surface-900/50">
                           {categoryLabels[category] || category}
                         </div>
                         {commands.map((command) => (

--- a/frontend/src/components/CommentsPanel.tsx
+++ b/frontend/src/components/CommentsPanel.tsx
@@ -125,7 +125,12 @@ export default function CommentsPanel({ entityType, entityId }: CommentsPanelPro
           {comments.map((comment: any) => (
             <div
               key={comment.id}
-              className={clsx('p-3 rounded-lg', comment.isResolved ? 'bg-white/50' : 'bg-white')}
+              className={clsx(
+                'p-3 rounded-lg',
+                comment.isResolved
+                  ? 'bg-white/50 dark:bg-surface-900/50'
+                  : 'bg-white dark:bg-surface-900'
+              )}
             >
               <div className="flex items-start justify-between gap-2">
                 <div className="flex-1">

--- a/frontend/src/components/ComplianceCalendar.tsx
+++ b/frontend/src/components/ComplianceCalendar.tsx
@@ -409,7 +409,7 @@ export function ComplianceCalendar({ className, showFilters = true }: Compliance
     <div className={clsx('space-y-6', className)}>
       {/* View Mode Toggle and Actions */}
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2 bg-white rounded-lg p-1">
+        <div className="flex items-center gap-2 bg-white rounded-lg p-1 dark:bg-surface-900">
           <button
             onClick={() => setViewMode('month')}
             className={clsx(
@@ -469,7 +469,7 @@ export function ComplianceCalendar({ className, showFilters = true }: Compliance
       </div>
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Calendar Grid */}
-        <div className="lg:col-span-2 bg-white rounded-xl border border-surface-200 p-6">
+        <div className="lg:col-span-2 bg-white rounded-xl border border-surface-200 p-6 dark:bg-surface-900">
           {/* Header */}
           <div className="flex items-center justify-between mb-6">
             <div className="flex items-center gap-4">
@@ -600,7 +600,7 @@ export function ComplianceCalendar({ className, showFilters = true }: Compliance
         <div className="space-y-6">
           {/* Selected Date Events */}
           {selectedDate && (
-            <div className="bg-white rounded-xl border border-surface-200 p-4">
+            <div className="bg-white rounded-xl border border-surface-200 p-4 dark:bg-surface-900">
               <h3 className="font-medium text-white mb-3">{formatDate(selectedDate)}</h3>
               {selectedDateEvents.length === 0 ? (
                 <p className="text-sm text-surface-500">No events scheduled</p>
@@ -635,7 +635,7 @@ export function ComplianceCalendar({ className, showFilters = true }: Compliance
           )}
 
           {/* Upcoming Events */}
-          <div className="bg-white rounded-xl border border-surface-200 p-4">
+          <div className="bg-white rounded-xl border border-surface-200 p-4 dark:bg-surface-900">
             <h3 className="font-medium text-white mb-3">Upcoming (30 days)</h3>
             {upcomingEvents.length === 0 ? (
               <p className="text-sm text-surface-500">No upcoming events</p>
@@ -696,7 +696,7 @@ export function ComplianceCalendar({ className, showFilters = true }: Compliance
               type="text"
               value={newEventTitle}
               onChange={(e) => setNewEventTitle(e.target.value)}
-              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-white placeholder-surface-500 focus:ring-2 focus:ring-brand-500 focus:border-transparent"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-white placeholder-surface-500 focus:ring-2 focus:ring-brand-500 focus:border-transparent dark:bg-surface-900"
               placeholder="Event title"
               required
             />
@@ -706,7 +706,7 @@ export function ComplianceCalendar({ className, showFilters = true }: Compliance
             <Textarea
               value={newEventDescription}
               onChange={(e) => setNewEventDescription(e.target.value)}
-              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-white placeholder-surface-500 focus:ring-2 focus:ring-brand-500 focus:border-transparent"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-white placeholder-surface-500 focus:ring-2 focus:ring-brand-500 focus:border-transparent dark:bg-surface-900"
               placeholder="Optional description"
               rows={2}
             />
@@ -717,7 +717,7 @@ export function ComplianceCalendar({ className, showFilters = true }: Compliance
               type="date"
               value={newEventDate}
               onChange={(e) => setNewEventDate(e.target.value)}
-              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-white focus:ring-2 focus:ring-brand-500 focus:border-transparent"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-white focus:ring-2 focus:ring-brand-500 focus:border-transparent dark:bg-surface-900"
               required
             />
           </div>
@@ -726,7 +726,7 @@ export function ComplianceCalendar({ className, showFilters = true }: Compliance
             <SelectNative
               value={newEventPriority}
               onChange={(e) => setNewEventPriority(e.target.value)}
-              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-white focus:ring-2 focus:ring-brand-500 focus:border-transparent"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-white focus:ring-2 focus:ring-brand-500 focus:border-transparent dark:bg-surface-900"
             >
               <option value="low">Low</option>
               <option value="medium">Medium</option>

--- a/frontend/src/components/ComplianceScoreCard.tsx
+++ b/frontend/src/components/ComplianceScoreCard.tsx
@@ -42,8 +42,8 @@ export function ComplianceScoreCard({
     <div
       onClick={onClick}
       className={`
-        bg-white border border-surface-200 rounded-xl p-6
-        ${onClick ? 'cursor-pointer hover:border-surface-300 transition-colors' : ''}
+        bg-white dark:bg-surface-900 border border-surface-200 dark:border-surface-800 rounded-xl p-6
+        ${onClick ? 'cursor-pointer hover:border-surface-300 dark:hover:border-surface-700 transition-colors' : ''}
       `}
     >
       <div className="flex items-start justify-between mb-4">

--- a/frontend/src/components/DashboardWidgets.tsx
+++ b/frontend/src/components/DashboardWidgets.tsx
@@ -207,7 +207,7 @@ export function DashboardWidgets({ widgets, storageKey, className }: DashboardWi
 
       {/* Widget Visibility Panel (when customizing) */}
       {isCustomizing && (
-        <div className="mb-6 p-4 bg-white border border-surface-200 rounded-xl">
+        <div className="mb-6 p-4 bg-white border border-surface-200 rounded-xl dark:bg-surface-900">
           <h3 className="text-sm font-medium text-surface-700 mb-3">
             Widget Visibility ({layout.filter((w) => w.visible).length} of {layout.length} visible)
           </h3>
@@ -274,7 +274,7 @@ export function DashboardWidgets({ widgets, storageKey, className }: DashboardWi
 
       {/* Empty State */}
       {visibleWidgets.length === 0 && (
-        <div className="text-center py-12 bg-white border border-surface-200 rounded-xl">
+        <div className="text-center py-12 bg-white border border-surface-200 rounded-xl dark:bg-surface-900">
           <EyeSlashIcon className="w-12 h-12 mx-auto text-surface-600 mb-4" />
           <h3 className="text-lg font-medium text-surface-700 mb-2">No widgets visible</h3>
           <p className="text-surface-500 mb-4">Click "Customize" to enable some widgets</p>
@@ -312,7 +312,10 @@ interface WidgetCardProps {
 export function WidgetCard({ title, children, action, className }: WidgetCardProps) {
   return (
     <div
-      className={clsx('bg-white rounded-xl border border-surface-200 overflow-hidden', className)}
+      className={clsx(
+        'bg-white rounded-xl border border-surface-200 overflow-hidden dark:bg-surface-900',
+        className
+      )}
     >
       <div className="p-4 border-b border-surface-200 flex items-center justify-between">
         <h3 className="font-medium text-surface-900">{title}</h3>

--- a/frontend/src/components/DemoDataSettings.tsx
+++ b/frontend/src/components/DemoDataSettings.tsx
@@ -324,7 +324,7 @@ export default function DemoDataSettings() {
 
 function DataCard({ label, count }: { label: string; count: number }) {
   return (
-    <div className="p-3 bg-white/50 rounded-lg">
+    <div className="p-3 bg-white/50 rounded-lg dark:bg-surface-900/50">
       <p className="text-lg font-semibold text-foreground">{count}</p>
       <p className="text-xs text-muted-foreground">{label}</p>
     </div>

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -102,7 +102,9 @@ export function EmptyState({
     ) : undefined;
 
   return (
-    <div className={`bg-white border border-surface-200 rounded-lg ${className ?? ''}`}>
+    <div
+      className={`bg-white border border-surface-200 rounded-lg ${className ?? ''} dark:bg-surface-900`}
+    >
       <UIEmptyState
         icon={iconElement}
         title={title}

--- a/frontend/src/components/EntityAuditHistory.tsx
+++ b/frontend/src/components/EntityAuditHistory.tsx
@@ -259,7 +259,7 @@ function ChangesDiff({
         {changedFields.map(({ field, oldValue, newValue }) => (
           <div
             key={field}
-            className="flex flex-col gap-1 p-2 rounded-lg bg-white/50 border border-surface-200"
+            className="flex flex-col gap-1 p-2 rounded-lg bg-white/50 border border-surface-200 dark:bg-surface-900/50"
           >
             <span className="text-xs text-surface-600 font-medium">
               {FIELD_LABELS[field] || field}
@@ -321,7 +321,7 @@ function AuditLogItem({ entry }: { entry: AuditLogEntry }) {
       {/* Content */}
       <div
         className={clsx(
-          'bg-white rounded-lg border border-surface-200 overflow-hidden',
+          'bg-white rounded-lg border border-surface-200 overflow-hidden dark:bg-surface-900',
           hasChanges && 'cursor-pointer hover:border-surface-300 transition-colors'
         )}
         onClick={() => hasChanges && setIsExpanded(!isExpanded)}
@@ -426,7 +426,7 @@ export function EntityAuditHistory({ entityType, entityId, limit = 50 }: EntityA
         <div className="flex items-center gap-3">
           <h3 className="text-lg font-semibold text-white">Change History</h3>
           {entries.length > 0 && (
-            <span className="text-xs text-surface-500 bg-white px-2 py-0.5 rounded-full">
+            <span className="text-xs text-surface-500 bg-white px-2 py-0.5 rounded-full dark:bg-surface-900">
               {entries.length} {entries.length === 1 ? 'entry' : 'entries'}
             </span>
           )}
@@ -438,7 +438,7 @@ export function EntityAuditHistory({ entityType, entityId, limit = 50 }: EntityA
             <SelectNative
               value={filterAction}
               onChange={(e) => setFilterAction(e.target.value)}
-              className="text-xs bg-white border border-surface-200 rounded-md text-surface-700 py-1.5 px-2"
+              className="text-xs bg-white border border-surface-200 rounded-md text-surface-700 py-1.5 px-2 dark:bg-surface-900"
             >
               <option value="all">All Actions</option>
               {uniqueActions.map((action) => (
@@ -468,7 +468,7 @@ export function EntityAuditHistory({ entityType, entityId, limit = 50 }: EntityA
           {Array.from({ length: 3 }).map((_, i) => (
             <div key={i} className="relative pl-8 pb-6">
               <div className="absolute left-0 w-6 h-6 rounded-full bg-surface-200 animate-pulse" />
-              <div className="bg-white rounded-lg border border-surface-200 p-4 animate-pulse">
+              <div className="bg-white rounded-lg border border-surface-200 p-4 animate-pulse dark:bg-surface-900">
                 <div className="h-4 bg-surface-200 rounded w-1/3 mb-2" />
                 <div className="h-3 bg-surface-200 rounded w-2/3" />
               </div>
@@ -476,7 +476,7 @@ export function EntityAuditHistory({ entityType, entityId, limit = 50 }: EntityA
           ))}
         </div>
       ) : filteredEntries.length === 0 ? (
-        <div className="text-center py-12 bg-white/50 rounded-lg border border-surface-200">
+        <div className="text-center py-12 bg-white/50 rounded-lg border border-surface-200 dark:bg-surface-900/50">
           <ClockIcon className="w-10 h-10 mx-auto text-surface-600 mb-3" />
           <p className="text-surface-600">No history recorded yet</p>
           <p className="text-surface-500 text-sm mt-1">Changes will appear here as they are made</p>

--- a/frontend/src/components/ExportDropdown.tsx
+++ b/frontend/src/components/ExportDropdown.tsx
@@ -118,7 +118,7 @@ export function ExportDropdown<T>({
       </Button>
 
       {isOpen && (
-        <div className="absolute right-0 mt-2 w-48 bg-white border border-surface-200 rounded-lg shadow-xl z-50 overflow-hidden">
+        <div className="absolute right-0 mt-2 w-48 bg-white border border-surface-200 rounded-lg shadow-xl z-50 overflow-hidden dark:bg-surface-900">
           {formatOptions.map((option) => (
             <button
               key={option.value}

--- a/frontend/src/components/GlobalSearch.tsx
+++ b/frontend/src/components/GlobalSearch.tsx
@@ -166,7 +166,7 @@ export default function GlobalSearch() {
             setIsOpen(true);
           }}
           onFocus={() => setIsOpen(true)}
-          className="w-full pl-10 pr-10 py-2 bg-white border border-surface-200 rounded-lg text-sm text-surface-900 placeholder-surface-500 focus:outline-none focus:border-brand-500 focus:ring-1 focus:ring-brand-500"
+          className="w-full pl-10 pr-10 py-2 bg-white border border-surface-200 rounded-lg text-sm text-surface-900 placeholder-surface-500 focus:outline-none focus:border-brand-500 focus:ring-1 focus:ring-brand-500 dark:bg-surface-900"
         />
         {query && (
           <button
@@ -182,7 +182,7 @@ export default function GlobalSearch() {
       </div>
       {/* Results dropdown */}
       {isOpen && query.length >= 2 && (
-        <div className="absolute top-full left-0 right-0 mt-2 bg-white border border-surface-200 rounded-lg shadow-xl max-h-96 overflow-y-auto z-50">
+        <div className="absolute top-full left-0 right-0 mt-2 bg-white border border-surface-200 rounded-lg shadow-xl max-h-96 overflow-y-auto z-50 dark:bg-surface-900">
           {isLoading ? (
             <div className="p-4 text-center text-surface-600">
               <div className="animate-spin w-5 h-5 border-2 border-surface-200 border-t-brand-500 rounded-full mx-auto"></div>
@@ -203,13 +203,13 @@ export default function GlobalSearch() {
                       'w-full px-4 py-3 flex items-center gap-3 text-left transition-colors',
                       isSelected
                         ? 'bg-brand-500/20 text-surface-900'
-                        : 'text-surface-700 hover:bg-white'
+                        : 'text-surface-700 hover:bg-white dark:bg-surface-900 dark:hover:bg-surface-800'
                     )}
                   >
                     <div
                       className={clsx(
                         'p-2 rounded-lg',
-                        isSelected ? 'bg-brand-500/30' : 'bg-white'
+                        isSelected ? 'bg-brand-500/30' : 'bg-white dark:bg-surface-900'
                       )}
                     >
                       <Icon className="w-4 h-4" />
@@ -222,7 +222,7 @@ export default function GlobalSearch() {
                             'text-xs px-2 py-0.5 rounded',
                             isSelected
                               ? 'bg-brand-500/30 text-brand-300'
-                              : 'bg-white text-surface-500'
+                              : 'bg-white text-surface-500 dark:bg-surface-900'
                           )}
                         >
                           {SEARCH_LABELS[result.type]}

--- a/frontend/src/components/KeyboardShortcuts.tsx
+++ b/frontend/src/components/KeyboardShortcuts.tsx
@@ -92,7 +92,7 @@ export function KeyboardShortcutsModal({ isOpen, onClose }: KeyboardShortcutsPro
               leaveFrom="opacity-100 scale-100"
               leaveTo="opacity-0 scale-95"
             >
-              <Dialog.Panel className="w-full max-w-2xl transform overflow-hidden rounded-xl bg-white border border-surface-200 shadow-2xl transition-all">
+              <Dialog.Panel className="w-full max-w-2xl transform overflow-hidden rounded-xl bg-white border border-surface-200 shadow-2xl transition-all dark:bg-surface-900">
                 <div className="flex items-center justify-between px-6 py-4 border-b border-surface-200">
                   <Dialog.Title className="text-lg font-semibold text-white">
                     Keyboard Shortcuts
@@ -134,7 +134,7 @@ export function KeyboardShortcutsModal({ isOpen, onClose }: KeyboardShortcutsPro
                   ))}
                 </div>
 
-                <div className="px-6 py-4 bg-white/50 border-t border-surface-200">
+                <div className="px-6 py-4 bg-white/50 border-t border-surface-200 dark:bg-surface-900/50">
                   <p className="text-xs text-surface-500 text-center">
                     Press{' '}
                     <kbd className="px-1.5 py-0.5 bg-surface-200 rounded text-surface-600">⌘</kbd> +{' '}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -247,7 +247,7 @@ function NavSectionComponent({ section }: { section: NavSection }) {
           'flex items-center justify-between w-full px-3 py-2 rounded-lg text-sm font-medium transition-all duration-300',
           hasActiveItem
             ? 'text-brand-400'
-            : 'text-surface-600 hover:bg-white hover:text-surface-900'
+            : 'text-surface-600 hover:bg-white hover:text-surface-900 dark:bg-surface-900 dark:hover:bg-surface-800'
         )}
       >
         <div className="flex items-center gap-3">
@@ -290,7 +290,7 @@ function NavSectionComponent({ section }: { section: NavSection }) {
                     'flex items-center gap-3 px-3 py-2 rounded-lg text-sm transition-all duration-200',
                     isActive
                       ? 'bg-brand-600/20 text-brand-400 font-medium'
-                      : 'text-surface-600 hover:bg-white hover:text-surface-900'
+                      : 'text-surface-600 hover:bg-white hover:text-surface-900 dark:bg-surface-900 dark:hover:bg-surface-800'
                   )}
                   style={{
                     transitionDelay: isOpen ? `${index * 30}ms` : '0ms',
@@ -352,7 +352,7 @@ export default function Layout() {
         role="navigation"
         aria-label="Main navigation"
         className={clsx(
-          'fixed inset-y-0 left-0 z-50 w-64 bg-white border-r border-surface-200 transform transition-transform duration-200 ease-in-out lg:translate-x-0',
+          'fixed inset-y-0 left-0 z-50 w-64 bg-white border-r border-surface-200 transform transition-transform duration-200 ease-in-out lg:translate-x-0 dark:bg-surface-900',
           sidebarOpen ? 'translate-x-0' : '-translate-x-full'
         )}
       >
@@ -372,7 +372,7 @@ export default function Layout() {
                 'flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors',
                 isDashboardActive
                   ? 'bg-brand-600/20 text-brand-400'
-                  : 'text-surface-600 hover:bg-white hover:text-surface-900'
+                  : 'text-surface-600 hover:bg-white hover:text-surface-900 dark:bg-surface-900 dark:hover:bg-surface-800'
               )}
               onClick={() => setSidebarOpen(false)}
             >
@@ -388,7 +388,7 @@ export default function Layout() {
                   'flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors ml-2',
                   isActive
                     ? 'bg-brand-600/20 text-brand-400'
-                    : 'text-surface-600 hover:bg-white hover:text-surface-900'
+                    : 'text-surface-600 hover:bg-white hover:text-surface-900 dark:bg-surface-900 dark:hover:bg-surface-800'
                 )
               }
               onClick={() => setSidebarOpen(false)}
@@ -398,7 +398,7 @@ export default function Layout() {
             </NavLink>
 
             {/* Divider */}
-            <div className="h-px bg-white my-2" />
+            <div className="h-px bg-white my-2 dark:bg-surface-900" />
 
             {/* Collapsible Sections */}
             {navSections
@@ -435,7 +435,7 @@ export default function Layout() {
             </div>
             <button
               onClick={logout}
-              className="flex items-center gap-2 w-full px-3 py-2 text-sm text-surface-600 hover:text-surface-900 hover:bg-white rounded-lg transition-colors"
+              className="flex items-center gap-2 w-full px-3 py-2 text-sm text-surface-600 hover:text-surface-900 hover:bg-white rounded-lg transition-colors dark:bg-surface-900 dark:hover:bg-surface-800"
             >
               <ArrowRightOnRectangleIcon className="w-5 h-5" />
               Sign out
@@ -450,7 +450,7 @@ export default function Layout() {
         <header
           role="banner"
           aria-label="Site header"
-          className="sticky top-0 z-[60] bg-white/80 backdrop-blur-sm border-b border-surface-200"
+          className="sticky top-0 z-[60] bg-white/80 backdrop-blur-sm border-b border-surface-200 dark:bg-surface-900/80"
         >
           <div className="flex items-center justify-between gap-4 px-4 py-3 lg:px-6">
             <div className="flex items-center gap-2">
@@ -469,7 +469,7 @@ export default function Layout() {
               {/* Keyboard Shortcuts Button */}
               <button
                 onClick={() => setShowShortcuts(true)}
-                className="p-2 text-surface-600 hover:text-surface-900 hover:bg-white rounded-lg transition-colors"
+                className="p-2 text-surface-600 hover:text-surface-900 hover:bg-white rounded-lg transition-colors dark:bg-surface-900 dark:hover:bg-surface-800"
                 title="Keyboard Shortcuts (⌘/)"
               >
                 <CommandLineIcon className="w-5 h-5" />
@@ -478,7 +478,7 @@ export default function Layout() {
               {/* Help Center Link */}
               <NavLink
                 to="/help"
-                className="p-2 text-surface-600 hover:text-surface-900 hover:bg-white rounded-lg transition-colors"
+                className="p-2 text-surface-600 hover:text-surface-900 hover:bg-white rounded-lg transition-colors dark:bg-surface-900 dark:hover:bg-surface-800"
                 title="Help Center"
               >
                 <QuestionMarkCircleIcon className="w-5 h-5" />
@@ -486,7 +486,7 @@ export default function Layout() {
 
               <NavLink
                 to="/account"
-                className="p-2 text-surface-600 hover:text-surface-900 hover:bg-white rounded-lg transition-colors"
+                className="p-2 text-surface-600 hover:text-surface-900 hover:bg-white rounded-lg transition-colors dark:bg-surface-900 dark:hover:bg-surface-800"
                 title="Account Settings"
               >
                 <CogIcon className="w-5 h-5" />

--- a/frontend/src/components/NavigationProgress.tsx
+++ b/frontend/src/components/NavigationProgress.tsx
@@ -39,7 +39,7 @@ export default function NavigationProgress() {
   if (!visible) return null;
 
   return (
-    <div className="fixed top-0 left-0 right-0 z-[60] h-1 bg-white/50">
+    <div className="fixed top-0 left-0 right-0 z-[60] h-1 bg-white/50 dark:bg-surface-900/50">
       <div
         className={clsx(
           'h-full bg-brand-500 transition-all duration-300 ease-out',

--- a/frontend/src/components/OfflineIndicator.tsx
+++ b/frontend/src/components/OfflineIndicator.tsx
@@ -67,7 +67,7 @@ export default function OfflineIndicator({
 
       {/* Expanded Details */}
       {isExpanded && (
-        <div className="absolute right-0 top-full mt-2 w-72 bg-white border border-surface-200 rounded-xl shadow-xl z-50 overflow-hidden">
+        <div className="absolute right-0 top-full mt-2 w-72 bg-white border border-surface-200 rounded-xl shadow-xl z-50 overflow-hidden dark:bg-surface-900">
           <div className="flex items-center justify-between p-3 border-b border-surface-200">
             <div className="flex items-center gap-2">
               {isOnline ? (
@@ -105,7 +105,7 @@ export default function OfflineIndicator({
                   <span className="text-xs text-surface-600">Pending Changes</span>
                   <span className="text-xs font-medium text-yellow-600">{pendingCount}</span>
                 </div>
-                <div className="w-full bg-white rounded-full h-1">
+                <div className="w-full bg-white rounded-full h-1 dark:bg-surface-900">
                   <div
                     className="bg-yellow-500 rounded-full h-1 transition-all"
                     style={{ width: `${Math.min(pendingCount * 10, 100)}%` }}
@@ -117,11 +117,11 @@ export default function OfflineIndicator({
             {/* Storage Stats */}
             {storageStats && (
               <div className="grid grid-cols-2 gap-2 text-xs">
-                <div className="p-2 bg-white rounded-lg">
+                <div className="p-2 bg-white rounded-lg dark:bg-surface-900">
                   <span className="text-surface-600">Cached Items</span>
                   <div className="font-medium text-white">{storageStats.cachedItems}</div>
                 </div>
-                <div className="p-2 bg-white rounded-lg">
+                <div className="p-2 bg-white rounded-lg dark:bg-surface-900">
                   <span className="text-surface-600">Storage Used</span>
                   <div className="font-medium text-white">{storageStats.estimatedSize}</div>
                 </div>

--- a/frontend/src/components/OnboardingBanner.tsx
+++ b/frontend/src/components/OnboardingBanner.tsx
@@ -158,7 +158,7 @@ function FeatureCard({
   description: string;
 }) {
   return (
-    <div className="flex items-center gap-2 p-2 bg-white/50 rounded-lg">
+    <div className="flex items-center gap-2 p-2 bg-white/50 rounded-lg dark:bg-surface-900/50">
       <Icon className="h-5 w-5 text-brand-400 flex-shrink-0" />
       <div className="min-w-0">
         <p className="text-xs font-medium text-foreground truncate">{label}</p>

--- a/frontend/src/components/OnboardingTour.tsx
+++ b/frontend/src/components/OnboardingTour.tsx
@@ -248,7 +248,7 @@ export function OnboardingTour({ isOpen, onClose, onComplete }: OnboardingTourPr
 
                   {/* Tips */}
                   {step.tips && step.tips.length > 0 && (
-                    <div className="bg-white/50 rounded-xl p-4 mb-6 text-left">
+                    <div className="bg-white/50 rounded-xl p-4 mb-6 text-left dark:bg-surface-900/50">
                       <p className="text-xs font-semibold text-surface-600 uppercase tracking-wider mb-3">
                         Pro Tips
                       </p>
@@ -291,7 +291,7 @@ export function OnboardingTour({ isOpen, onClose, onComplete }: OnboardingTourPr
                 </div>
 
                 {/* Footer */}
-                <div className="flex items-center justify-between px-8 py-4 border-t border-surface-200 bg-white/50">
+                <div className="flex items-center justify-between px-8 py-4 border-t border-surface-200 bg-white/50 dark:bg-surface-900/50">
                   <button
                     onClick={handlePrev}
                     disabled={isFirst}

--- a/frontend/src/components/OnboardingWizard.tsx
+++ b/frontend/src/components/OnboardingWizard.tsx
@@ -145,7 +145,7 @@ export function OnboardingWizard({ onDismiss }: OnboardingWizardProps) {
   }
 
   return (
-    <div className="bg-white border border-surface-200 rounded-xl p-6 mb-6">
+    <div className="bg-white border border-surface-200 rounded-xl p-6 mb-6 dark:bg-surface-900">
       <div className="flex items-start justify-between mb-6">
         <div>
           <h2 className="text-xl font-semibold text-surface-900">Welcome to GigaChad GRC! 🚀</h2>
@@ -194,7 +194,7 @@ export function OnboardingWizard({ onDismiss }: OnboardingWizardProps) {
                     ? 'bg-green-900/20 border-green-800'
                     : isNext
                       ? 'bg-blue-900/20 border-blue-700'
-                      : 'bg-white border-surface-200'
+                      : 'bg-white border-surface-200 dark:bg-surface-900'
                 }
               `}
             >

--- a/frontend/src/components/ProductionReadiness.tsx
+++ b/frontend/src/components/ProductionReadiness.tsx
@@ -60,7 +60,7 @@ export function ProductionReadiness() {
 
   if (loading) {
     return (
-      <div className="bg-white rounded-xl p-6">
+      <div className="bg-white rounded-xl p-6 dark:bg-surface-900">
         <div className="flex items-center justify-center py-8">
           <ArrowPathIcon className="h-6 w-6 animate-spin text-primary" />
           <span className="ml-2 text-foreground/60">Analyzing system...</span>
@@ -71,7 +71,7 @@ export function ProductionReadiness() {
 
   if (error || !data) {
     return (
-      <div className="bg-white rounded-xl p-6">
+      <div className="bg-white rounded-xl p-6 dark:bg-surface-900">
         <div className="text-center py-8">
           <ExclamationTriangleIcon className="h-12 w-12 mx-auto text-yellow-500 mb-3" />
           <p className="text-foreground/60">{error || 'Unable to load data'}</p>
@@ -93,7 +93,7 @@ export function ProductionReadiness() {
     data.score >= 80 ? 'bg-green-500/20' : data.score >= 60 ? 'bg-yellow-500/20' : 'bg-red-500/20';
 
   return (
-    <div className="bg-white rounded-xl overflow-hidden">
+    <div className="bg-white rounded-xl overflow-hidden dark:bg-surface-900">
       {/* Header with score */}
       <div className="p-6 border-b border-white/10">
         <div className="flex items-center justify-between">
@@ -108,7 +108,7 @@ export function ProductionReadiness() {
           </div>
           <button
             onClick={fetchReadiness}
-            className="p-2 hover:bg-white/10 rounded-lg text-foreground/60 hover:text-foreground"
+            className="p-2 hover:bg-white/10 rounded-lg text-foreground/60 hover:text-foreground dark:bg-surface-900/10 dark:hover:bg-surface-800/10"
             title="Refresh"
           >
             <ArrowPathIcon className="h-5 w-5" />

--- a/frontend/src/components/QuickActions.tsx
+++ b/frontend/src/components/QuickActions.tsx
@@ -72,7 +72,12 @@ export function QuickActions({ className }: QuickActionsProps) {
   ];
 
   return (
-    <div className={clsx('bg-white rounded-xl border border-surface-200 p-4', className)}>
+    <div
+      className={clsx(
+        'bg-white rounded-xl border border-surface-200 p-4 dark:bg-surface-900',
+        className
+      )}
+    >
       <h3 className="font-medium text-white mb-4 flex items-center gap-2">
         <PlusIcon className="w-5 h-5 text-brand-400" />
         Quick Actions
@@ -138,7 +143,7 @@ export function QuickActionsBar() {
   ];
 
   return (
-    <div className="flex items-center gap-2 bg-white/50 rounded-lg p-1">
+    <div className="flex items-center gap-2 bg-white/50 rounded-lg p-1 dark:bg-surface-900/50">
       {actions.map((action) => (
         <button
           key={action.id}

--- a/frontend/src/components/ReportDownloadButton.tsx
+++ b/frontend/src/components/ReportDownloadButton.tsx
@@ -153,7 +153,7 @@ export function ReportDownloadButton({
         leaveFrom="transform opacity-100 scale-100"
         leaveTo="transform opacity-0 scale-95"
       >
-        <Menu.Items className="absolute right-0 mt-2 w-72 origin-top-right rounded-lg bg-white border border-surface-200 shadow-lg focus:outline-none z-50">
+        <Menu.Items className="absolute right-0 mt-2 w-72 origin-top-right rounded-lg bg-white border border-surface-200 shadow-lg focus:outline-none z-50 dark:bg-surface-900">
           <div className="p-2">
             <p className="px-3 py-2 text-xs font-medium text-surface-600 uppercase tracking-wider">
               Download Reports

--- a/frontend/src/components/ScheduledReports.tsx
+++ b/frontend/src/components/ScheduledReports.tsx
@@ -168,7 +168,7 @@ export function ScheduledReports({ className }: ScheduledReportsProps) {
           <div className="animate-spin h-8 w-8 border-2 border-indigo-500 border-t-transparent rounded-full"></div>
         </div>
       ) : reports.length === 0 ? (
-        <div className="text-center py-12 bg-white border border-surface-200 rounded-xl">
+        <div className="text-center py-12 bg-white border border-surface-200 rounded-xl dark:bg-surface-900">
           <ClockIcon className="w-12 h-12 mx-auto text-surface-600 mb-4" />
           <h3 className="text-lg font-medium text-surface-700 mb-2">No scheduled reports</h3>
           <p className="text-surface-500 mb-4">
@@ -231,7 +231,7 @@ function ReportCard({ report, onEdit, onDelete, onToggle, onRunNow }: ReportCard
   return (
     <div
       className={clsx(
-        'bg-white border rounded-xl p-4',
+        'bg-white border rounded-xl p-4 dark:bg-surface-900',
         report.enabled ? 'border-surface-200' : 'border-surface-200/50 opacity-60'
       )}
     >

--- a/frontend/src/components/SessionWarning.tsx
+++ b/frontend/src/components/SessionWarning.tsx
@@ -89,14 +89,14 @@ export default function SessionWarning({
           <div className="flex-1">
             <h4 className="font-semibold">Session Expiring Soon</h4>
             <p className="text-sm text-yellow-100 mt-1">
-              Your session will expire in {formatTime(timeRemaining)}.
-              Save your work to avoid losing any changes.
+              Your session will expire in {formatTime(timeRemaining)}. Save your work to avoid
+              losing any changes.
             </p>
             <div className="flex gap-2 mt-3">
               {onExtendSession && (
                 <button
                   onClick={handleExtend}
-                  className="px-3 py-1.5 bg-white text-yellow-700 rounded text-sm font-medium hover:bg-yellow-50 transition-colors"
+                  className="px-3 py-1.5 bg-white text-yellow-700 rounded text-sm font-medium hover:bg-yellow-50 transition-colors dark:bg-surface-900"
                 >
                   Extend Session
                 </button>

--- a/frontend/src/components/SetupWizard.tsx
+++ b/frontend/src/components/SetupWizard.tsx
@@ -182,7 +182,7 @@ export function SetupWizard({ onClose }: { onClose: () => void }) {
           </div>
           <button
             onClick={onClose}
-            className="p-2 hover:bg-white/10 rounded-lg text-foreground/60 hover:text-foreground"
+            className="p-2 hover:bg-white/10 rounded-lg text-foreground/60 hover:text-foreground dark:bg-surface-900/10 dark:hover:bg-surface-800/10"
           >
             <XMarkIcon className="h-5 w-5" />
           </button>
@@ -217,7 +217,9 @@ export function SetupWizard({ onClose }: { onClose: () => void }) {
                   key={step.id}
                   onClick={() => setCurrentStep(index)}
                   className={`w-full text-left p-3 rounded-lg mb-2 transition-colors ${
-                    isActive ? 'bg-primary/20 border border-primary/50' : 'hover:bg-white/5'
+                    isActive
+                      ? 'bg-primary/20 border border-primary/50'
+                      : 'hover:bg-white/5 dark:bg-surface-900/5 dark:hover:bg-surface-800/5'
                   }`}
                 >
                   <div className="flex items-center gap-3">
@@ -299,7 +301,7 @@ export function SetupWizard({ onClose }: { onClose: () => void }) {
                     </div>
 
                     {currentStepData.commands && currentStepData.commands.length > 0 && (
-                      <div className="bg-white rounded-lg p-4">
+                      <div className="bg-white rounded-lg p-4 dark:bg-surface-900">
                         <h4 className="text-sm font-medium text-foreground mb-3">Commands</h4>
                         <div className="space-y-2">
                           {currentStepData.commands.map((command, i) => (

--- a/frontend/src/components/Skeleton.tsx
+++ b/frontend/src/components/Skeleton.tsx
@@ -18,7 +18,12 @@ export function SkeletonSubtitle({ className }: { className?: string }) {
 
 export function SkeletonCard({ className }: { className?: string }) {
   return (
-    <div className={clsx('bg-white border border-surface-200 rounded-lg p-6 space-y-4', className)}>
+    <div
+      className={clsx(
+        'bg-white border border-surface-200 rounded-lg p-6 space-y-4 dark:bg-surface-900',
+        className
+      )}
+    >
       <div className="flex items-center space-x-4">
         <Skeleton shape="circle" className="h-12 w-12" />
         <div className="space-y-2 flex-1">
@@ -37,7 +42,12 @@ export function SkeletonCard({ className }: { className?: string }) {
 
 export function SkeletonStatCard({ className }: { className?: string }) {
   return (
-    <div className={clsx('bg-white border border-surface-200 rounded-lg p-6', className)}>
+    <div
+      className={clsx(
+        'bg-white border border-surface-200 rounded-lg p-6 dark:bg-surface-900',
+        className
+      )}
+    >
       <Skeleton className="h-4 w-24 mb-2" />
       <Skeleton className="h-10 w-16 mb-1" />
       <Skeleton className="h-3 w-20" />
@@ -64,7 +74,10 @@ interface SkeletonTableProps {
 export function SkeletonTable({ rows = 5, columns = 5, className }: SkeletonTableProps) {
   return (
     <div
-      className={clsx('bg-white border border-surface-200 rounded-lg overflow-hidden', className)}
+      className={clsx(
+        'bg-white border border-surface-200 rounded-lg overflow-hidden dark:bg-surface-900',
+        className
+      )}
     >
       <div className="border-b border-surface-200 bg-surface-50 px-6 py-3">
         <div className="flex space-x-4">
@@ -179,7 +192,12 @@ export function SkeletonDetailSection({
   className?: string;
 }) {
   return (
-    <div className={clsx('bg-white border border-surface-200 rounded-lg p-6 space-y-4', className)}>
+    <div
+      className={clsx(
+        'bg-white border border-surface-200 rounded-lg p-6 space-y-4 dark:bg-surface-900',
+        className
+      )}
+    >
       {title && <Skeleton className="h-6 w-32 mb-4" />}
       <SkeletonText lines={4} />
     </div>
@@ -199,11 +217,11 @@ export function SkeletonDashboard({ className }: { className?: string }) {
         ))}
       </div>
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <div className="bg-white border border-surface-200 rounded-lg p-6">
+        <div className="bg-white border border-surface-200 rounded-lg p-6 dark:bg-surface-900">
           <Skeleton className="h-6 w-40 mb-4" />
           <Skeleton className="h-56 w-full" />
         </div>
-        <div className="bg-white border border-surface-200 rounded-lg p-6">
+        <div className="bg-white border border-surface-200 rounded-lg p-6 dark:bg-surface-900">
           <Skeleton className="h-6 w-40 mb-4" />
           <Skeleton className="h-44 w-full" />
           <div className="flex justify-center gap-4 mt-4">
@@ -214,11 +232,11 @@ export function SkeletonDashboard({ className }: { className?: string }) {
         </div>
       </div>
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <div className="bg-white border border-surface-200 rounded-lg p-6">
+        <div className="bg-white border border-surface-200 rounded-lg p-6 dark:bg-surface-900">
           <Skeleton className="h-6 w-40 mb-4" />
           <Skeleton className="h-44 w-full" />
         </div>
-        <div className="bg-white border border-surface-200 rounded-lg p-6">
+        <div className="bg-white border border-surface-200 rounded-lg p-6 dark:bg-surface-900">
           <Skeleton className="h-6 w-48 mb-4" />
           <div className="space-y-3">
             {Array.from({ length: 6 }).map((_, i) => (

--- a/frontend/src/components/SystemHealthBanner.tsx
+++ b/frontend/src/components/SystemHealthBanner.tsx
@@ -113,7 +113,7 @@ export function SystemHealthBanner() {
             </p>
           </div>
         </div>
-        <button className="p-1 hover:bg-white/10 rounded">
+        <button className="p-1 hover:bg-white/10 rounded dark:bg-surface-900/10 dark:hover:bg-surface-800/10">
           {expanded ? (
             <ChevronUpIcon className="h-5 w-5" />
           ) : (
@@ -203,7 +203,7 @@ function WarningItem({ warning, onDismiss }: { warning: SystemWarning; onDismiss
             e.stopPropagation();
             onDismiss();
           }}
-          className="p-1 hover:bg-white/10 rounded text-foreground/50 hover:text-foreground"
+          className="p-1 hover:bg-white/10 rounded text-foreground/50 hover:text-foreground dark:bg-surface-900/10 dark:hover:bg-surface-800/10"
           title="Dismiss for this session"
         >
           <XMarkIcon className="h-4 w-4" />

--- a/frontend/src/components/TasksPanel.tsx
+++ b/frontend/src/components/TasksPanel.tsx
@@ -374,7 +374,7 @@ function TaskCard({
   return (
     <div
       className={clsx(
-        'card p-3 cursor-pointer hover:bg-white transition-colors',
+        'card p-3 cursor-pointer hover:bg-white transition-colors dark:bg-surface-900 dark:hover:bg-surface-800',
         task.status === 'completed' && 'opacity-60'
       )}
       onClick={onEdit}

--- a/frontend/src/components/VirtualTable.tsx
+++ b/frontend/src/components/VirtualTable.tsx
@@ -63,7 +63,7 @@ function VirtualTableInner<T>({
     return (
       <div className={clsx('card overflow-hidden', className)}>
         <div className="animate-pulse">
-          <div className="h-12 bg-white border-b border-surface-200" />
+          <div className="h-12 bg-white border-b border-surface-200 dark:bg-surface-900" />
           {Array.from({ length: 10 }).map((_, i) => (
             <div key={i} className="h-13 border-b border-surface-200 flex items-center px-4 gap-4">
               <div className="h-4 bg-surface-200 rounded w-1/4" />
@@ -92,7 +92,7 @@ function VirtualTableInner<T>({
       {/* Fixed header */}
       <div
         className={clsx(
-          'flex items-center bg-white border-b border-surface-200 sticky top-0 z-10',
+          'flex items-center bg-white border-b border-surface-200 sticky top-0 z-10 dark:bg-surface-900',
           headerClassName
         )}
         style={{ height: rowHeight }}
@@ -135,7 +135,8 @@ function VirtualTableInner<T>({
                 data-index={virtualRow.index}
                 className={clsx(
                   'absolute top-0 left-0 w-full flex items-center border-b border-surface-200 transition-colors',
-                  onRowClick && 'cursor-pointer hover:bg-white/50',
+                  onRowClick &&
+                    'cursor-pointer hover:bg-white/50 dark:bg-surface-900/50 dark:hover:bg-surface-800/50',
                   isSelected && 'bg-brand-500/10',
                   rowClasses
                 )}

--- a/frontend/src/components/VirtualizedTable.tsx
+++ b/frontend/src/components/VirtualizedTable.tsx
@@ -125,7 +125,7 @@ export function VirtualizedTable<T>({
       {/* Header */}
       <div
         className={clsx(
-          'flex bg-white border-b border-surface-200',
+          'flex bg-white border-b border-surface-200 dark:bg-surface-900',
           stickyHeader && 'sticky top-0 z-10'
         )}
         style={{ minHeight: rowHeight }}
@@ -181,7 +181,8 @@ export function VirtualizedTable<T>({
                 data-index={virtualRow.index}
                 className={clsx(
                   'flex absolute top-0 left-0 w-full border-b border-surface-200 transition-colors',
-                  onRowClick && 'cursor-pointer hover:bg-white/50',
+                  onRowClick &&
+                    'cursor-pointer hover:bg-white/50 dark:bg-surface-900/50 dark:hover:bg-surface-800/50',
                   isSelected && 'bg-brand-500/10'
                 )}
                 style={{
@@ -226,7 +227,7 @@ export function VirtualizedTable<T>({
       </div>
 
       {/* Footer with count */}
-      <div className="flex items-center justify-between px-4 py-2 bg-white/50 border-t border-surface-200 text-xs text-muted-foreground">
+      <div className="flex items-center justify-between px-4 py-2 bg-white/50 border-t border-surface-200 text-xs text-muted-foreground dark:bg-surface-900/50">
         <span>
           {selectedIds && selectedIds.size > 0
             ? `${selectedIds.size} of ${data.length} selected`

--- a/frontend/src/components/WorkspaceSwitcher.tsx
+++ b/frontend/src/components/WorkspaceSwitcher.tsx
@@ -127,7 +127,7 @@ export function WorkspaceSwitcher() {
   return (
     <>
       <Menu as="div" className="relative">
-        <Menu.Button className="flex items-center gap-2 px-3 py-2 rounded-lg bg-white hover:bg-surface-200 border border-surface-300 transition-colors text-sm text-foreground">
+        <Menu.Button className="flex items-center gap-2 px-3 py-2 rounded-lg bg-white hover:bg-surface-200 border border-surface-300 transition-colors text-sm text-foreground dark:bg-surface-900">
           <BuildingOfficeIcon className="w-4 h-4 text-surface-700" />
           <span className="font-medium max-w-[160px] truncate">
             {currentWorkspace?.name || 'Select Workspace'}
@@ -144,7 +144,7 @@ export function WorkspaceSwitcher() {
           leaveFrom="transform opacity-100 scale-100"
           leaveTo="transform opacity-0 scale-95"
         >
-          <Menu.Items className="absolute left-0 mt-2 w-64 rounded-lg bg-white border border-surface-200 shadow-lg z-50 py-1 focus:outline-none">
+          <Menu.Items className="absolute left-0 mt-2 w-64 rounded-lg bg-white border border-surface-200 shadow-lg z-50 py-1 focus:outline-none dark:bg-surface-900">
             {/* Workspace List */}
             <div className="px-2 py-1">
               <p className="text-xs text-muted-foreground uppercase tracking-wider px-2 py-1">

--- a/frontend/src/components/ai/AIAssistantPanel.tsx
+++ b/frontend/src/components/ai/AIAssistantPanel.tsx
@@ -94,7 +94,7 @@ export default function AIAssistantPanel({ isOpen, onClose }: AIAssistantPanelPr
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-y-0 right-0 w-96 bg-white border-l border-surface-200 shadow-2xl z-50 flex flex-col">
+    <div className="fixed inset-y-0 right-0 w-96 bg-white border-l border-surface-200 shadow-2xl z-50 flex flex-col dark:bg-surface-900">
       {/* Header */}
       <div className="flex items-center justify-between p-4 border-b border-surface-200">
         <div className="flex items-center gap-3">
@@ -110,7 +110,7 @@ export default function AIAssistantPanel({ isOpen, onClose }: AIAssistantPanelPr
         </div>
         <button
           onClick={onClose}
-          className="p-1.5 text-surface-600 hover:text-white rounded-lg hover:bg-white transition-colors"
+          className="p-1.5 text-surface-600 hover:text-white rounded-lg hover:bg-white transition-colors dark:bg-surface-900 dark:hover:bg-surface-800"
         >
           <XMarkIcon className="w-5 h-5" />
         </button>
@@ -162,7 +162,7 @@ export default function AIAssistantPanel({ isOpen, onClose }: AIAssistantPanelPr
 
       {/* Mock Mode Info Banner */}
       {isMockMode && (
-        <div className="mx-4 mt-2 p-2 rounded-lg bg-white/50 border border-surface-200">
+        <div className="mx-4 mt-2 p-2 rounded-lg bg-white/50 border border-surface-200 dark:bg-surface-900/50">
           <p className="text-xs text-surface-600">
             <span className="text-amber-600 font-medium">Demo Mode:</span> AI responses are
             generated from policy templates. Perfect for testing and demonstrations. Add an API key
@@ -182,7 +182,7 @@ export default function AIAssistantPanel({ isOpen, onClose }: AIAssistantPanelPr
               className={clsx(
                 'w-full p-4 rounded-xl border transition-all text-left group',
                 isUsable
-                  ? 'border-surface-200 hover:border-purple-500/50 hover:bg-white/50'
+                  ? 'border-surface-200 hover:border-purple-500/50 hover:bg-white/50 dark:bg-surface-900/50 dark:hover:bg-surface-800/50'
                   : 'border-surface-200 opacity-50 cursor-not-allowed',
                 selectedFeature === feature.id && 'border-purple-500 bg-purple-500/10'
               )}
@@ -235,7 +235,7 @@ export default function AIAssistantPanel({ isOpen, onClose }: AIAssistantPanelPr
       )}
 
       {/* Quick Tip */}
-      <div className="p-4 border-t border-surface-200 bg-white/50">
+      <div className="p-4 border-t border-surface-200 bg-white/50 dark:bg-surface-900/50">
         <p className="text-xs text-surface-600">
           <span className="text-purple-600 font-medium">Tip:</span> AI features are also available
           directly in forms. Look for the{' '}
@@ -418,10 +418,10 @@ function SettingsPanel({ config, isMockMode, mockModeReason }: SettingsPanelProp
 
       <p className="text-xs text-surface-500 mt-2">
         To enable full AI capabilities, set environment variables:
-        <code className="block mt-1 p-2 bg-white rounded text-surface-700">
+        <code className="block mt-1 p-2 bg-white rounded text-surface-700 dark:bg-surface-900">
           OPENAI_API_KEY=sk-...
         </code>
-        <code className="block mt-1 p-2 bg-white rounded text-surface-700">
+        <code className="block mt-1 p-2 bg-white rounded text-surface-700 dark:bg-surface-900">
           ANTHROPIC_API_KEY=sk-ant-...
         </code>
       </p>

--- a/frontend/src/components/ai/AICategorization.tsx
+++ b/frontend/src/components/ai/AICategorization.tsx
@@ -102,7 +102,7 @@ export default function AICategorization({
             <div className="text-xs text-surface-600">Suggested Category</div>
             <button
               onClick={() => handleSelectCategory(result.suggestedCategory)}
-              className="w-full flex items-center justify-between p-2 bg-white/50 hover:bg-white rounded-lg transition-colors group"
+              className="w-full flex items-center justify-between p-2 bg-white/50 hover:bg-white rounded-lg transition-colors group dark:bg-surface-900/50 dark:hover:bg-surface-800"
             >
               <div className="flex items-center gap-2">
                 <span className="text-white font-medium">{result.suggestedCategory}</span>
@@ -129,7 +129,7 @@ export default function AICategorization({
                   <button
                     key={i}
                     onClick={() => handleSelectCategory(alt.category)}
-                    className="w-full flex items-center justify-between p-2 bg-white/30 hover:bg-white/50 rounded-lg transition-colors text-sm group"
+                    className="w-full flex items-center justify-between p-2 bg-white/30 hover:bg-white/50 rounded-lg transition-colors text-sm group dark:bg-surface-900/30 dark:hover:bg-surface-800/50"
                   >
                     <span className="text-surface-700">{alt.category}</span>
                     <div className="flex items-center gap-2">

--- a/frontend/src/components/ai/AIRiskScoring.tsx
+++ b/frontend/src/components/ai/AIRiskScoring.tsx
@@ -123,7 +123,7 @@ export default function AIRiskScoring({
         <div className="p-4 space-y-4">
           {/* Scores */}
           <div className="grid grid-cols-2 gap-4">
-            <div className="bg-white/50 rounded-lg p-3">
+            <div className="bg-white/50 rounded-lg p-3 dark:bg-surface-900/50">
               <div className="text-xs text-surface-600 mb-1">Suggested Likelihood</div>
               <div className="flex items-center gap-2">
                 <div
@@ -141,7 +141,7 @@ export default function AIRiskScoring({
               <p className="text-xs text-surface-600 mt-2">{result.likelihoodRationale}</p>
             </div>
 
-            <div className="bg-white/50 rounded-lg p-3">
+            <div className="bg-white/50 rounded-lg p-3 dark:bg-surface-900/50">
               <div className="text-xs text-surface-600 mb-1">Suggested Impact</div>
               <div className="flex items-center gap-2">
                 <div

--- a/frontend/src/components/ai/AISmartSearch.tsx
+++ b/frontend/src/components/ai/AISmartSearch.tsx
@@ -108,7 +108,7 @@ export default function AISmartSearch({
           onChange={(e) => handleInputChange(e.target.value)}
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
-          className="w-full pl-10 pr-24 py-3 bg-white border border-surface-200 rounded-xl text-white placeholder-surface-500 focus:outline-none focus:ring-2 focus:ring-purple-500/50 focus:border-purple-500 transition-all"
+          className="w-full pl-10 pr-24 py-3 bg-white border border-surface-200 rounded-xl text-white placeholder-surface-500 focus:outline-none focus:ring-2 focus:ring-purple-500/50 focus:border-purple-500 transition-all dark:bg-surface-900"
         />
 
         <div className="absolute inset-y-0 right-0 flex items-center gap-1 pr-2">
@@ -133,7 +133,7 @@ export default function AISmartSearch({
       </div>
       {/* Entity Filters */}
       {showFilters && (
-        <div className="flex flex-wrap gap-2 p-3 bg-white/50 rounded-lg border border-surface-200">
+        <div className="flex flex-wrap gap-2 p-3 bg-white/50 rounded-lg border border-surface-200 dark:bg-surface-900/50">
           <span className="text-xs text-surface-600 mr-2 self-center">Search in:</span>
           {ENTITY_OPTIONS.map((option) => (
             <button

--- a/frontend/src/components/bcdr/BIAWizard.tsx
+++ b/frontend/src/components/bcdr/BIAWizard.tsx
@@ -60,7 +60,12 @@ interface WizardState {
 // ============================================
 
 const IMPACT_OPTIONS = [
-  { value: 'none', label: 'None', description: 'No measurable impact', color: 'bg-gray-500' },
+  {
+    value: 'none',
+    label: 'None',
+    description: 'No measurable impact',
+    color: 'bg-gray-500 dark:bg-surface-500',
+  },
   {
     value: 'minor',
     label: 'Minor',
@@ -602,7 +607,12 @@ export function BIAWizard({
               const option = IMPACT_OPTIONS.find((o) => o.value === item.value);
               return (
                 <div key={item.label} className="flex items-center gap-2">
-                  <div className={clsx('w-3 h-3 rounded-full', option?.color || 'bg-gray-500')} />
+                  <div
+                    className={clsx(
+                      'w-3 h-3 rounded-full',
+                      option?.color || 'bg-gray-500 dark:bg-surface-500'
+                    )}
+                  />
                   <span className="text-slate-400">{item.label}:</span>
                   <span className="text-white capitalize">{item.value}</span>
                 </div>

--- a/frontend/src/components/bcdr/DeclareIncidentModal.tsx
+++ b/frontend/src/components/bcdr/DeclareIncidentModal.tsx
@@ -173,7 +173,7 @@ export function DeclareIncidentModal({ onClose, onComplete }: DeclareIncidentMod
                   'p-3 rounded-md border-2 text-left transition-all',
                   incidentType === type.value
                     ? 'border-brand-500 bg-brand-50'
-                    : 'border-surface-300 bg-white hover:border-surface-400'
+                    : 'border-surface-300 bg-white hover:border-surface-400 dark:bg-surface-900'
                 )}
               >
                 <span className="text-sm font-medium text-surface-900">{type.label}</span>
@@ -197,7 +197,7 @@ export function DeclareIncidentModal({ onClose, onComplete }: DeclareIncidentMod
                   'w-full p-3 rounded-md border-2 text-left transition-all flex items-center gap-3',
                   severity === level.value
                     ? 'border-brand-500 bg-brand-50'
-                    : 'border-surface-300 bg-white hover:border-surface-400'
+                    : 'border-surface-300 bg-white hover:border-surface-400 dark:bg-surface-900'
                 )}
               >
                 <div className={clsx('w-3 h-3 rounded-full', level.color)} />

--- a/frontend/src/components/config-as-code/ConfigIDE.tsx
+++ b/frontend/src/components/config-as-code/ConfigIDE.tsx
@@ -426,9 +426,9 @@ export default function ConfigIDE({ workspaceId }: Props) {
   }
 
   return (
-    <div className="flex h-[calc(100vh-200px)] border border-surface-200 rounded-lg overflow-hidden bg-white">
+    <div className="flex h-[calc(100vh-200px)] border border-surface-200 rounded-lg overflow-hidden bg-white dark:bg-surface-900">
       {/* File Explorer Sidebar */}
-      <div className="w-64 border-r border-surface-200 bg-white overflow-y-auto">
+      <div className="w-64 border-r border-surface-200 bg-white overflow-y-auto dark:bg-surface-900">
         <div className="p-4 border-b border-surface-200">
           <div className="flex items-center justify-between mb-2">
             <h3 className="text-sm font-semibold text-surface-800">Files</h3>
@@ -562,7 +562,7 @@ export default function ConfigIDE({ workspaceId }: Props) {
         {selectedFile ? (
           <>
             {/* Editor Header */}
-            <div className="h-12 border-b border-surface-200 bg-white flex items-center justify-between px-4">
+            <div className="h-12 border-b border-surface-200 bg-white flex items-center justify-between px-4 dark:bg-surface-900">
               <div className="flex items-center gap-2">
                 <DocumentTextIcon className="w-5 h-5 text-surface-600" />
                 <span className="text-sm font-medium text-surface-800">{selectedFile}</span>
@@ -656,7 +656,7 @@ export default function ConfigIDE({ workspaceId }: Props) {
 
             {/* Preview Panel */}
             {previewData && (
-              <div className="h-48 border-t border-surface-200 bg-white p-4 overflow-y-auto">
+              <div className="h-48 border-t border-surface-200 bg-white p-4 overflow-y-auto dark:bg-surface-900">
                 <div className="flex items-center gap-2 mb-2">
                   <EyeIcon className="w-5 h-5 text-brand-400" />
                   <h4 className="font-semibold text-surface-800">Preview Changes</h4>

--- a/frontend/src/components/controls/CollectorConfigModal.tsx
+++ b/frontend/src/components/controls/CollectorConfigModal.tsx
@@ -677,7 +677,7 @@ export default function CollectorConfigModal({
                   {testResult.message}
                 </p>
                 {testResult.data && (
-                  <pre className="mt-2 p-2 bg-white/50 rounded text-xs text-surface-600 overflow-auto max-h-32">
+                  <pre className="mt-2 p-2 bg-white/50 rounded text-xs text-surface-600 overflow-auto max-h-32 dark:bg-surface-900/50">
                     {JSON.stringify(testResult.data, null, 2)}
                   </pre>
                 )}
@@ -688,7 +688,7 @@ export default function CollectorConfigModal({
       </div>
 
       {/* Footer */}
-      <div className="flex items-center justify-between px-6 py-4 border-t border-surface-200 bg-white/50">
+      <div className="flex items-center justify-between px-6 py-4 border-t border-surface-200 bg-white/50 dark:bg-surface-900/50">
         <div>
           {isEditing && (
             <Button

--- a/frontend/src/components/controls/ControlEvidencePanel.tsx
+++ b/frontend/src/components/controls/ControlEvidencePanel.tsx
@@ -27,7 +27,7 @@ export default function ControlEvidencePanel({
   };
 
   return (
-    <div className="bg-white rounded-lg border border-surface-200 p-6">
+    <div className="bg-white rounded-lg border border-surface-200 p-6 dark:bg-surface-900">
       <div className="flex items-center justify-between mb-4">
         <h3 className="text-lg font-medium text-white">Evidence</h3>
         <Link
@@ -55,7 +55,7 @@ export default function ControlEvidencePanel({
           {evidence.map((item) => (
             <div
               key={item.id}
-              className="flex items-center justify-between p-3 bg-white rounded-lg"
+              className="flex items-center justify-between p-3 bg-white rounded-lg dark:bg-surface-900"
             >
               <Link
                 to={`/evidence/${item.id}`}

--- a/frontend/src/components/controls/ControlImplementationCard.tsx
+++ b/frontend/src/components/controls/ControlImplementationCard.tsx
@@ -46,7 +46,7 @@ const STATUS_OPTIONS = [
   { value: 'not_started', label: 'Not Started', color: 'bg-surface-500' },
   { value: 'in_progress', label: 'In Progress', color: 'bg-amber-500' },
   { value: 'implemented', label: 'Implemented', color: 'bg-emerald-500' },
-  { value: 'not_applicable', label: 'Not Applicable', color: 'bg-gray-500' },
+  { value: 'not_applicable', label: 'Not Applicable', color: 'bg-gray-500 dark:bg-surface-500' },
 ];
 
 const FREQUENCY_OPTIONS = [
@@ -111,7 +111,7 @@ export default function ControlImplementationCard({
   };
 
   return (
-    <div className="bg-white rounded-lg border border-surface-200 p-6">
+    <div className="bg-white rounded-lg border border-surface-200 p-6 dark:bg-surface-900">
       <div className="flex items-center justify-between mb-4">
         <h3 className="text-lg font-medium text-white">Implementation Status</h3>
         {!isEditing && (

--- a/frontend/src/components/controls/EvidenceCollectors.tsx
+++ b/frontend/src/components/controls/EvidenceCollectors.tsx
@@ -204,7 +204,7 @@ function CollectorCard({
     <div className="border border-surface-200 rounded-lg overflow-hidden">
       {/* Header */}
       <div
-        className="flex items-center justify-between p-4 bg-white/50 cursor-pointer"
+        className="flex items-center justify-between p-4 bg-white/50 cursor-pointer dark:bg-surface-900/50"
         onClick={onToggle}
       >
         <div className="flex items-center gap-3">
@@ -329,7 +329,7 @@ function CollectorCard({
 
           {/* Schedule Info */}
           {collector.scheduleEnabled && (
-            <div className="p-3 bg-white/50 rounded-lg">
+            <div className="p-3 bg-white/50 rounded-lg dark:bg-surface-900/50">
               <div className="flex items-center gap-2 text-sm">
                 <ClockIcon className="w-4 h-4 text-surface-500" />
                 <span className="text-surface-700">
@@ -355,7 +355,7 @@ function CollectorCard({
                   return (
                     <div
                       key={run.id}
-                      className="flex items-center justify-between p-2 bg-white/30 rounded text-xs"
+                      className="flex items-center justify-between p-2 bg-white/30 rounded text-xs dark:bg-surface-900/30"
                     >
                       <div className="flex items-center gap-2">
                         <RunIcon className={clsx('w-4 h-4', statusConfig[runStatus]?.color)} />

--- a/frontend/src/components/dashboard/DashboardHeader.tsx
+++ b/frontend/src/components/dashboard/DashboardHeader.tsx
@@ -1,6 +1,6 @@
 /**
  * Dashboard Header Component
- * 
+ *
  * Displays the dashboard title, customization controls, and report download button.
  */
 
@@ -24,30 +24,30 @@ export const DashboardHeader = memo(function DashboardHeader({
   return (
     <div className="flex justify-between items-center mb-6">
       <div>
-        <h1 className="text-2xl font-bold text-gray-900">Dashboard</h1>
-        <p className="text-sm text-gray-500 mt-1">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-surface-50">Dashboard</h1>
+        <p className="text-sm text-gray-500 mt-1 dark:text-surface-400">
           Overview of your GRC program status
         </p>
       </div>
       <div className="flex items-center gap-3">
         <ReportDownloadButton />
-        
+
         {showCustomDashboards && onOpenCustomDashboards && (
           <button
             onClick={onOpenCustomDashboards}
-            className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+            className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors dark:bg-surface-900 dark:hover:bg-surface-900 dark:text-surface-200 dark:border-surface-700"
           >
             <Squares2X2Icon className="w-5 h-5" />
             Custom Dashboards
           </button>
         )}
-        
+
         <button
           onClick={onToggleCustomize}
           className={`inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg transition-colors ${
             isCustomizing
               ? 'bg-indigo-600 text-white hover:bg-indigo-700'
-              : 'bg-white text-gray-700 border border-gray-300 hover:bg-gray-50'
+              : 'bg-white text-gray-700 border border-gray-300 hover:bg-gray-50 dark:bg-surface-900 dark:hover:bg-surface-900 dark:text-surface-200 dark:border-surface-700'
           }`}
         >
           {isCustomizing ? (

--- a/frontend/src/components/dashboard/DashboardStats.tsx
+++ b/frontend/src/components/dashboard/DashboardStats.tsx
@@ -1,6 +1,6 @@
 /**
  * Dashboard Stats Component
- * 
+ *
  * Displays the main statistics cards at the top of the dashboard.
  */
 
@@ -88,25 +88,23 @@ const StatCard = memo(function StatCard({
   href,
 }: StatCardProps) {
   const colors = colorClasses[color];
-  
+
   return (
     <Link
       to={href}
-      className="bg-white rounded-xl shadow-sm border border-gray-200 p-5 hover:shadow-md transition-all hover:border-gray-300 group"
+      className="bg-white rounded-xl shadow-sm border border-gray-200 p-5 hover:shadow-md transition-all hover:border-gray-300 group dark:bg-surface-900 dark:border-surface-800"
     >
       <div className="flex items-start justify-between">
         <div>
-          <p className="text-sm font-medium text-gray-600">{title}</p>
-          <p className="text-2xl font-bold text-gray-900 mt-1">{value}</p>
-          {subValue && (
-            <p className={clsx('text-sm mt-1', colors.text)}>{subValue}</p>
-          )}
+          <p className="text-sm font-medium text-gray-600 dark:text-surface-300">{title}</p>
+          <p className="text-2xl font-bold text-gray-900 mt-1 dark:text-surface-50">{value}</p>
+          {subValue && <p className={clsx('text-sm mt-1', colors.text)}>{subValue}</p>}
         </div>
         <div className={clsx('p-3 rounded-lg', colors.bg)}>
           <Icon className={clsx('w-6 h-6', colors.text)} />
         </div>
       </div>
-      <div className="mt-3 flex items-center text-sm text-gray-500 group-hover:text-indigo-600 transition-colors">
+      <div className="mt-3 flex items-center text-sm text-gray-500 group-hover:text-indigo-600 transition-colors dark:text-surface-400">
         <span>View details</span>
         <ChevronRightIcon className="w-4 h-4 ml-1 group-hover:translate-x-1 transition-transform" />
       </div>
@@ -127,9 +125,10 @@ export const DashboardStats = memo(function DashboardStats({
     return null;
   }
 
-  const controlsImplemented = data.controls.total > 0
-    ? Math.round((data.controls.implemented / data.controls.total) * 100)
-    : 0;
+  const controlsImplemented =
+    data.controls.total > 0
+      ? Math.round((data.controls.implemented / data.controls.total) * 100)
+      : 0;
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4 mb-6">
@@ -144,7 +143,9 @@ export const DashboardStats = memo(function DashboardStats({
       <StatCard
         title="Evidence"
         value={data.evidence.total}
-        subValue={data.evidence.expiringSoon > 0 ? `${data.evidence.expiringSoon} expiring soon` : undefined}
+        subValue={
+          data.evidence.expiringSoon > 0 ? `${data.evidence.expiringSoon} expiring soon` : undefined
+        }
         icon={FolderOpenIcon}
         color="green"
         href="/evidence"
@@ -152,7 +153,11 @@ export const DashboardStats = memo(function DashboardStats({
       <StatCard
         title="Risks"
         value={data.risks.total}
-        subValue={data.risks.high + data.risks.critical > 0 ? `${data.risks.high + data.risks.critical} high/critical` : 'No high risks'}
+        subValue={
+          data.risks.high + data.risks.critical > 0
+            ? `${data.risks.high + data.risks.critical} high/critical`
+            : 'No high risks'
+        }
         icon={ExclamationTriangleIcon}
         color={data.risks.high + data.risks.critical > 0 ? 'red' : 'yellow'}
         href="/risks"
@@ -168,7 +173,11 @@ export const DashboardStats = memo(function DashboardStats({
       <StatCard
         title="Policies"
         value={data.policies.total}
-        subValue={data.policies.pendingReview > 0 ? `${data.policies.pendingReview} pending review` : `${data.policies.active} active`}
+        subValue={
+          data.policies.pendingReview > 0
+            ? `${data.policies.pendingReview} pending review`
+            : `${data.policies.active} active`
+        }
         icon={DocumentTextIcon}
         color="blue"
         href="/policies"

--- a/frontend/src/components/dashboard/DashboardWidgetToggle.tsx
+++ b/frontend/src/components/dashboard/DashboardWidgetToggle.tsx
@@ -1,6 +1,6 @@
 /**
  * Dashboard Widget Toggle Component
- * 
+ *
  * Displays a customization panel for toggling dashboard widgets on/off.
  */
 
@@ -70,15 +70,15 @@ export const DashboardWidgetToggle = memo(function DashboardWidgetToggle({
   }
 
   return (
-    <div className="mb-6 p-4 bg-gray-50 rounded-lg border border-gray-200">
-      <h3 className="text-sm font-medium text-gray-900 mb-3">
+    <div className="mb-6 p-4 bg-gray-50 rounded-lg border border-gray-200 dark:bg-surface-900 dark:border-surface-800">
+      <h3 className="text-sm font-medium text-gray-900 mb-3 dark:text-surface-50">
         Toggle Dashboard Widgets
       </h3>
       <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-2">
         {Object.entries(WIDGET_LABELS).map(([key, label]) => {
           const widgetKey = key as keyof DashboardConfig['widgets'];
           const isEnabled = config.widgets[widgetKey];
-          
+
           return (
             <button
               key={key}
@@ -87,14 +87,10 @@ export const DashboardWidgetToggle = memo(function DashboardWidgetToggle({
                 'flex items-center gap-2 px-3 py-2 text-sm rounded-lg transition-colors',
                 isEnabled
                   ? 'bg-indigo-100 text-indigo-700 hover:bg-indigo-200'
-                  : 'bg-gray-100 text-gray-500 hover:bg-gray-200'
+                  : 'bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-surface-800 dark:hover:bg-surface-700 dark:text-surface-400'
               )}
             >
-              {isEnabled ? (
-                <EyeIcon className="w-4 h-4" />
-              ) : (
-                <EyeSlashIcon className="w-4 h-4" />
-              )}
+              {isEnabled ? <EyeIcon className="w-4 h-4" /> : <EyeSlashIcon className="w-4 h-4" />}
               <span className="truncate">{label}</span>
             </button>
           );

--- a/frontend/src/components/dashboard/WorkspaceComparisonWidget.tsx
+++ b/frontend/src/components/dashboard/WorkspaceComparisonWidget.tsx
@@ -50,7 +50,7 @@ export function WorkspaceComparisonWidget() {
 
   if (isLoading) {
     return (
-      <div className="bg-white rounded-lg border border-surface-200 p-4">
+      <div className="bg-white rounded-lg border border-surface-200 p-4 dark:bg-surface-900">
         <div className="animate-pulse">
           <div className="h-5 bg-surface-200 rounded w-1/3 mb-4"></div>
           <div className="space-y-3">
@@ -79,7 +79,7 @@ export function WorkspaceComparisonWidget() {
   };
 
   return (
-    <div className="bg-white rounded-lg border border-surface-200 overflow-hidden">
+    <div className="bg-white rounded-lg border border-surface-200 overflow-hidden dark:bg-surface-900">
       {/* Header */}
       <div className="flex items-center justify-between p-4 border-b border-surface-200">
         <div className="flex items-center gap-2">
@@ -97,17 +97,17 @@ export function WorkspaceComparisonWidget() {
 
       {/* Org-wide Stats */}
       <div className="grid grid-cols-3 gap-px bg-surface-200">
-        <div className="bg-white p-3 text-center">
+        <div className="bg-white p-3 text-center dark:bg-surface-900">
           <p className="text-xs text-muted-foreground">Avg Score</p>
           <p className={`text-lg font-bold ${getScoreColor(data.avgComplianceScore)}`}>
             {data.avgComplianceScore}%
           </p>
         </div>
-        <div className="bg-white p-3 text-center">
+        <div className="bg-white p-3 text-center dark:bg-surface-900">
           <p className="text-xs text-muted-foreground">Total Controls</p>
           <p className="text-lg font-bold text-foreground">{data.totals.controls}</p>
         </div>
-        <div className="bg-white p-3 text-center">
+        <div className="bg-white p-3 text-center dark:bg-surface-900">
           <p className="text-xs text-muted-foreground">Total Risks</p>
           <p className="text-lg font-bold text-foreground">{data.totals.risks}</p>
         </div>

--- a/frontend/src/components/dashboards/TemplateGallery.tsx
+++ b/frontend/src/components/dashboards/TemplateGallery.tsx
@@ -66,7 +66,7 @@ export default function TemplateGallery({ onClose, onSelectTemplate }: TemplateG
             {templates?.map((template: Dashboard) => (
               <div
                 key={template.id}
-                className="bg-white border border-surface-200 rounded-lg p-4 hover:border-brand-500/50 transition-colors"
+                className="bg-white border border-surface-200 rounded-lg p-4 hover:border-brand-500/50 transition-colors dark:bg-surface-900"
               >
                 <div className="flex items-start justify-between mb-3">
                   <div>
@@ -83,7 +83,7 @@ export default function TemplateGallery({ onClose, onSelectTemplate }: TemplateG
                 </div>
 
                 {/* Widget preview */}
-                <div className="bg-white rounded p-3 mb-4">
+                <div className="bg-white rounded p-3 mb-4 dark:bg-surface-900">
                   <div className="grid grid-cols-4 gap-1 h-20">
                     {template.widgets?.slice(0, 8).map((widget, i) => (
                       <div

--- a/frontend/src/components/dashboards/WidgetConfigModal.tsx
+++ b/frontend/src/components/dashboards/WidgetConfigModal.tsx
@@ -218,7 +218,7 @@ export default function WidgetConfigModal({ widget, onSave, onClose }: WidgetCon
 
             {/* Preview Results */}
             {previewData && (
-              <div className="bg-white rounded-lg p-4">
+              <div className="bg-white rounded-lg p-4 dark:bg-surface-900">
                 <h4 className="text-sm font-medium text-surface-700 mb-2">
                   Preview ({previewData.length} results)
                 </h4>
@@ -240,7 +240,7 @@ export default function WidgetConfigModal({ widget, onSave, onClose }: WidgetCon
                   id="showLegend"
                   checked={config.showLegend || false}
                   onChange={(e) => setConfig({ ...config, showLegend: e.target.checked })}
-                  className="w-4 h-4 rounded border-surface-300 bg-white text-brand-500 focus:ring-brand-500"
+                  className="w-4 h-4 rounded border-surface-300 bg-white text-brand-500 focus:ring-brand-500 dark:bg-surface-900"
                 />
                 <label htmlFor="showLegend" className="text-sm text-surface-700">
                   Show Legend
@@ -256,7 +256,7 @@ export default function WidgetConfigModal({ widget, onSave, onClose }: WidgetCon
                   id="showValues"
                   checked={config.showValues || false}
                   onChange={(e) => setConfig({ ...config, showValues: e.target.checked })}
-                  className="w-4 h-4 rounded border-surface-300 bg-white text-brand-500 focus:ring-brand-500"
+                  className="w-4 h-4 rounded border-surface-300 bg-white text-brand-500 focus:ring-brand-500 dark:bg-surface-900"
                 />
                 <label htmlFor="showValues" className="text-sm text-surface-700">
                   Show Values on Chart

--- a/frontend/src/components/dashboards/WidgetContainer.tsx
+++ b/frontend/src/components/dashboards/WidgetContainer.tsx
@@ -44,12 +44,12 @@ export default function WidgetContainer({
   return (
     <div
       className={clsx(
-        'h-full w-full bg-white border border-surface-200 rounded-lg overflow-hidden flex flex-col',
+        'h-full w-full bg-white border border-surface-200 rounded-lg overflow-hidden flex flex-col dark:bg-surface-900',
         isEditing && 'ring-2 ring-brand-500/30'
       )}
     >
       {/* Header */}
-      <div className="flex items-center justify-between px-4 py-2 border-b border-surface-200 bg-white/50">
+      <div className="flex items-center justify-between px-4 py-2 border-b border-surface-200 bg-white/50 dark:bg-surface-900/50">
         <div className="flex items-center gap-2">
           {isEditing && (
             <div className="widget-drag-handle cursor-move p-1 hover:bg-surface-200 rounded">

--- a/frontend/src/components/dashboards/WidgetPalette.tsx
+++ b/frontend/src/components/dashboards/WidgetPalette.tsx
@@ -81,7 +81,7 @@ export default function WidgetPalette({ onSelect, onClose }: WidgetPaletteProps)
                     onClick={() => onSelect(widget.type)}
                     className={clsx(
                       'flex flex-col items-center p-4 rounded-lg border border-surface-200',
-                      'bg-white hover:bg-surface-200 hover:border-brand-500/50',
+                      'bg-white hover:bg-surface-200 hover:border-brand-500/50 dark:bg-surface-900',
                       'transition-all duration-200 text-left'
                     )}
                   >
@@ -104,7 +104,7 @@ export default function WidgetPalette({ onSelect, onClose }: WidgetPaletteProps)
       </div>
 
       {/* Footer */}
-      <div className="p-4 border-t border-surface-200 bg-white/50">
+      <div className="p-4 border-t border-surface-200 bg-white/50 dark:bg-surface-900/50">
         <p className="text-sm text-surface-500">
           Click a widget to add it to your dashboard. You can configure it after adding.
         </p>

--- a/frontend/src/components/dashboards/WidgetRenderer.tsx
+++ b/frontend/src/components/dashboards/WidgetRenderer.tsx
@@ -363,7 +363,10 @@ function TableWidget({ data, config }: { data: any[]; config: any }) {
         </thead>
         <tbody>
           {displayData.map((row, i) => (
-            <tr key={i} className="border-b border-surface-200 hover:bg-white/50">
+            <tr
+              key={i}
+              className="border-b border-surface-200 hover:bg-white/50 dark:bg-surface-900/50 dark:hover:bg-surface-800/50"
+            >
               {columns.map((col: any) => (
                 <td key={col.field} className="py-2 px-3 text-surface-600">
                   {formatValue(row[col.field])}
@@ -413,7 +416,7 @@ function ProgressWidget({ data, config }: { data: any[]; config: any }) {
         </span>
         <span className="text-surface-800 font-medium">{percentage}%</span>
       </div>
-      <div className="w-full h-3 bg-white rounded-full overflow-hidden">
+      <div className="w-full h-3 bg-white rounded-full overflow-hidden dark:bg-surface-900">
         <div
           className="h-full rounded-full transition-all duration-500"
           style={{ width: `${percentage}%`, backgroundColor: color }}
@@ -438,7 +441,7 @@ function ListWidget({ data, config: _config }: { data: any[]; config: any }) {
         return (
           <div
             key={i}
-            className="flex items-center justify-between p-2 bg-white/50 rounded hover:bg-white"
+            className="flex items-center justify-between p-2 bg-white/50 rounded hover:bg-white dark:bg-surface-900/50 dark:hover:bg-surface-800"
           >
             <span className="text-surface-800 truncate">{formatValue(displayFields[0]?.[1])}</span>
             {displayFields[1] && (

--- a/frontend/src/components/integrations/AdvancedBuilderTab.tsx
+++ b/frontend/src/components/integrations/AdvancedBuilderTab.tsx
@@ -147,7 +147,7 @@ export default function AdvancedBuilderTab({ config, onChange }: AdvancedBuilder
     return (
       <button
         onClick={() => toggleSection(section)}
-        className="w-full flex items-center justify-between p-4 bg-white/50 hover:bg-white transition-colors"
+        className="w-full flex items-center justify-between p-4 bg-white/50 hover:bg-white transition-colors dark:bg-surface-900/50 dark:hover:bg-surface-800"
       >
         <div className="flex items-center gap-2">
           {isExpanded ? (
@@ -197,7 +197,7 @@ export default function AdvancedBuilderTab({ config, onChange }: AdvancedBuilder
       <div>
         <SectionHeader section="auth" title="Authentication" />
         {expandedSections.has('auth') && (
-          <div className="p-6 bg-white/50">
+          <div className="p-6 bg-white/50 dark:bg-surface-900/50">
             <AuthConfigPanel config={config.authConfig} onChange={updateAuthConfig} />
           </div>
         )}
@@ -206,7 +206,7 @@ export default function AdvancedBuilderTab({ config, onChange }: AdvancedBuilder
       <div>
         <SectionHeader section="endpoints" title="API Endpoints" count={config.endpoints.length} />
         {expandedSections.has('endpoints') && (
-          <div className="p-6 bg-white/50">
+          <div className="p-6 bg-white/50 dark:bg-surface-900/50">
             <div className="flex flex-col lg:flex-row gap-6">
               {/* Endpoint List */}
               <div className="w-full lg:w-64 space-y-2">
@@ -218,7 +218,7 @@ export default function AdvancedBuilderTab({ config, onChange }: AdvancedBuilder
                       'w-full text-left p-3 rounded-lg border transition-colors',
                       selectedEndpointId === endpoint.id
                         ? 'bg-brand-500/10 border-brand-500/30'
-                        : 'bg-white border-surface-200 hover:border-surface-300'
+                        : 'bg-white border-surface-200 hover:border-surface-300 dark:bg-surface-900'
                     )}
                   >
                     <div className="flex items-center gap-2">
@@ -259,7 +259,7 @@ export default function AdvancedBuilderTab({ config, onChange }: AdvancedBuilder
                     onDelete={() => deleteEndpoint(selectedEndpoint.id)}
                   />
                 ) : (
-                  <div className="h-64 flex items-center justify-center text-surface-500 bg-white/50 rounded-lg border border-surface-200">
+                  <div className="h-64 flex items-center justify-center text-surface-500 bg-white/50 rounded-lg border border-surface-200 dark:bg-surface-900/50">
                     Select an endpoint to configure or add a new one
                   </div>
                 )}
@@ -276,7 +276,7 @@ export default function AdvancedBuilderTab({ config, onChange }: AdvancedBuilder
           count={config.responseMappings.length}
         />
         {expandedSections.has('mapping') && (
-          <div className="p-6 bg-white/50">
+          <div className="p-6 bg-white/50 dark:bg-surface-900/50">
             <ResponseMapper
               mappings={config.responseMappings}
               onChange={(mappings) => onChange({ ...config, responseMappings: mappings })}
@@ -289,7 +289,7 @@ export default function AdvancedBuilderTab({ config, onChange }: AdvancedBuilder
       <div>
         <SectionHeader section="testing" title="Test & Preview" />
         {expandedSections.has('testing') && (
-          <div className="p-6 bg-white/50">
+          <div className="p-6 bg-white/50 dark:bg-surface-900/50">
             <RequestTester
               endpoints={config.endpoints}
               authConfig={config.authConfig}

--- a/frontend/src/components/integrations/AuthConfigPanel.tsx
+++ b/frontend/src/components/integrations/AuthConfigPanel.tsx
@@ -88,7 +88,7 @@ export default function AuthConfigPanel({ config, onChange }: AuthConfigPanelPro
               className={`p-3 text-left rounded-lg border transition-colors ${
                 config.type === authType.value
                   ? 'bg-brand-500/10 border-brand-500/30 text-brand-400'
-                  : 'bg-white border-surface-200 hover:border-surface-300 text-surface-700'
+                  : 'bg-white border-surface-200 hover:border-surface-300 text-surface-700 dark:bg-surface-900'
               }`}
             >
               <div className="font-medium text-sm">{authType.label}</div>
@@ -99,7 +99,7 @@ export default function AuthConfigPanel({ config, onChange }: AuthConfigPanelPro
       </div>
       {/* API Key Configuration */}
       {config.type === 'api_key' && (
-        <div className="space-y-4 p-4 bg-white/50 rounded-lg border border-surface-200">
+        <div className="space-y-4 p-4 bg-white/50 rounded-lg border border-surface-200 dark:bg-surface-900/50">
           <div>
             <label className="text-sm text-surface-600 block mb-1.5">API Key</label>
             <Input
@@ -144,7 +144,7 @@ export default function AuthConfigPanel({ config, onChange }: AuthConfigPanelPro
       )}
       {/* Bearer Token Configuration */}
       {config.type === 'bearer' && (
-        <div className="space-y-4 p-4 bg-white/50 rounded-lg border border-surface-200">
+        <div className="space-y-4 p-4 bg-white/50 rounded-lg border border-surface-200 dark:bg-surface-900/50">
           <div>
             <label className="text-sm text-surface-600 block mb-1.5">Bearer Token</label>
             <Input
@@ -173,7 +173,7 @@ export default function AuthConfigPanel({ config, onChange }: AuthConfigPanelPro
       )}
       {/* Basic Auth Configuration */}
       {config.type === 'basic' && (
-        <div className="space-y-4 p-4 bg-white/50 rounded-lg border border-surface-200">
+        <div className="space-y-4 p-4 bg-white/50 rounded-lg border border-surface-200 dark:bg-surface-900/50">
           <div>
             <label className="text-sm text-surface-600 block mb-1.5">Username</label>
             <Input
@@ -202,7 +202,7 @@ export default function AuthConfigPanel({ config, onChange }: AuthConfigPanelPro
       )}
       {/* OAuth 2.0 Configuration */}
       {config.type === 'oauth2' && (
-        <div className="space-y-4 p-4 bg-white/50 rounded-lg border border-surface-200">
+        <div className="space-y-4 p-4 bg-white/50 rounded-lg border border-surface-200 dark:bg-surface-900/50">
           <div>
             <label className="text-sm text-surface-600 block mb-2">Grant Type</label>
             <div className="grid grid-cols-2 gap-2">
@@ -213,7 +213,7 @@ export default function AuthConfigPanel({ config, onChange }: AuthConfigPanelPro
                   className={`p-3 text-left rounded-lg border transition-colors ${
                     config.oauth2Config?.grantType === grant.value
                       ? 'bg-brand-500/10 border-brand-500/30'
-                      : 'bg-white border-surface-200 hover:border-surface-300'
+                      : 'bg-white border-surface-200 hover:border-surface-300 dark:bg-surface-900'
                   }`}
                 >
                   <div className="font-medium text-sm text-surface-800">{grant.label}</div>
@@ -269,7 +269,7 @@ export default function AuthConfigPanel({ config, onChange }: AuthConfigPanelPro
       )}
       {/* Custom Authentication */}
       {config.type === 'custom' && (
-        <div className="space-y-4 p-4 bg-white/50 rounded-lg border border-surface-200">
+        <div className="space-y-4 p-4 bg-white/50 rounded-lg border border-surface-200 dark:bg-surface-900/50">
           <div>
             <label className="text-sm text-surface-600 block mb-1.5">Header Name</label>
             <Input

--- a/frontend/src/components/integrations/CodeEditor.tsx
+++ b/frontend/src/components/integrations/CodeEditor.tsx
@@ -175,7 +175,7 @@ export default function CodeEditor({
   return (
     <div className="h-full flex flex-col">
       {/* Toolbar */}
-      <div className="flex items-center justify-between px-4 py-2 bg-white/50 border-b border-surface-200">
+      <div className="flex items-center justify-between px-4 py-2 bg-white/50 border-b border-surface-200 dark:bg-surface-900/50">
         <div className="flex items-center gap-2">
           <Button
             onClick={handleValidate}
@@ -223,7 +223,7 @@ export default function CodeEditor({
       </div>
       {/* Validation/Test Results */}
       {(validation || testResult) && (
-        <div className="px-4 py-2 bg-white/30 border-b border-surface-200">
+        <div className="px-4 py-2 bg-white/30 border-b border-surface-200 dark:bg-surface-900/30">
           {validation && (
             <div
               className={clsx(
@@ -275,7 +275,7 @@ export default function CodeEditor({
               <div>
                 <div>{testResult.message}</div>
                 {testResult.data && (
-                  <pre className="mt-2 p-2 bg-white rounded text-xs text-surface-700 overflow-auto max-h-32">
+                  <pre className="mt-2 p-2 bg-white rounded text-xs text-surface-700 overflow-auto max-h-32 dark:bg-surface-900">
                     {JSON.stringify(testResult.data, null, 2)}
                   </pre>
                 )}
@@ -305,7 +305,7 @@ export default function CodeEditor({
         />
       </div>
       {/* Help Text */}
-      <div className="px-4 py-2 bg-white/30 border-t border-surface-200 text-xs text-surface-500">
+      <div className="px-4 py-2 bg-white/30 border-t border-surface-200 text-xs text-surface-500 dark:bg-surface-900/30">
         <strong>Tip:</strong> The <code className="bg-surface-200 px-1 rounded">sync(context)</code>{' '}
         function is called when syncing. Return an object with an{' '}
         <code className="bg-surface-200 px-1 rounded">evidence</code> array containing data to save.

--- a/frontend/src/components/integrations/CustomConfigModal.tsx
+++ b/frontend/src/components/integrations/CustomConfigModal.tsx
@@ -374,7 +374,7 @@ export default function CustomConfigModal({
       </div>
 
       {/* Footer */}
-      <div className="flex items-center justify-between px-6 py-4 border-t border-surface-200 bg-white/50">
+      <div className="flex items-center justify-between px-6 py-4 border-t border-surface-200 bg-white/50 dark:bg-surface-900/50">
         <div className="flex items-center gap-2">
           {hasChanges && <span className="text-xs text-yellow-600">• Unsaved changes</span>}
         </div>

--- a/frontend/src/components/integrations/EndpointBuilder.tsx
+++ b/frontend/src/components/integrations/EndpointBuilder.tsx
@@ -85,7 +85,7 @@ export default function EndpointBuilder({ endpoint, onChange, onDelete }: Endpoi
         />
         <button
           onClick={onDelete}
-          className="p-2 text-surface-600 hover:text-red-600 hover:bg-white rounded-lg transition-colors"
+          className="p-2 text-surface-600 hover:text-red-600 hover:bg-white rounded-lg transition-colors dark:bg-surface-900 dark:hover:bg-surface-800"
           title="Delete endpoint"
         >
           <TrashIcon className="w-5 h-5" />
@@ -154,7 +154,7 @@ export default function EndpointBuilder({ endpoint, onChange, onDelete }: Endpoi
               />
               <button
                 onClick={() => removeHeader(key)}
-                className="p-2 text-surface-600 hover:text-red-600 hover:bg-white rounded-lg transition-colors"
+                className="p-2 text-surface-600 hover:text-red-600 hover:bg-white rounded-lg transition-colors dark:bg-surface-900 dark:hover:bg-surface-800"
               >
                 <XMarkIcon className="w-4 h-4" />
               </button>
@@ -196,7 +196,7 @@ export default function EndpointBuilder({ endpoint, onChange, onDelete }: Endpoi
               />
               <button
                 onClick={() => removeQueryParam(key)}
-                className="p-2 text-surface-600 hover:text-red-600 hover:bg-white rounded-lg transition-colors"
+                className="p-2 text-surface-600 hover:text-red-600 hover:bg-white rounded-lg transition-colors dark:bg-surface-900 dark:hover:bg-surface-800"
               >
                 <XMarkIcon className="w-4 h-4" />
               </button>
@@ -229,7 +229,7 @@ export default function EndpointBuilder({ endpoint, onChange, onDelete }: Endpoi
             />
           )}
           {!showBodyEditor && endpoint.body && (
-            <pre className="p-3 bg-white rounded-lg text-xs text-surface-700 overflow-x-auto">
+            <pre className="p-3 bg-white rounded-lg text-xs text-surface-700 overflow-x-auto dark:bg-surface-900">
               {endpoint.body.slice(0, 200)}
               {endpoint.body.length > 200 && '...'}
             </pre>

--- a/frontend/src/components/integrations/IntegrationConfigModal.tsx
+++ b/frontend/src/components/integrations/IntegrationConfigModal.tsx
@@ -201,7 +201,7 @@ export default function IntegrationConfigModal({
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-between p-6 border-t border-surface-200 bg-white">
+        <div className="flex items-center justify-between p-6 border-t border-surface-200 bg-white dark:bg-surface-900">
           <div className="text-sm text-surface-500">
             {activeTab === 'quick' &&
               `${quickSetupConfig.evidenceTypes.length} evidence types selected`}

--- a/frontend/src/components/integrations/QuickSetupTab.tsx
+++ b/frontend/src/components/integrations/QuickSetupTab.tsx
@@ -311,7 +311,7 @@ export default function QuickSetupTab({ typeMeta, config, onChange }: QuickSetup
               <button
                 key={key}
                 onClick={() => applyPreset(key as keyof typeof PRESETS)}
-                className="px-3 py-1.5 text-xs bg-white hover:bg-surface-200 border border-surface-200 rounded-lg transition-colors"
+                className="px-3 py-1.5 text-xs bg-white hover:bg-surface-200 border border-surface-200 rounded-lg transition-colors dark:bg-surface-900"
                 title={preset.description}
               >
                 {preset.label}
@@ -341,10 +341,10 @@ export default function QuickSetupTab({ typeMeta, config, onChange }: QuickSetup
               const allSelected = selectedCount === types.length;
 
               return (
-                <div key={category} className="bg-white/50">
+                <div key={category} className="bg-white/50 dark:bg-surface-900/50">
                   {/* Category Header */}
                   <div
-                    className="flex items-center justify-between px-4 py-3 cursor-pointer hover:bg-white transition-colors"
+                    className="flex items-center justify-between px-4 py-3 cursor-pointer hover:bg-white transition-colors dark:bg-surface-900 dark:hover:bg-surface-800"
                     onClick={() => toggleCategory(category)}
                   >
                     <div className="flex items-center gap-2">
@@ -382,7 +382,7 @@ export default function QuickSetupTab({ typeMeta, config, onChange }: QuickSetup
                               'flex items-start gap-3 p-3 rounded-lg cursor-pointer transition-colors',
                               isSelected
                                 ? 'bg-brand-500/10 border border-brand-500/30'
-                                : 'bg-white/50 border border-transparent hover:border-surface-200'
+                                : 'bg-white/50 border border-transparent hover:border-surface-200 dark:bg-surface-900/50'
                             )}
                           >
                             <div
@@ -415,7 +415,7 @@ export default function QuickSetupTab({ typeMeta, config, onChange }: QuickSetup
 
           {/* Summary */}
           {config.evidenceTypes.length > 0 && (
-            <div className="mt-4 p-4 bg-white/50 rounded-lg border border-surface-200">
+            <div className="mt-4 p-4 bg-white/50 rounded-lg border border-surface-200 dark:bg-surface-900/50">
               <h4 className="text-xs font-semibold text-surface-700 uppercase mb-2">
                 Collection Summary
               </h4>

--- a/frontend/src/components/integrations/RawApiTab.tsx
+++ b/frontend/src/components/integrations/RawApiTab.tsx
@@ -282,7 +282,7 @@ export default function RawApiTab({ config, onChange }: RawApiTabProps) {
     <div className="h-full flex flex-col">
       {/* Mode Toggle */}
       <div className="p-4 border-b border-surface-200">
-        <div className="flex items-center gap-2 p-1 bg-white rounded-lg w-fit">
+        <div className="flex items-center gap-2 p-1 bg-white rounded-lg w-fit dark:bg-surface-900">
           <button
             onClick={() => setMode('requests')}
             className={clsx(
@@ -338,7 +338,7 @@ export default function RawApiTab({ config, onChange }: RawApiTabProps) {
                     'w-full text-left p-2 rounded-lg transition-colors group',
                     selectedRequestId === request.id
                       ? 'bg-brand-500/10 border border-brand-500/30'
-                      : 'hover:bg-white border border-transparent'
+                      : 'hover:bg-white border border-transparent dark:bg-surface-900 dark:hover:bg-surface-800'
                   )}
                 >
                   <div className="flex items-center gap-2">
@@ -388,14 +388,14 @@ export default function RawApiTab({ config, onChange }: RawApiTabProps) {
                   <div className="flex items-center gap-2">
                     <button
                       onClick={() => duplicateRequest(selectedRequest.id)}
-                      className="p-1.5 text-surface-600 hover:text-surface-800 hover:bg-white rounded transition-colors"
+                      className="p-1.5 text-surface-600 hover:text-surface-800 hover:bg-white rounded transition-colors dark:bg-surface-900 dark:hover:bg-surface-800"
                       title="Duplicate"
                     >
                       <DocumentDuplicateIcon className="w-4 h-4" />
                     </button>
                     <button
                       onClick={() => deleteRequest(selectedRequest.id)}
-                      className="p-1.5 text-surface-600 hover:text-red-600 hover:bg-white rounded transition-colors"
+                      className="p-1.5 text-surface-600 hover:text-red-600 hover:bg-white rounded transition-colors dark:bg-surface-900 dark:hover:bg-surface-800"
                       title="Delete"
                     >
                       <TrashIcon className="w-4 h-4" />
@@ -549,7 +549,7 @@ export default function RawApiTab({ config, onChange }: RawApiTabProps) {
       ) : (
         /* Custom Code Mode */
         <div className="flex-1 flex flex-col overflow-hidden p-4 space-y-4">
-          <div className="p-4 bg-white/50 rounded-lg border border-surface-200">
+          <div className="p-4 bg-white/50 rounded-lg border border-surface-200 dark:bg-surface-900/50">
             <div className="flex items-start gap-2">
               <InformationCircleIcon className="w-5 h-5 text-brand-400 flex-shrink-0 mt-0.5" />
               <div className="text-sm text-surface-600">

--- a/frontend/src/components/integrations/RequestTester.tsx
+++ b/frontend/src/components/integrations/RequestTester.tsx
@@ -202,7 +202,7 @@ export default function RequestTester({
       </div>
       {/* Request Preview */}
       {selectedEndpoint && baseUrl && (
-        <div className="p-4 bg-white/50 rounded-lg border border-surface-200">
+        <div className="p-4 bg-white/50 rounded-lg border border-surface-200 dark:bg-surface-900/50">
           <div className="flex items-center justify-between mb-2">
             <span className="text-xs text-surface-500 uppercase font-medium">Request Preview</span>
           </div>
@@ -331,7 +331,7 @@ export default function RequestTester({
               </button>
               {showHeaders && (
                 <div className="px-4 pb-3">
-                  <div className="p-3 bg-white/50 rounded font-mono text-xs space-y-1">
+                  <div className="p-3 bg-white/50 rounded font-mono text-xs space-y-1 dark:bg-surface-900/50">
                     {Object.entries(testResult.headers).map(([key, value]) => (
                       <div key={key}>
                         <span className="text-surface-500">{key}:</span>{' '}
@@ -360,7 +360,7 @@ export default function RequestTester({
               </button>
               {showRawResponse && (
                 <div className="px-4 pb-4">
-                  <pre className="p-4 bg-white rounded-lg overflow-x-auto text-xs font-mono text-surface-700 max-h-96">
+                  <pre className="p-4 bg-white rounded-lg overflow-x-auto text-xs font-mono text-surface-700 max-h-96 dark:bg-surface-900">
                     {JSON.stringify(testResult.data, null, 2)}
                   </pre>
                 </div>

--- a/frontend/src/components/integrations/ResponseMapper.tsx
+++ b/frontend/src/components/integrations/ResponseMapper.tsx
@@ -117,7 +117,7 @@ export default function ResponseMapper({
   return (
     <div className="space-y-6">
       {/* Instructions */}
-      <div className="p-4 bg-white/50 rounded-lg border border-surface-200">
+      <div className="p-4 bg-white/50 rounded-lg border border-surface-200 dark:bg-surface-900/50">
         <div className="flex items-start gap-2">
           <InformationCircleIcon className="w-5 h-5 text-brand-400 flex-shrink-0 mt-0.5" />
           <div className="text-sm text-surface-600">
@@ -138,7 +138,7 @@ export default function ResponseMapper({
           {showSuggestions ? 'Hide suggestions' : 'Show common field suggestions'}
         </button>
         {showSuggestions && (
-          <div className="flex flex-wrap gap-2 p-3 bg-white/30 rounded-lg">
+          <div className="flex flex-wrap gap-2 p-3 bg-white/30 rounded-lg dark:bg-surface-900/30">
             {SUGGESTED_FIELDS.map(({ field, description }) => (
               <button
                 key={field}
@@ -179,7 +179,10 @@ export default function ResponseMapper({
       {/* Mapping List */}
       <div className="space-y-3">
         {mappings.map((mapping) => (
-          <div key={mapping.id} className="p-4 bg-white/50 rounded-lg border border-surface-200">
+          <div
+            key={mapping.id}
+            className="p-4 bg-white/50 rounded-lg border border-surface-200 dark:bg-surface-900/50"
+          >
             <div className="flex items-start gap-4">
               <div className="flex-1 grid grid-cols-1 md:grid-cols-2 gap-4">
                 {/* Source Path */}
@@ -259,7 +262,7 @@ export default function ResponseMapper({
               {/* Delete Button */}
               <button
                 onClick={() => deleteMapping(mapping.id)}
-                className="p-2 text-surface-600 hover:text-red-600 hover:bg-white rounded-lg transition-colors"
+                className="p-2 text-surface-600 hover:text-red-600 hover:bg-white rounded-lg transition-colors dark:bg-surface-900 dark:hover:bg-surface-800"
               >
                 <TrashIcon className="w-4 h-4" />
               </button>
@@ -280,7 +283,7 @@ export default function ResponseMapper({
         ))}
 
         {mappings.length === 0 && (
-          <div className="text-center py-8 text-surface-500 bg-white/30 rounded-lg border border-dashed border-surface-200">
+          <div className="text-center py-8 text-surface-500 bg-white/30 rounded-lg border border-dashed border-surface-200 dark:bg-surface-900/30">
             No field mappings configured. Add mappings to extract data from API responses.
           </div>
         )}

--- a/frontend/src/components/integrations/VisualConfigBuilder.tsx
+++ b/frontend/src/components/integrations/VisualConfigBuilder.tsx
@@ -349,7 +349,7 @@ function EndpointCard({
     <div className="border border-surface-200 rounded-lg overflow-hidden">
       {/* Header */}
       <div
-        className="flex items-center justify-between px-4 py-3 bg-white/50 cursor-pointer"
+        className="flex items-center justify-between px-4 py-3 bg-white/50 cursor-pointer dark:bg-surface-900/50"
         onClick={onToggle}
       >
         <div className="flex items-center gap-3">
@@ -392,7 +392,7 @@ function EndpointCard({
       </div>
       {/* Expanded Content */}
       {isExpanded && (
-        <div className="p-4 space-y-4 bg-white/30">
+        <div className="p-4 space-y-4 bg-white/30 dark:bg-surface-900/30">
           {/* Name & Description */}
           <div className="grid grid-cols-2 gap-4">
             <div>

--- a/frontend/src/components/mappings/MappingEditorModal.tsx
+++ b/frontend/src/components/mappings/MappingEditorModal.tsx
@@ -638,7 +638,7 @@ function MultiSelectStage({
           aria-label={
             mode === 'requirement-to-controls' ? 'Candidate controls' : 'Candidate requirements'
           }
-          className="max-h-72 overflow-y-auto space-y-1 border border-surface-200 rounded-lg p-2 bg-white/40"
+          className="max-h-72 overflow-y-auto space-y-1 border border-surface-200 rounded-lg p-2 bg-white/40 dark:bg-surface-900/40"
         >
           {candidates.map((c) => {
             const id = c.id;
@@ -655,14 +655,14 @@ function MultiSelectStage({
                     'flex items-start gap-3 rounded-md px-3 py-2 cursor-pointer',
                     checked
                       ? 'bg-brand-600/20 border border-brand-500/40'
-                      : 'hover:bg-white border border-transparent'
+                      : 'hover:bg-white border border-transparent dark:bg-surface-900 dark:hover:bg-surface-800'
                   )}
                 >
                   <input
                     type="checkbox"
                     checked={checked}
                     onChange={() => onToggle(id)}
-                    className="mt-1 h-4 w-4 rounded border-surface-300 bg-white text-brand-500 focus:ring-brand-500"
+                    className="mt-1 h-4 w-4 rounded border-surface-300 bg-white text-brand-500 focus:ring-brand-500 dark:bg-surface-900"
                   />
                   <span className="flex-1">
                     <span className="block font-mono text-sm text-surface-800">{primary}</span>
@@ -702,7 +702,7 @@ function PerRowFormStage({ rows, getLabel, onChange, disabled, isEditMode }: Per
         {rows.map((row) => (
           <li
             key={row.candidateId}
-            className="rounded-lg border border-surface-200 p-3 bg-white/40"
+            className="rounded-lg border border-surface-200 p-3 bg-white/40 dark:bg-surface-900/40"
           >
             {!isEditMode && (
               <p className="text-sm font-medium text-surface-800 mb-2">
@@ -768,7 +768,7 @@ function SuggestionsPanel({
   return (
     <section
       aria-label="AI mapping suggestions"
-      className="rounded-lg border border-surface-200 bg-white/40 p-3 space-y-3"
+      className="rounded-lg border border-surface-200 bg-white/40 p-3 space-y-3 dark:bg-surface-900/40"
     >
       <div className="flex items-center justify-between gap-3">
         <div className="flex items-center gap-2">
@@ -836,7 +836,7 @@ function SuggestionsPanel({
             return (
               <li
                 key={s.candidateId}
-                className="rounded-md border border-surface-200 bg-white/60 p-2.5"
+                className="rounded-md border border-surface-200 bg-white/60 p-2.5 dark:bg-surface-900/60"
               >
                 <div className="flex items-start justify-between gap-3">
                   <div className="flex-1 min-w-0">

--- a/frontend/src/components/mappings/MappingHistoryDrawer.tsx
+++ b/frontend/src/components/mappings/MappingHistoryDrawer.tsx
@@ -138,7 +138,7 @@ function DiffRows({ prev, current }: DiffRowsProps) {
         return (
           <div
             key={field}
-            className="flex flex-col gap-1 p-2 rounded-lg bg-white/40 border border-surface-200"
+            className="flex flex-col gap-1 p-2 rounded-lg bg-white/40 border border-surface-200 dark:bg-surface-900/40"
           >
             <span className="text-xs text-surface-600 font-medium">{FIELD_LABELS[field]}</span>
             <div className="flex items-center gap-2 text-sm flex-wrap">
@@ -229,7 +229,7 @@ function HistoryEntryItem({
       >
         <Icon className={clsx('w-3.5 h-3.5', meta.text)} />
       </div>
-      <div className="bg-white rounded-lg border border-surface-200 p-3">
+      <div className="bg-white rounded-lg border border-surface-200 p-3 dark:bg-surface-900">
         <div className="flex items-start justify-between gap-3">
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 flex-wrap">
@@ -311,7 +311,7 @@ function HistoryEntryItem({
                 disabled={isRestoring}
                 aria-label="Restore reason"
                 placeholder="Why are you restoring this version?"
-                className="w-full rounded-md bg-white border border-surface-200 text-surface-900 px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-purple-500 disabled:opacity-50"
+                className="w-full rounded-md bg-white border border-surface-200 text-surface-900 px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-purple-500 disabled:opacity-50 dark:bg-surface-900"
               />
             </label>
             <div className="flex justify-end gap-2">
@@ -346,7 +346,7 @@ function SkeletonRow() {
   return (
     <div className="relative pl-8 pb-6" aria-hidden="true">
       <div className="absolute left-0 top-0 w-6 h-6 rounded-full bg-surface-200 animate-pulse" />
-      <div className="bg-white rounded-lg border border-surface-200 p-4 animate-pulse">
+      <div className="bg-white rounded-lg border border-surface-200 p-4 animate-pulse dark:bg-surface-900">
         <div className="h-4 bg-surface-200 rounded w-1/3 mb-2" />
         <div className="h-3 bg-surface-200 rounded w-2/3" />
       </div>
@@ -422,7 +422,10 @@ export function MappingHistoryDrawer({
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <div className="fixed inset-0 bg-white opacity-60" aria-hidden="true" />
+          <div
+            className="fixed inset-0 bg-white opacity-60 dark:bg-surface-900"
+            aria-hidden="true"
+          />
         </Transition.Child>
 
         <div className="fixed inset-0 overflow-hidden">
@@ -438,7 +441,7 @@ export function MappingHistoryDrawer({
                 leaveTo="translate-x-full"
               >
                 <Dialog.Panel
-                  className="pointer-events-auto w-screen max-w-xl h-full bg-white border-l border-surface-200 shadow-xl flex flex-col"
+                  className="pointer-events-auto w-screen max-w-xl h-full bg-white border-l border-surface-200 shadow-xl flex flex-col dark:bg-surface-900"
                   aria-labelledby="mapping-history-drawer-title"
                 >
                   <header className="flex items-start justify-between p-4 border-b border-surface-200">
@@ -497,7 +500,7 @@ export function MappingHistoryDrawer({
                     )}
 
                     {!isLoading && !error && entries.length === 0 && (
-                      <div className="text-center py-12 bg-white/40 rounded-lg border border-surface-200">
+                      <div className="text-center py-12 bg-white/40 rounded-lg border border-surface-200 dark:bg-surface-900/40">
                         <ClockIcon
                           className="w-10 h-10 mx-auto text-surface-600 mb-3"
                           aria-hidden="true"

--- a/frontend/src/components/mappings/MappingImportWizard.tsx
+++ b/frontend/src/components/mappings/MappingImportWizard.tsx
@@ -189,7 +189,7 @@ export function MappingImportWizard({
           onClick={handleClose}
         />
 
-        <div className="relative w-full max-w-3xl bg-white rounded-xl shadow-2xl border border-surface-200">
+        <div className="relative w-full max-w-3xl bg-white rounded-xl shadow-2xl border border-surface-200 dark:bg-surface-900">
           <div className="flex items-center justify-between p-6 border-b border-surface-200">
             <div>
               <h2 className="text-xl font-semibold text-surface-900">Import mappings</h2>
@@ -203,7 +203,7 @@ export function MappingImportWizard({
               type="button"
               onClick={handleClose}
               aria-label="Close import wizard"
-              className="p-2 text-surface-600 hover:text-surface-800 hover:bg-white rounded-lg transition-colors"
+              className="p-2 text-surface-600 hover:text-surface-800 hover:bg-white rounded-lg transition-colors dark:bg-surface-900 dark:hover:bg-surface-800"
             >
               <XMarkIcon className="w-5 h-5" />
             </button>
@@ -319,7 +319,7 @@ function UploadStage({
 }: UploadStageProps) {
   return (
     <div className="space-y-4">
-      <div className="p-4 bg-white/50 rounded-lg border border-surface-200 text-sm text-surface-700">
+      <div className="p-4 bg-white/50 rounded-lg border border-surface-200 text-sm text-surface-700 dark:bg-surface-900/50">
         <p className="font-medium text-surface-800 mb-2">Required columns</p>
         <ul className="space-y-1 text-xs text-surface-600 list-disc list-inside">
           <li>
@@ -357,7 +357,7 @@ function UploadStage({
             id="mapping-import-framework"
             value={selectedFrameworkId}
             onChange={(e) => onFrameworkChange(e.target.value)}
-            className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-sm text-surface-900 focus:outline-none focus:border-brand-500"
+            className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-sm text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
           >
             <option value="">Select a framework…</option>
             {frameworks.map((fw) => (
@@ -441,7 +441,7 @@ function PreviewStage({ result }: { result: ImportResult }) {
 
       <div className="border border-surface-200 rounded-lg overflow-hidden">
         <table className="w-full text-sm" aria-label="Import preview rows">
-          <thead className="bg-white text-xs uppercase text-surface-600">
+          <thead className="bg-white text-xs uppercase text-surface-600 dark:bg-surface-900">
             <tr>
               <th className="px-3 py-2 text-left">Row</th>
               <th className="px-3 py-2 text-left">Framework</th>
@@ -465,7 +465,7 @@ function PreviewStage({ result }: { result: ImportResult }) {
                   key={row.row}
                   data-testid={`preview-row-${row.row}`}
                   data-status={row.status}
-                  className="hover:bg-white/40"
+                  className="hover:bg-white/40 dark:bg-surface-900/40 dark:hover:bg-surface-800/40"
                 >
                   <td className="px-3 py-2 font-mono text-surface-600">{row.row}</td>
                   <td className="px-3 py-2 text-surface-800">
@@ -548,7 +548,7 @@ function ResultStage({ result }: { result: ImportResult }) {
 
 function SummaryTile({ label, value, accent }: { label: string; value: number; accent: string }) {
   return (
-    <div className="bg-white rounded-lg p-4 text-center">
+    <div className="bg-white rounded-lg p-4 text-center dark:bg-surface-900">
       <div className={clsx('text-2xl font-bold', accent)}>{value}</div>
       <div className="text-sm text-surface-600">{label}</div>
     </div>

--- a/frontend/src/components/mcp/MCPWorkflowBuilder.tsx
+++ b/frontend/src/components/mcp/MCPWorkflowBuilder.tsx
@@ -110,9 +110,9 @@ export default function MCPWorkflowBuilder() {
       case 'running':
         return <ArrowPathIcon className="w-5 h-5 text-blue-500 animate-spin" />;
       case 'cancelled':
-        return <StopIcon className="w-5 h-5 text-gray-500" />;
+        return <StopIcon className="w-5 h-5 text-gray-500 dark:text-surface-400" />;
       default:
-        return <ClockIcon className="w-5 h-5 text-gray-500" />;
+        return <ClockIcon className="w-5 h-5 text-gray-500 dark:text-surface-400" />;
     }
   };
 
@@ -152,7 +152,7 @@ export default function MCPWorkflowBuilder() {
 
           {loadingWorkflows ? (
             <div className="p-8 text-center">
-              <ArrowPathIcon className="w-8 h-8 animate-spin mx-auto text-gray-400" />
+              <ArrowPathIcon className="w-8 h-8 animate-spin mx-auto text-gray-400 dark:text-surface-500" />
             </div>
           ) : (
             <div className="divide-y divide-gray-200 dark:divide-surface-200">
@@ -163,7 +163,7 @@ export default function MCPWorkflowBuilder() {
                   className={`p-4 cursor-pointer transition-colors ${
                     selectedWorkflow === workflow.id
                       ? 'bg-brand-50 dark:bg-brand-900/20'
-                      : 'hover:bg-gray-50 dark:hover:bg-surface-200/50'
+                      : 'hover:bg-gray-50 dark:hover:bg-surface-200/50 dark:bg-surface-900'
                   }`}
                 >
                   <div className="flex items-center justify-between">
@@ -186,7 +186,7 @@ export default function MCPWorkflowBuilder() {
                         </p>
                       </div>
                     </div>
-                    <ChevronRightIcon className="w-5 h-5 text-gray-400" />
+                    <ChevronRightIcon className="w-5 h-5 text-gray-400 dark:text-surface-500" />
                   </div>
                 </div>
               ))}
@@ -249,7 +249,7 @@ export default function MCPWorkflowBuilder() {
             </div>
           ) : (
             <div className="bg-white dark:bg-white rounded-lg border border-gray-200 dark:border-surface-200 p-8 text-center">
-              <BoltIcon className="w-12 h-12 mx-auto text-gray-400" />
+              <BoltIcon className="w-12 h-12 mx-auto text-gray-400 dark:text-surface-500" />
               <p className="mt-2 text-gray-600 dark:text-gray-400">
                 Select a workflow to view details
               </p>
@@ -266,7 +266,7 @@ export default function MCPWorkflowBuilder() {
 
             {executions.length === 0 ? (
               <div className="p-8 text-center">
-                <ClockIcon className="w-12 h-12 mx-auto text-gray-400" />
+                <ClockIcon className="w-12 h-12 mx-auto text-gray-400 dark:text-surface-500" />
                 <p className="mt-2 text-gray-600 dark:text-gray-400">No executions yet</p>
               </div>
             ) : (
@@ -295,7 +295,7 @@ export default function MCPWorkflowBuilder() {
                             {execution.status === 'running' && (
                               <button
                                 onClick={() => cancelMutation.mutate(execution.id)}
-                                className="p-2 text-gray-500 hover:text-red-600 dark:hover:text-red-600"
+                                className="p-2 text-gray-500 hover:text-red-600 dark:hover:text-red-600 dark:text-surface-400"
                                 title="Cancel"
                               >
                                 <StopIcon className="w-5 h-5" />
@@ -312,7 +312,7 @@ export default function MCPWorkflowBuilder() {
                               running: 'bg-blue-500 animate-pulse',
                               completed: 'bg-green-500',
                               failed: 'bg-red-500',
-                              skipped: 'bg-gray-400',
+                              skipped: 'bg-gray-400 dark:bg-surface-600',
                             };
                             return (
                               <div
@@ -349,7 +349,7 @@ export default function MCPWorkflowBuilder() {
                 setShowExecutionModal(false);
                 setExecutionInput({});
               }}
-              className="text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
+              className="text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 dark:text-surface-400"
             >
               ×
             </button>

--- a/frontend/src/components/notifications/NotificationBell.tsx
+++ b/frontend/src/components/notifications/NotificationBell.tsx
@@ -123,7 +123,7 @@ export default function NotificationBell() {
       {/* Bell Button */}
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="relative p-2 rounded-lg text-surface-600 hover:text-surface-900 hover:bg-white focus:outline-none focus:ring-2 focus:ring-brand-500 transition-colors"
+        className="relative p-2 rounded-lg text-surface-600 hover:text-surface-900 hover:bg-white focus:outline-none focus:ring-2 focus:ring-brand-500 transition-colors dark:bg-surface-900 dark:hover:bg-surface-800"
         aria-label="Notifications"
       >
         {unreadCount > 0 ? (
@@ -142,9 +142,9 @@ export default function NotificationBell() {
 
       {/* Dropdown Panel */}
       {isOpen && (
-        <div className="absolute left-0 mt-2 w-80 bg-white rounded-xl shadow-2xl border border-surface-200 z-[100] overflow-hidden">
+        <div className="absolute left-0 mt-2 w-80 bg-white rounded-xl shadow-2xl border border-surface-200 z-[100] overflow-hidden dark:bg-surface-900">
           {/* Header */}
-          <div className="flex items-center justify-between px-4 py-3 bg-white border-b border-surface-200">
+          <div className="flex items-center justify-between px-4 py-3 bg-white border-b border-surface-200 dark:bg-surface-900">
             <h3 className="text-sm font-semibold text-surface-900">Notifications</h3>
             <div className="flex items-center space-x-2">
               {unreadCount > 0 && (
@@ -191,7 +191,7 @@ export default function NotificationBell() {
 
                   const NotificationContent = (
                     <div
-                      className={`p-3 hover:bg-white transition-colors cursor-pointer ${!notification.isRead ? 'bg-white/50' : ''}`}
+                      className={`p-3 hover:bg-white dark:hover:bg-surface-800 transition-colors cursor-pointer ${!notification.isRead ? 'bg-white/50 dark:bg-surface-900/50' : ''}`}
                     >
                       <div className="flex items-start space-x-2">
                         {/* Severity Icon */}
@@ -276,7 +276,7 @@ export default function NotificationBell() {
 
           {/* Footer */}
           {notifications.length > 0 && (
-            <div className="px-3 py-2 bg-white border-t border-surface-200 text-center">
+            <div className="px-3 py-2 bg-white border-t border-surface-200 text-center dark:bg-surface-900">
               <Link
                 to="/settings/notifications"
                 onClick={() => setIsOpen(false)}

--- a/frontend/src/components/reports/ReportBuilder.tsx
+++ b/frontend/src/components/reports/ReportBuilder.tsx
@@ -290,7 +290,7 @@ export default function ReportBuilder({ initialConfig, onSave, className }: Repo
   return (
     <div className={clsx('flex h-full', className)}>
       {/* Sidebar - Section Types */}
-      <div className="w-64 bg-white border-r border-surface-200 p-4 space-y-4">
+      <div className="w-64 bg-white border-r border-surface-200 p-4 space-y-4 dark:bg-surface-900">
         <div>
           <h3 className="text-sm font-medium text-surface-600 mb-2">Add Section</h3>
           <div className="space-y-1">
@@ -298,7 +298,7 @@ export default function ReportBuilder({ initialConfig, onSave, className }: Repo
               <button
                 key={type}
                 onClick={() => addSection(type)}
-                className="w-full flex items-center gap-2 px-3 py-2 text-sm text-surface-700 hover:text-white hover:bg-white rounded-lg transition-colors"
+                className="w-full flex items-center gap-2 px-3 py-2 text-sm text-surface-700 hover:text-white hover:bg-white rounded-lg transition-colors dark:bg-surface-900 dark:hover:bg-surface-800"
               >
                 <Icon className="w-4 h-4" />
                 {label}
@@ -314,21 +314,21 @@ export default function ReportBuilder({ initialConfig, onSave, className }: Repo
             value={config.name}
             onChange={(e) => setConfig((prev) => ({ ...prev, name: e.target.value }))}
             placeholder="Report Name"
-            className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-white text-sm focus:outline-none focus:border-brand-500"
+            className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-white text-sm focus:outline-none focus:border-brand-500 dark:bg-surface-900"
           />
           <Textarea
             value={config.description || ''}
             onChange={(e) => setConfig((prev) => ({ ...prev, description: e.target.value }))}
             placeholder="Description (optional)"
             rows={2}
-            className="w-full mt-2 px-3 py-2 bg-white border border-surface-200 rounded-lg text-white text-sm focus:outline-none focus:border-brand-500 resize-none"
+            className="w-full mt-2 px-3 py-2 bg-white border border-surface-200 rounded-lg text-white text-sm focus:outline-none focus:border-brand-500 resize-none dark:bg-surface-900"
           />
         </div>
 
         <div className="border-t border-surface-200 pt-4 space-y-2">
           <button
             onClick={() => setIsPreviewMode(!isPreviewMode)}
-            className="w-full flex items-center justify-center gap-2 px-3 py-2 bg-white hover:bg-surface-200 text-white rounded-lg text-sm transition-colors"
+            className="w-full flex items-center justify-center gap-2 px-3 py-2 bg-white hover:bg-surface-200 text-white rounded-lg text-sm transition-colors dark:bg-surface-900"
           >
             <EyeIcon className="w-4 h-4" />
             {isPreviewMode ? 'Edit Mode' : 'Preview'}
@@ -353,14 +353,14 @@ export default function ReportBuilder({ initialConfig, onSave, className }: Repo
             <div className="flex items-center gap-2">
               <button
                 onClick={() => handleExport('pdf')}
-                className="flex items-center gap-1.5 px-3 py-1.5 bg-white hover:bg-surface-200 text-white rounded-lg text-sm"
+                className="flex items-center gap-1.5 px-3 py-1.5 bg-white hover:bg-surface-200 text-white rounded-lg text-sm dark:bg-surface-900"
               >
                 <ArrowDownTrayIcon className="w-4 h-4" />
                 PDF
               </button>
               <button
                 onClick={() => handleExport('xlsx')}
-                className="flex items-center gap-1.5 px-3 py-1.5 bg-white hover:bg-surface-200 text-white rounded-lg text-sm"
+                className="flex items-center gap-1.5 px-3 py-1.5 bg-white hover:bg-surface-200 text-white rounded-lg text-sm dark:bg-surface-900"
               >
                 <ArrowDownTrayIcon className="w-4 h-4" />
                 Excel
@@ -459,7 +459,7 @@ function SectionEditor({
         'relative p-4 rounded-lg border transition-all cursor-pointer',
         isSelected
           ? 'border-brand-500 bg-brand-500/5'
-          : 'border-surface-200 hover:border-surface-300 bg-white/50'
+          : 'border-surface-200 hover:border-surface-300 bg-white/50 dark:bg-surface-900/50'
       )}
     >
       {/* Controls */}
@@ -571,7 +571,7 @@ function SectionPreview({ section }: { section: ReportSection }) {
 
   // Placeholder for dynamic content
   return (
-    <div className="p-4 bg-white/50 rounded-lg border border-surface-200">
+    <div className="p-4 bg-white/50 rounded-lg border border-surface-200 dark:bg-surface-900/50">
       <p className="text-sm text-surface-600">
         [Preview: {section.type} from {section.dataSource}]
       </p>
@@ -593,7 +593,7 @@ function SectionConfigPanel({ section, onUpdate, onClose }: SectionConfigPanelPr
   const showDataConfig = ['table', 'chart', 'summary'].includes(section.type);
 
   return (
-    <div className="w-80 bg-white border-l border-surface-200 p-4 overflow-y-auto">
+    <div className="w-80 bg-white border-l border-surface-200 p-4 overflow-y-auto dark:bg-surface-900">
       <div className="flex items-center justify-between mb-4">
         <h3 className="font-medium text-white">Section Settings</h3>
         <button onClick={onClose} className="text-surface-600 hover:text-white">
@@ -608,7 +608,7 @@ function SectionConfigPanel({ section, onUpdate, onClose }: SectionConfigPanelPr
               type="text"
               value={section.title || ''}
               onChange={(e) => onUpdate({ title: e.target.value })}
-              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-white text-sm"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-white text-sm dark:bg-surface-900"
             />
           </div>
         )}
@@ -620,7 +620,7 @@ function SectionConfigPanel({ section, onUpdate, onClose }: SectionConfigPanelPr
               value={section.content || ''}
               onChange={(e) => onUpdate({ content: e.target.value })}
               rows={5}
-              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-white text-sm resize-none"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-white text-sm resize-none dark:bg-surface-900"
             />
           </div>
         )}
@@ -632,7 +632,7 @@ function SectionConfigPanel({ section, onUpdate, onClose }: SectionConfigPanelPr
               <SelectNative
                 value={section.dataSource || 'controls'}
                 onChange={(e) => onUpdate({ dataSource: e.target.value as DataSource })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-white text-sm"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-white text-sm dark:bg-surface-900"
               >
                 {Object.entries(DATA_SOURCES).map(([key, { label }]) => (
                   <option key={key} value={key}>
@@ -658,7 +658,7 @@ function SectionConfigPanel({ section, onUpdate, onClose }: SectionConfigPanelPr
                             : fields.filter((f) => f !== field),
                         });
                       }}
-                      className="rounded border-surface-300 bg-white text-brand-500"
+                      className="rounded border-surface-300 bg-white text-brand-500 dark:bg-surface-900"
                     />
                     <span className="text-surface-700">{field}</span>
                   </label>
@@ -672,7 +672,7 @@ function SectionConfigPanel({ section, onUpdate, onClose }: SectionConfigPanelPr
                 <SelectNative
                   value={section.chartType || 'bar'}
                   onChange={(e) => onUpdate({ chartType: e.target.value as ChartType })}
-                  className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-white text-sm"
+                  className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-white text-sm dark:bg-surface-900"
                 >
                   <option value="bar">Bar Chart</option>
                   <option value="pie">Pie Chart</option>
@@ -687,7 +687,7 @@ function SectionConfigPanel({ section, onUpdate, onClose }: SectionConfigPanelPr
               <SelectNative
                 value={section.groupBy || ''}
                 onChange={(e) => onUpdate({ groupBy: e.target.value || undefined })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-white text-sm"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-white text-sm dark:bg-surface-900"
               >
                 <option value="">No grouping</option>
                 {DATA_SOURCES[section.dataSource || 'controls'].fields.map((field) => (
@@ -704,7 +704,7 @@ function SectionConfigPanel({ section, onUpdate, onClose }: SectionConfigPanelPr
                 <SelectNative
                   value={section.sortBy || ''}
                   onChange={(e) => onUpdate({ sortBy: e.target.value || undefined })}
-                  className="flex-1 px-3 py-2 bg-white border border-surface-200 rounded-lg text-white text-sm"
+                  className="flex-1 px-3 py-2 bg-white border border-surface-200 rounded-lg text-white text-sm dark:bg-surface-900"
                 >
                   <option value="">Default</option>
                   {DATA_SOURCES[section.dataSource || 'controls'].fields.map((field) => (
@@ -716,7 +716,7 @@ function SectionConfigPanel({ section, onUpdate, onClose }: SectionConfigPanelPr
                 <SelectNative
                   value={section.sortOrder || 'asc'}
                   onChange={(e) => onUpdate({ sortOrder: e.target.value as 'asc' | 'desc' })}
-                  className="w-20 px-2 py-2 bg-white border border-surface-200 rounded-lg text-white text-sm"
+                  className="w-20 px-2 py-2 bg-white border border-surface-200 rounded-lg text-white text-sm dark:bg-surface-900"
                 >
                   <option value="asc">↑</option>
                   <option value="desc">↓</option>

--- a/frontend/src/components/risk/CreateTaskModal.tsx
+++ b/frontend/src/components/risk/CreateTaskModal.tsx
@@ -48,7 +48,7 @@ const taskTypes = [
 ];
 
 const priorities = [
-  { value: 'low', label: 'Low', color: 'text-gray-500' },
+  { value: 'low', label: 'Low', color: 'text-gray-500 dark:text-surface-400' },
   { value: 'medium', label: 'Medium', color: 'text-amber-500' },
   { value: 'high', label: 'High', color: 'text-orange-500' },
   { value: 'critical', label: 'Critical', color: 'text-red-500' },
@@ -138,7 +138,7 @@ export default function CreateTaskModal({ riskId, onClose, onSuccess }: CreateTa
             </h2>
             <button
               onClick={onClose}
-              className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+              className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 dark:text-surface-500"
             >
               <XMarkIcon className="h-5 w-5" />
             </button>
@@ -162,7 +162,7 @@ export default function CreateTaskModal({ riskId, onClose, onSuccess }: CreateTa
                   </option>
                 ))}
               </SelectNative>
-              <p className="mt-1 text-xs text-gray-500">
+              <p className="mt-1 text-xs text-gray-500 dark:text-surface-400">
                 {taskTypes.find((t) => t.value === formData.taskType)?.description}
               </p>
             </div>
@@ -205,16 +205,18 @@ export default function CreateTaskModal({ riskId, onClose, onSuccess }: CreateTa
               {selectedUser ? (
                 <div className="flex items-center justify-between p-2 border border-gray-300 dark:border-gray-600 rounded-md bg-gray-50 dark:bg-gray-700">
                   <div className="flex items-center gap-2">
-                    <UserIcon className="h-5 w-5 text-gray-400" />
+                    <UserIcon className="h-5 w-5 text-gray-400 dark:text-surface-500" />
                     <span className="text-gray-900 dark:text-gray-100">
                       {selectedUser.firstName} {selectedUser.lastName}
                     </span>
-                    <span className="text-sm text-gray-500">({selectedUser.email})</span>
+                    <span className="text-sm text-gray-500 dark:text-surface-400">
+                      ({selectedUser.email})
+                    </span>
                   </div>
                   <button
                     type="button"
                     onClick={() => setFormData((prev) => ({ ...prev, assigneeId: '' }))}
-                    className="text-gray-400 hover:text-gray-600"
+                    className="text-gray-400 hover:text-gray-600 dark:text-surface-500"
                   >
                     <XMarkIcon className="h-4 w-4" />
                   </button>
@@ -222,7 +224,7 @@ export default function CreateTaskModal({ riskId, onClose, onSuccess }: CreateTa
               ) : (
                 <div className="relative">
                   <div className="relative">
-                    <MagnifyingGlassIcon className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+                    <MagnifyingGlassIcon className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400 dark:text-surface-500" />
                     <Input
                       type="text"
                       value={userSearch}
@@ -239,20 +241,24 @@ export default function CreateTaskModal({ riskId, onClose, onSuccess }: CreateTa
                   {showUserDropdown && (
                     <div className="absolute z-10 w-full mt-1 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md shadow-lg max-h-48 overflow-y-auto">
                       {filteredUsers.length === 0 ? (
-                        <div className="p-2 text-sm text-gray-500">No users found</div>
+                        <div className="p-2 text-sm text-gray-500 dark:text-surface-400">
+                          No users found
+                        </div>
                       ) : (
                         filteredUsers.slice(0, 10).map((user: User) => (
                           <button
                             key={user.id}
                             type="button"
                             onClick={() => selectUser(user.id)}
-                            className="w-full flex items-center gap-2 p-2 text-left hover:bg-gray-100 dark:hover:bg-gray-600"
+                            className="w-full flex items-center gap-2 p-2 text-left hover:bg-gray-100 dark:hover:bg-gray-600 dark:bg-surface-800"
                           >
-                            <UserIcon className="h-4 w-4 text-gray-400" />
+                            <UserIcon className="h-4 w-4 text-gray-400 dark:text-surface-500" />
                             <span className="text-gray-900 dark:text-gray-100">
                               {user.firstName} {user.lastName}
                             </span>
-                            <span className="text-sm text-gray-500">({user.email})</span>
+                            <span className="text-sm text-gray-500 dark:text-surface-400">
+                              ({user.email})
+                            </span>
                           </button>
                         ))
                       )}
@@ -335,7 +341,7 @@ export default function CreateTaskModal({ riskId, onClose, onSuccess }: CreateTa
               <button
                 type="button"
                 onClick={onClose}
-                className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md"
+                className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md dark:bg-surface-800"
               >
                 Cancel
               </button>

--- a/frontend/src/components/risk/RiskAssetsTab.tsx
+++ b/frontend/src/components/risk/RiskAssetsTab.tsx
@@ -71,7 +71,7 @@ function RiskAssetsTab({
           {assets.map((asset) => (
             <div
               key={asset.id}
-              className="flex items-center justify-between p-4 bg-white rounded-lg border border-surface-200"
+              className="flex items-center justify-between p-4 bg-white rounded-lg border border-surface-200 dark:bg-surface-900"
             >
               <div className="flex items-center gap-4">
                 <Server className="w-5 h-5 text-surface-600" />

--- a/frontend/src/components/risk/RiskControlsTab.tsx
+++ b/frontend/src/components/risk/RiskControlsTab.tsx
@@ -81,7 +81,7 @@ function RiskControlsTab({
           {controls.map((control) => (
             <div
               key={control.id}
-              className="flex items-center justify-between p-4 bg-white rounded-lg border border-surface-200"
+              className="flex items-center justify-between p-4 bg-white rounded-lg border border-surface-200 dark:bg-surface-900"
             >
               <div className="flex items-center gap-4">
                 <Target className="w-5 h-5 text-surface-600" />

--- a/frontend/src/components/risk/RiskEditModal.tsx
+++ b/frontend/src/components/risk/RiskEditModal.tsx
@@ -84,7 +84,7 @@ export default function RiskEditModal({
             type="text"
             value={formData.title}
             onChange={(e) => setFormData({ ...formData, title: e.target.value })}
-            className="w-full bg-white border border-surface-200 rounded-lg px-3 py-2 text-white"
+            className="w-full bg-white border border-surface-200 rounded-lg px-3 py-2 text-white dark:bg-surface-900"
             required
           />
         </div>
@@ -94,7 +94,7 @@ export default function RiskEditModal({
             value={formData.description}
             onChange={(e) => setFormData({ ...formData, description: e.target.value })}
             rows={3}
-            className="w-full bg-white border border-surface-200 rounded-lg px-3 py-2 text-white"
+            className="w-full bg-white border border-surface-200 rounded-lg px-3 py-2 text-white dark:bg-surface-900"
           />
         </div>
         <div>
@@ -102,7 +102,7 @@ export default function RiskEditModal({
           <SelectNative
             value={formData.category}
             onChange={(e) => setFormData({ ...formData, category: e.target.value })}
-            className="w-full bg-white border border-surface-200 rounded-lg px-3 py-2 text-white"
+            className="w-full bg-white border border-surface-200 rounded-lg px-3 py-2 text-white dark:bg-surface-900"
           >
             {RISK_CATEGORIES.map((cat) => (
               <option key={cat} value={cat}>
@@ -116,7 +116,7 @@ export default function RiskEditModal({
           <SelectNative
             value={formData.reviewFrequency}
             onChange={(e) => setFormData({ ...formData, reviewFrequency: e.target.value })}
-            className="w-full bg-white border border-surface-200 rounded-lg px-3 py-2 text-white"
+            className="w-full bg-white border border-surface-200 rounded-lg px-3 py-2 text-white dark:bg-surface-900"
           >
             {REVIEW_FREQUENCIES.map((freq) => (
               <option key={freq.value} value={freq.value}>

--- a/frontend/src/components/risk/RiskHeatMap.tsx
+++ b/frontend/src/components/risk/RiskHeatMap.tsx
@@ -194,7 +194,7 @@ export function RiskHeatMap({
                     {/* Hover tooltip */}
                     {isHovered && cellRisks.length > 0 && (
                       <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-50 pointer-events-none">
-                        <div className="bg-white border border-surface-200 rounded-lg shadow-xl p-3 min-w-[200px]">
+                        <div className="bg-white border border-surface-200 rounded-lg shadow-xl p-3 min-w-[200px] dark:bg-surface-900">
                           <p className="text-xs text-surface-600 mb-1">
                             {LIKELIHOOD_LABELS[likelihood]} × {IMPACT_LABELS[impact]}
                           </p>
@@ -236,7 +236,7 @@ export function RiskHeatMap({
 
       {/* Selected Cell Details */}
       {selectedCell && risksByCell[selectedCell]?.length > 0 && (
-        <div className="bg-white border border-surface-200 rounded-lg p-4">
+        <div className="bg-white border border-surface-200 rounded-lg p-4 dark:bg-surface-900">
           <div className="flex items-center justify-between mb-3">
             <h4 className="font-medium text-surface-900">
               {LIKELIHOOD_LABELS[selectedCell.split('-')[0]]} ×{' '}
@@ -268,7 +268,7 @@ export function RiskHeatMap({
 
       {/* Legend */}
       {showLegend && (
-        <div className="flex items-center justify-between bg-white/50 rounded-lg p-3">
+        <div className="flex items-center justify-between bg-white/50 rounded-lg p-3 dark:bg-surface-900/50">
           <div className="flex items-center gap-4">
             <div className="flex items-center gap-2">
               <div className="w-3 h-3 rounded bg-emerald-400" />

--- a/frontend/src/components/risk/RiskScenariosTab.tsx
+++ b/frontend/src/components/risk/RiskScenariosTab.tsx
@@ -61,7 +61,10 @@ export default function RiskScenariosTab({
       ) : (
         <div className="space-y-3">
           {scenarios.map((scenario) => (
-            <div key={scenario.id} className="p-4 bg-white rounded-lg border border-surface-200">
+            <div
+              key={scenario.id}
+              className="p-4 bg-white rounded-lg border border-surface-200 dark:bg-surface-900"
+            >
               <div className="flex items-center justify-between mb-3">
                 <h4 className="text-white font-medium">{scenario.name}</h4>
                 <button

--- a/frontend/src/components/risk/RiskTasksPanel.tsx
+++ b/frontend/src/components/risk/RiskTasksPanel.tsx
@@ -40,7 +40,7 @@ const statusColors: Record<string, string> = {
 };
 
 const priorityColors: Record<string, string> = {
-  low: 'text-gray-500',
+  low: 'text-gray-500 dark:text-surface-400',
   medium: 'text-amber-500',
   high: 'text-orange-500',
   critical: 'text-red-500',
@@ -53,7 +53,7 @@ const StatusIcon: React.FC<{ status: string }> = ({ status }) => {
     case 'in_progress':
       return <ClockIcon className="h-5 w-5 text-blue-500" />;
     case 'cancelled':
-      return <XCircleIcon className="h-5 w-5 text-gray-500" />;
+      return <XCircleIcon className="h-5 w-5 text-gray-500 dark:text-surface-400" />;
     default:
       return <ClipboardDocumentListIcon className="h-5 w-5 text-amber-500" />;
   }
@@ -238,7 +238,9 @@ function TaskCard({ task, onStart, onComplete, onCancel, isLoading }: TaskCardPr
             <span className={`text-xs font-medium ${priorityColors[task.priority]}`}>
               {task.priority}
             </span>
-            {task.isAutoCreated && <span className="text-xs text-gray-400">auto</span>}
+            {task.isAutoCreated && (
+              <span className="text-xs text-gray-400 dark:text-surface-500">auto</span>
+            )}
           </div>
 
           {task.description && (
@@ -326,7 +328,7 @@ function TaskCard({ task, onStart, onComplete, onCancel, isLoading }: TaskCardPr
             </button>
             <button
               onClick={() => setShowCancelDialog(false)}
-              className="px-3 py-1 text-xs font-medium text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700 rounded"
+              className="px-3 py-1 text-xs font-medium text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700 rounded dark:bg-surface-800"
             >
               Never mind
             </button>
@@ -346,7 +348,7 @@ function CompletedTaskRow({ task }: { task: RiskWorkflowTask }) {
         {task.status}
       </span>
       {task.completedAt && (
-        <span className="text-xs text-gray-500">
+        <span className="text-xs text-gray-500 dark:text-surface-400">
           {format(new Date(task.completedAt), 'MMM d, yyyy')}
         </span>
       )}

--- a/frontend/src/components/risk/RiskTreatmentModal.tsx
+++ b/frontend/src/components/risk/RiskTreatmentModal.tsx
@@ -108,7 +108,7 @@ export default function RiskTreatmentModal({
           <SelectNative
             value={formData.targetResidualRisk}
             onChange={(e) => setFormData({ ...formData, targetResidualRisk: e.target.value })}
-            className="w-full bg-white border border-surface-200 rounded-lg px-3 py-2 text-white"
+            className="w-full bg-white border border-surface-200 rounded-lg px-3 py-2 text-white dark:bg-surface-900"
           >
             {RISK_LEVELS.map((level) => (
               <option key={level.value} value={level.value}>
@@ -123,7 +123,7 @@ export default function RiskTreatmentModal({
             type="date"
             value={formData.treatmentDueDate}
             onChange={(e) => setFormData({ ...formData, treatmentDueDate: e.target.value })}
-            className="w-full bg-white border border-surface-200 rounded-lg px-3 py-2 text-white"
+            className="w-full bg-white border border-surface-200 rounded-lg px-3 py-2 text-white dark:bg-surface-900"
           />
         </div>
         <div>
@@ -133,7 +133,7 @@ export default function RiskTreatmentModal({
             onChange={(e) => setFormData({ ...formData, treatmentNotes: e.target.value })}
             rows={3}
             placeholder="Describe the treatment approach..."
-            className="w-full bg-white border border-surface-200 rounded-lg px-3 py-2 text-white"
+            className="w-full bg-white border border-surface-200 rounded-lg px-3 py-2 text-white dark:bg-surface-900"
           />
         </div>
         <div className="flex justify-end gap-3 pt-4">

--- a/frontend/src/components/risk/RiskWorkflowPanel.tsx
+++ b/frontend/src/components/risk/RiskWorkflowPanel.tsx
@@ -324,7 +324,7 @@ export default function RiskWorkflowPanel({ risk, onUpdate }: RiskWorkflowPanelP
   const actions = getAvailableActions();
 
   return (
-    <div className="bg-white rounded-xl border border-surface-200 overflow-hidden">
+    <div className="bg-white rounded-xl border border-surface-200 overflow-hidden dark:bg-surface-900">
       {/* Header */}
       <button
         onClick={() => setExpanded(!expanded)}
@@ -1021,7 +1021,7 @@ function SubmitAssessmentModal({
 
   return (
     <Dialog open onClose={onClose}>
-      <div className="p-4 border-b border-surface-200 flex justify-between items-center sticky top-0 bg-white">
+      <div className="p-4 border-b border-surface-200 flex justify-between items-center sticky top-0 bg-white dark:bg-surface-900">
         <h3 className="text-lg font-medium text-white">Risk Assessment Form</h3>
         <button onClick={onClose} className="p-1 hover:bg-surface-200 rounded">
           <X className="w-5 h-5 text-surface-600" />
@@ -1177,7 +1177,7 @@ function SubmitAssessmentModal({
           />
         </div>
       </div>
-      <div className="p-4 border-t border-surface-200 flex justify-end gap-3 sticky bottom-0 bg-white">
+      <div className="p-4 border-t border-surface-200 flex justify-end gap-3 sticky bottom-0 bg-white dark:bg-surface-900">
         <button onClick={onClose} className="px-4 py-2 bg-surface-200 text-surface-700 rounded-lg">
           Cancel
         </button>

--- a/frontend/src/components/settings/ApiSettings.tsx
+++ b/frontend/src/components/settings/ApiSettings.tsx
@@ -97,7 +97,7 @@ export default function ApiSettings() {
           {keys.map((key: ApiKey) => (
             <div
               key={key.id}
-              className="flex items-center justify-between p-4 bg-white/50 rounded-lg"
+              className="flex items-center justify-between p-4 bg-white/50 rounded-lg dark:bg-surface-900/50"
             >
               <div>
                 <div className="flex items-center gap-2">

--- a/frontend/src/components/settings/ModuleSettings.tsx
+++ b/frontend/src/components/settings/ModuleSettings.tsx
@@ -123,7 +123,7 @@ export function ModuleSettings() {
               className={`px-3 py-1.5 rounded-full text-xs border ${
                 selectedPreset?.id === preset.id
                   ? 'bg-brand-500 text-white border-brand-500'
-                  : 'bg-white text-surface-700 border-surface-200 hover:bg-white'
+                  : 'bg-white text-surface-700 border-surface-200 hover:bg-white dark:bg-surface-900 dark:hover:bg-surface-800'
               }`}
             >
               {preset.name}
@@ -154,7 +154,7 @@ export function ModuleSettings() {
                 <div className="flex items-center gap-2">
                   <span className="text-sm font-semibold text-surface-900">{mod.name}</span>
                   {!checked && (
-                    <span className="text-[10px] px-2 py-0.5 rounded-full bg-white text-surface-600">
+                    <span className="text-[10px] px-2 py-0.5 rounded-full bg-white text-surface-600 dark:bg-surface-900">
                       Disabled
                     </span>
                   )}

--- a/frontend/src/components/shared/ConfirmDeleteModal.tsx
+++ b/frontend/src/components/shared/ConfirmDeleteModal.tsx
@@ -1,6 +1,6 @@
 /**
  * Confirm Delete Modal Component
- * 
+ *
  * A reusable confirmation modal for delete operations with loading state.
  */
 
@@ -83,21 +83,18 @@ export const ConfirmDeleteModal = memo(function ConfirmDeleteModal({
       >
         {/* Background overlay */}
         <div
-          className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"
+          className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity dark:bg-surface-500"
           aria-hidden="true"
         />
 
         {/* Modal centering trick */}
-        <span
-          className="hidden sm:inline-block sm:h-screen sm:align-middle"
-          aria-hidden="true"
-        >
+        <span className="hidden sm:inline-block sm:h-screen sm:align-middle" aria-hidden="true">
           &#8203;
         </span>
 
         {/* Modal panel */}
-        <div className="inline-block transform overflow-hidden rounded-lg bg-white text-left align-bottom shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:align-middle">
-          <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+        <div className="inline-block transform overflow-hidden rounded-lg bg-white text-left align-bottom shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:align-middle dark:bg-surface-900">
+          <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4 dark:bg-surface-900">
             <div className="sm:flex sm:items-start">
               <div
                 className={`mx-auto flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full ${styles.iconBg} sm:mx-0 sm:h-10 sm:w-10`}
@@ -109,18 +106,20 @@ export const ConfirmDeleteModal = memo(function ConfirmDeleteModal({
               </div>
               <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
                 <h3
-                  className="text-lg font-medium leading-6 text-gray-900"
+                  className="text-lg font-medium leading-6 text-gray-900 dark:text-surface-50"
                   id="modal-title"
                 >
                   {title}
                 </h3>
                 <div className="mt-2">
-                  <p className="text-sm text-gray-500">{message || defaultMessage}</p>
+                  <p className="text-sm text-gray-500 dark:text-surface-400">
+                    {message || defaultMessage}
+                  </p>
                 </div>
               </div>
             </div>
           </div>
-          <div className="bg-gray-50 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6">
+          <div className="bg-gray-50 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6 dark:bg-surface-900">
             <button
               type="button"
               disabled={isLoading}
@@ -159,7 +158,7 @@ export const ConfirmDeleteModal = memo(function ConfirmDeleteModal({
               type="button"
               disabled={isLoading}
               onClick={onClose}
-              className="mt-3 inline-flex w-full justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-base font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 sm:mt-0 sm:w-auto sm:text-sm disabled:opacity-50"
+              className="mt-3 inline-flex w-full justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-base font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 sm:mt-0 sm:w-auto sm:text-sm disabled:opacity-50 dark:bg-surface-900 dark:hover:bg-surface-900 dark:text-surface-200 dark:border-surface-700"
             >
               {cancelButtonText}
             </button>

--- a/frontend/src/components/shared/StatusBadge.tsx
+++ b/frontend/src/components/shared/StatusBadge.tsx
@@ -1,6 +1,6 @@
 /**
  * Status Badge Component
- * 
+ *
  * A reusable badge component for displaying status with consistent styling.
  */
 
@@ -21,13 +21,13 @@ export const STATUS_CONFIGS: Record<string, StatusConfig> = {
   in_progress: { label: 'In Progress', color: 'yellow' },
   not_started: { label: 'Not Started', color: 'gray' },
   not_applicable: { label: 'N/A', color: 'gray' },
-  
+
   // Risk statuses
   open: { label: 'Open', color: 'red' },
   mitigated: { label: 'Mitigated', color: 'green' },
   accepted: { label: 'Accepted', color: 'blue' },
   transferred: { label: 'Transferred', color: 'purple' },
-  
+
   // Evidence statuses
   valid: { label: 'Valid', color: 'green' },
   expired: { label: 'Expired', color: 'red' },
@@ -35,30 +35,30 @@ export const STATUS_CONFIGS: Record<string, StatusConfig> = {
   pending_review: { label: 'Pending Review', color: 'yellow' },
   approved: { label: 'Approved', color: 'green' },
   rejected: { label: 'Rejected', color: 'red' },
-  
+
   // Vendor statuses
   active: { label: 'Active', color: 'green' },
   inactive: { label: 'Inactive', color: 'gray' },
   under_review: { label: 'Under Review', color: 'yellow' },
   terminated: { label: 'Terminated', color: 'red' },
-  
+
   // Audit statuses
   planned: { label: 'Planned', color: 'blue' },
   in_progress_audit: { label: 'In Progress', color: 'yellow' },
   completed: { label: 'Completed', color: 'green' },
   cancelled: { label: 'Cancelled', color: 'gray' },
-  
+
   // Priority levels
   critical: { label: 'Critical', color: 'red' },
   high: { label: 'High', color: 'orange' },
   medium: { label: 'Medium', color: 'yellow' },
   low: { label: 'Low', color: 'green' },
-  
+
   // Policy statuses
   draft: { label: 'Draft', color: 'gray' },
   published: { label: 'Published', color: 'green' },
   archived: { label: 'Archived', color: 'gray' },
-  
+
   // Task statuses
   todo: { label: 'To Do', color: 'gray' },
   done: { label: 'Done', color: 'green' },
@@ -66,7 +66,7 @@ export const STATUS_CONFIGS: Record<string, StatusConfig> = {
 };
 
 const colorClasses = {
-  gray: 'bg-gray-100 text-gray-800',
+  gray: 'bg-gray-100 text-gray-800 dark:bg-surface-800 dark:text-surface-100',
   green: 'bg-green-100 text-green-800',
   yellow: 'bg-yellow-100 text-yellow-800',
   red: 'bg-red-100 text-red-800',
@@ -77,7 +77,7 @@ const colorClasses = {
 };
 
 const dotColorClasses = {
-  gray: 'bg-gray-400',
+  gray: 'bg-gray-400 dark:bg-surface-600',
   green: 'bg-green-400',
   yellow: 'bg-yellow-400',
   red: 'bg-red-400',
@@ -109,12 +109,13 @@ export const StatusBadge = memo(function StatusBadge({
 }: StatusBadgeProps) {
   // Normalize status key (lowercase, replace spaces with underscores)
   const normalizedStatus = status.toLowerCase().replace(/\s+/g, '_');
-  
+
   // Get config from props or predefined configs
-  const statusConfig = config || STATUS_CONFIGS[normalizedStatus] || {
-    label: status,
-    color: 'gray' as const,
-  };
+  const statusConfig = config ||
+    STATUS_CONFIGS[normalizedStatus] || {
+      label: status,
+      color: 'gray' as const,
+    };
 
   const sizeClasses = {
     sm: 'px-2 py-0.5 text-xs',
@@ -146,9 +147,7 @@ export const StatusBadge = memo(function StatusBadge({
           )}
         />
       )}
-      {statusConfig.icon && (
-        <statusConfig.icon className="w-4 h-4" />
-      )}
+      {statusConfig.icon && <statusConfig.icon className="w-4 h-4" />}
       {statusConfig.label}
     </span>
   );

--- a/frontend/src/components/trust/AIAnswerAssistant.tsx
+++ b/frontend/src/components/trust/AIAnswerAssistant.tsx
@@ -190,7 +190,7 @@ export function AIAnswerAssistant({
               </div>
 
               {/* Suggested Answer */}
-              <div className="bg-white/50 rounded-lg p-3 border border-surface-200">
+              <div className="bg-white/50 rounded-lg p-3 border border-surface-200 dark:bg-surface-900/50">
                 <p className="text-sm text-surface-800 whitespace-pre-wrap">
                   {suggestion.suggestedAnswer}
                 </p>

--- a/frontend/src/components/trust/KnowledgeBaseSearchPanel.tsx
+++ b/frontend/src/components/trust/KnowledgeBaseSearchPanel.tsx
@@ -157,12 +157,12 @@ export function KnowledgeBaseSearchPanel({
   return (
     <div
       className={clsx(
-        'bg-white border border-surface-200 rounded-xl shadow-xl overflow-hidden',
+        'bg-white border border-surface-200 rounded-xl shadow-xl overflow-hidden dark:bg-surface-900',
         className
       )}
     >
       {/* Header */}
-      <div className="bg-white px-4 py-3 flex items-center justify-between border-b border-surface-200">
+      <div className="bg-white px-4 py-3 flex items-center justify-between border-b border-surface-200 dark:bg-surface-900">
         <div className="flex items-center gap-2">
           <BookOpenIcon className="w-5 h-5 text-brand-400" />
           <h3 className="font-semibold text-surface-900">Knowledge Base</h3>
@@ -185,7 +185,7 @@ export function KnowledgeBaseSearchPanel({
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             placeholder="Search knowledge base..."
-            className="w-full pl-9 pr-3 py-2 bg-white border border-surface-300 rounded-lg text-surface-900 text-sm focus:outline-none focus:border-brand-500 placeholder:text-surface-500"
+            className="w-full pl-9 pr-3 py-2 bg-white border border-surface-300 rounded-lg text-surface-900 text-sm focus:outline-none focus:border-brand-500 placeholder:text-surface-500 dark:bg-surface-900"
           />
           {loading && (
             <ArrowPathIcon className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-surface-600 animate-spin" />
@@ -214,7 +214,9 @@ export function KnowledgeBaseSearchPanel({
             key={entry.id}
             className={clsx(
               'border-b border-surface-200 last:border-b-0 transition-colors',
-              selectedEntry?.id === entry.id ? 'bg-brand-500/10' : 'hover:bg-white'
+              selectedEntry?.id === entry.id
+                ? 'bg-brand-500/10'
+                : 'hover:bg-white dark:bg-surface-900 dark:hover:bg-surface-800'
             )}
           >
             <button
@@ -257,7 +259,7 @@ export function KnowledgeBaseSearchPanel({
             {/* Expanded View */}
             {selectedEntry?.id === entry.id && (
               <div className="px-3 pb-3 space-y-3">
-                <div className="bg-white rounded-lg p-3 border border-surface-300">
+                <div className="bg-white rounded-lg p-3 border border-surface-300 dark:bg-surface-900">
                   <p className="text-sm text-surface-800 whitespace-pre-wrap">
                     {entry.answer || 'No answer content'}
                   </p>
@@ -300,7 +302,7 @@ export function KnowledgeBaseSearchPanel({
         ))}
       </div>
       {/* Footer hint */}
-      <div className="px-4 py-2 bg-white border-t border-surface-200">
+      <div className="px-4 py-2 bg-white border-t border-surface-200 dark:bg-surface-900">
         <p className="text-xs text-surface-500 text-center">
           Click an entry to preview, then "Use This Answer" to apply
         </p>

--- a/frontend/src/components/trust/TrustAnalystQueueWidget.tsx
+++ b/frontend/src/components/trust/TrustAnalystQueueWidget.tsx
@@ -38,7 +38,12 @@ export function TrustAnalystQueueWidget({ className }: TrustAnalystQueueWidgetPr
 
   if (!organizationId) {
     return (
-      <div className={clsx('bg-white border border-surface-200 rounded-xl p-6', className)}>
+      <div
+        className={clsx(
+          'bg-white border border-surface-200 rounded-xl p-6 dark:bg-surface-900',
+          className
+        )}
+      >
         <p className="text-surface-600 text-sm">Sign in to view your questionnaire queue.</p>
       </div>
     );
@@ -46,13 +51,18 @@ export function TrustAnalystQueueWidget({ className }: TrustAnalystQueueWidgetPr
 
   if (isLoading) {
     return (
-      <div className={clsx('bg-white border border-surface-200 rounded-xl p-6', className)}>
+      <div
+        className={clsx(
+          'bg-white border border-surface-200 rounded-xl p-6 dark:bg-surface-900',
+          className
+        )}
+      >
         <div className="animate-pulse space-y-4">
           <div className="h-6 bg-surface-200 rounded w-48" />
           <div className="space-y-3">
-            <div className="h-16 bg-white rounded" />
-            <div className="h-16 bg-white rounded" />
-            <div className="h-16 bg-white rounded" />
+            <div className="h-16 bg-white rounded dark:bg-surface-900" />
+            <div className="h-16 bg-white rounded dark:bg-surface-900" />
+            <div className="h-16 bg-white rounded dark:bg-surface-900" />
           </div>
         </div>
       </div>
@@ -61,7 +71,12 @@ export function TrustAnalystQueueWidget({ className }: TrustAnalystQueueWidgetPr
 
   if (error) {
     return (
-      <div className={clsx('bg-white border border-surface-200 rounded-xl p-6', className)}>
+      <div
+        className={clsx(
+          'bg-white border border-surface-200 rounded-xl p-6 dark:bg-surface-900',
+          className
+        )}
+      >
         <p className="text-red-600 text-sm">Failed to load queue</p>
       </div>
     );
@@ -74,7 +89,10 @@ export function TrustAnalystQueueWidget({ className }: TrustAnalystQueueWidgetPr
 
   return (
     <div
-      className={clsx('bg-white border border-surface-200 rounded-xl overflow-hidden', className)}
+      className={clsx(
+        'bg-white border border-surface-200 rounded-xl overflow-hidden dark:bg-surface-900',
+        className
+      )}
     >
       {/* Header */}
       <div className="px-5 py-4 border-b border-surface-200 flex items-center justify-between">
@@ -165,7 +183,7 @@ export function TrustAnalystQueueWidget({ className }: TrustAnalystQueueWidgetPr
       </div>
 
       {/* Footer */}
-      <div className="px-5 py-3 border-t border-surface-200 bg-white/50">
+      <div className="px-5 py-3 border-t border-surface-200 bg-white/50 dark:bg-surface-900/50">
         <Link
           to="/questionnaires"
           className="flex items-center justify-center gap-2 text-sm text-brand-400 hover:text-brand-300 transition-colors"
@@ -198,7 +216,7 @@ function StatBox({
   };
 
   return (
-    <div className="bg-white p-3 text-center">
+    <div className="bg-white p-3 text-center dark:bg-surface-900">
       <div
         className={clsx('text-2xl font-bold', value > 0 ? colorClasses[color] : 'text-surface-500')}
       >
@@ -254,7 +272,7 @@ function QueueSection({
           <Link
             key={item.id}
             to={`/questionnaires/${item.id}`}
-            className="block px-4 py-3 hover:bg-white/50 transition-colors group"
+            className="block px-4 py-3 hover:bg-white/50 transition-colors group dark:bg-surface-900/50 dark:hover:bg-surface-800/50"
           >
             <div className="flex items-start justify-between gap-2">
               <div className="flex-1 min-w-0">

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -53,10 +53,12 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
       <input
         ref={ref}
         className={cn(
-          'w-full rounded-md border bg-white px-3 text-surface-900 placeholder:text-surface-600 transition-colors',
-          'focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-1 focus-visible:ring-offset-surface-50',
+          'w-full rounded-md border bg-white dark:bg-surface-900 px-3 text-surface-900 dark:text-surface-100 placeholder:text-surface-600 dark:placeholder:text-surface-500 transition-colors',
+          'focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-1 focus-visible:ring-offset-surface-50 dark:focus-visible:ring-offset-surface-950',
           'disabled:opacity-50 disabled:cursor-not-allowed',
-          invalid ? 'border-red-500/60' : 'border-surface-300 hover:border-surface-400',
+          invalid
+            ? 'border-red-500/60 dark:border-red-500/70'
+            : 'border-surface-300 dark:border-surface-700 hover:border-surface-400 dark:hover:border-surface-600',
           sizes[inputSize],
           className
         )}

--- a/frontend/src/components/vendor/SOC2AnalysisPanel.tsx
+++ b/frontend/src/components/vendor/SOC2AnalysisPanel.tsx
@@ -80,7 +80,7 @@ export function SOC2AnalysisPanel({
 
   if (!analysis) {
     return (
-      <div className="bg-white/50 border border-surface-200 rounded-lg p-6">
+      <div className="bg-white/50 border border-surface-200 rounded-lg p-6 dark:bg-surface-900/50">
         <div className="flex items-center gap-3 mb-4">
           <SparklesIcon className="w-6 h-6 text-purple-600" />
           <div>
@@ -90,7 +90,7 @@ export function SOC2AnalysisPanel({
             </p>
           </div>
         </div>
-        <div className="bg-white/50 rounded-lg p-4 mb-4">
+        <div className="bg-white/50 rounded-lg p-4 mb-4 dark:bg-surface-900/50">
           <p className="text-sm text-surface-700 mb-3">AI analysis will extract:</p>
           <ul className="text-sm text-surface-600 space-y-2">
             <li className="flex items-center gap-2">
@@ -136,7 +136,7 @@ export function SOC2AnalysisPanel({
   return (
     <div className="space-y-4">
       {/* Analysis Header */}
-      <div className="bg-white/50 border border-surface-200 rounded-lg p-4">
+      <div className="bg-white/50 border border-surface-200 rounded-lg p-4 dark:bg-surface-900/50">
         <div className="flex items-start justify-between">
           <div className="flex items-center gap-3">
             <div className="p-2 bg-purple-500/20 rounded-lg">
@@ -166,13 +166,13 @@ export function SOC2AnalysisPanel({
         </div>
 
         {/* Summary */}
-        <div className="mt-4 p-3 bg-white/50 rounded-lg">
+        <div className="mt-4 p-3 bg-white/50 rounded-lg dark:bg-surface-900/50">
           <p className="text-sm text-surface-700">{analysis.summary}</p>
         </div>
 
         {/* Key Stats */}
         <div className="grid grid-cols-4 gap-3 mt-4">
-          <div className="text-center p-2 bg-white/50 rounded-lg">
+          <div className="text-center p-2 bg-white/50 rounded-lg dark:bg-surface-900/50">
             <p
               className={clsx('text-xl font-bold', RISK_SCORE_COLORS[analysis.suggestedRiskScore])}
             >
@@ -181,7 +181,7 @@ export function SOC2AnalysisPanel({
             </p>
             <p className="text-xs text-surface-600">Risk Score</p>
           </div>
-          <div className="text-center p-2 bg-white/50 rounded-lg">
+          <div className="text-center p-2 bg-white/50 rounded-lg dark:bg-surface-900/50">
             <p
               className={clsx(
                 'text-xl font-bold',
@@ -192,11 +192,11 @@ export function SOC2AnalysisPanel({
             </p>
             <p className="text-xs text-surface-600">Exceptions</p>
           </div>
-          <div className="text-center p-2 bg-white/50 rounded-lg">
+          <div className="text-center p-2 bg-white/50 rounded-lg dark:bg-surface-900/50">
             <p className="text-xl font-bold text-yellow-600">{analysis.cuecs.length}</p>
             <p className="text-xs text-surface-600">CUECs</p>
           </div>
-          <div className="text-center p-2 bg-white/50 rounded-lg">
+          <div className="text-center p-2 bg-white/50 rounded-lg dark:bg-surface-900/50">
             <p className="text-xl font-bold text-blue-600">{analysis.controlGaps.length}</p>
             <p className="text-xs text-surface-600">Gaps</p>
           </div>
@@ -309,7 +309,7 @@ export function SOC2AnalysisPanel({
         >
           <div className="space-y-2">
             {analysis.subserviceOrganizations.map((org, idx) => (
-              <div key={idx} className="p-3 bg-white/50 rounded-lg">
+              <div key={idx} className="p-3 bg-white/50 rounded-lg dark:bg-surface-900/50">
                 <p className="font-medium text-surface-900">{org.name}</p>
                 <p className="text-sm text-surface-600 mt-1">{org.services}</p>
                 <p className="text-xs text-surface-500 mt-1">
@@ -356,7 +356,7 @@ function CollapsibleSection({
   children,
 }: CollapsibleSectionProps) {
   return (
-    <div className="bg-white/50 border border-surface-200 rounded-lg overflow-hidden">
+    <div className="bg-white/50 border border-surface-200 rounded-lg overflow-hidden dark:bg-surface-900/50">
       <button
         onClick={onToggle}
         className="w-full flex items-center justify-between p-4 hover:bg-surface-200/50 transition-colors"
@@ -416,7 +416,7 @@ function CUECCard({ cuec }: { cuec: CUEC }) {
   };
 
   return (
-    <div className="p-3 bg-white/50 rounded-lg">
+    <div className="p-3 bg-white/50 rounded-lg dark:bg-surface-900/50">
       <div className="flex items-start justify-between">
         <p className="text-sm text-surface-800 flex-1">{cuec.description}</p>
         <span
@@ -442,7 +442,7 @@ function GapCard({ gap }: { gap: ControlGap }) {
   };
 
   return (
-    <div className="p-3 bg-white/50 rounded-lg">
+    <div className="p-3 bg-white/50 rounded-lg dark:bg-surface-900/50">
       <div className="flex items-center justify-between mb-2">
         <span className="font-medium text-surface-900">{gap.area}</span>
         <span className={clsx('text-xs capitalize', priorityColors[gap.priority])}>

--- a/frontend/src/components/vendor/VendorReviewsDueWidget.tsx
+++ b/frontend/src/components/vendor/VendorReviewsDueWidget.tsx
@@ -94,7 +94,9 @@ export function VendorReviewsDueWidget({ className }: VendorReviewsDueWidgetProp
         <div
           className={clsx(
             'p-3 rounded-lg text-center',
-            summary.overdueCount > 0 ? 'bg-red-500/10 border border-red-500/30' : 'bg-white'
+            summary.overdueCount > 0
+              ? 'bg-red-500/10 border border-red-500/30'
+              : 'bg-white dark:bg-surface-900'
           )}
         >
           <p
@@ -112,7 +114,7 @@ export function VendorReviewsDueWidget({ className }: VendorReviewsDueWidgetProp
             'p-3 rounded-lg text-center',
             summary.dueThisWeekCount > 0
               ? 'bg-orange-500/10 border border-orange-500/30'
-              : 'bg-white'
+              : 'bg-white dark:bg-surface-900'
           )}
         >
           <p
@@ -130,7 +132,7 @@ export function VendorReviewsDueWidget({ className }: VendorReviewsDueWidgetProp
             'p-3 rounded-lg text-center',
             summary.dueThisMonthCount > 0
               ? 'bg-yellow-500/10 border border-yellow-500/30'
-              : 'bg-white'
+              : 'bg-white dark:bg-surface-900'
           )}
         >
           <p
@@ -222,7 +224,7 @@ function ReviewItem({ vendor, status, statusText }: ReviewItemProps) {
   return (
     <Link
       to={`/vendors/${vendor.id}`}
-      className="flex items-center justify-between p-3 bg-white/50 hover:bg-surface-200 rounded-lg transition-colors group"
+      className="flex items-center justify-between p-3 bg-white/50 hover:bg-surface-200 rounded-lg transition-colors group dark:bg-surface-900/50"
     >
       <div className="flex items-center gap-3 min-w-0">
         <Icon className={clsx('w-4 h-4 flex-shrink-0', statusColors[status])} />

--- a/frontend/src/components/vendor/VendorRiskAssessmentPanel.tsx
+++ b/frontend/src/components/vendor/VendorRiskAssessmentPanel.tsx
@@ -77,7 +77,7 @@ function ScoreBar({
   return (
     <div className="flex items-center gap-3">
       <span className="text-sm text-surface-600 w-24">{label}</span>
-      <div className="flex-1 h-2 bg-white rounded-full overflow-hidden">
+      <div className="flex-1 h-2 bg-white rounded-full overflow-hidden dark:bg-surface-900">
         <div className={clsx('h-full transition-all', color)} style={{ width: `${percentage}%` }} />
       </div>
       <span className="text-sm font-medium text-surface-700 w-12 text-right">
@@ -174,7 +174,7 @@ export function VendorRiskAssessmentPanel({
 
   if (loading) {
     return (
-      <div className="bg-white border border-surface-200 rounded-lg p-6">
+      <div className="bg-white border border-surface-200 rounded-lg p-6 dark:bg-surface-900">
         <div className="flex items-center gap-3 mb-4">
           <ShieldExclamationIcon className="w-5 h-5 text-brand-400" />
           <h3 className="text-lg font-medium text-surface-900">Risk Assessment</h3>
@@ -189,7 +189,7 @@ export function VendorRiskAssessmentPanel({
 
   if (error) {
     return (
-      <div className="bg-white border border-surface-200 rounded-lg p-6">
+      <div className="bg-white border border-surface-200 rounded-lg p-6 dark:bg-surface-900">
         <div className="flex items-center gap-3 mb-4">
           <ShieldExclamationIcon className="w-5 h-5 text-brand-400" />
           <h3 className="text-lg font-medium text-surface-900">Risk Assessment</h3>
@@ -207,7 +207,7 @@ export function VendorRiskAssessmentPanel({
 
   if (!latestAssessment) {
     return (
-      <div className="bg-white border border-surface-200 rounded-lg p-6">
+      <div className="bg-white border border-surface-200 rounded-lg p-6 dark:bg-surface-900">
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center gap-3">
             <ShieldExclamationIcon className="w-5 h-5 text-brand-400" />
@@ -232,7 +232,7 @@ export function VendorRiskAssessmentPanel({
   }
 
   return (
-    <div className="bg-white border border-surface-200 rounded-lg p-6">
+    <div className="bg-white border border-surface-200 rounded-lg p-6 dark:bg-surface-900">
       {/* Header */}
       <div className="flex items-center justify-between mb-6">
         <div className="flex items-center gap-3">
@@ -319,7 +319,7 @@ export function VendorRiskAssessmentPanel({
       </div>
 
       {/* Recommended Action */}
-      <div className="p-3 bg-white/50 rounded-lg mb-6">
+      <div className="p-3 bg-white/50 rounded-lg mb-6 dark:bg-surface-900/50">
         <div className="flex items-start gap-2">
           <CheckCircleIcon className="w-5 h-5 text-brand-400 mt-0.5 flex-shrink-0" />
           <div>
@@ -331,7 +331,7 @@ export function VendorRiskAssessmentPanel({
 
       {/* Details Grid */}
       <div className="grid grid-cols-2 gap-4 mb-6">
-        <div className="p-3 bg-white/30 rounded-lg">
+        <div className="p-3 bg-white/30 rounded-lg dark:bg-surface-900/30">
           <h5 className="text-xs text-surface-500 uppercase tracking-wide mb-1">Likelihood</h5>
           <p className="text-lg font-semibold text-surface-800">
             {latestAssessment.likelihood.level}
@@ -342,7 +342,7 @@ export function VendorRiskAssessmentPanel({
             {latestAssessment.likelihood.controlStrength}
           </p>
         </div>
-        <div className="p-3 bg-white/30 rounded-lg">
+        <div className="p-3 bg-white/30 rounded-lg dark:bg-surface-900/30">
           <h5 className="text-xs text-surface-500 uppercase tracking-wide mb-1">Impact</h5>
           <p className="text-lg font-semibold text-surface-800">{latestAssessment.impact.level}</p>
           <p className="text-xs text-surface-600">Total: {latestAssessment.impact.total} points</p>
@@ -371,7 +371,7 @@ export function VendorRiskAssessmentPanel({
               {history.slice(1).map((assessment) => (
                 <div
                   key={assessment.id}
-                  className="flex items-center justify-between p-3 bg-white/30 rounded-lg"
+                  className="flex items-center justify-between p-3 bg-white/30 rounded-lg dark:bg-surface-900/30"
                 >
                   <div>
                     <p className="text-sm font-medium text-surface-700">{assessment.title}</p>

--- a/frontend/src/components/vendor/VendorRiskAssessmentWizard.tsx
+++ b/frontend/src/components/vendor/VendorRiskAssessmentWizard.tsx
@@ -193,7 +193,7 @@ function RadioOption({
         'w-full text-left p-3 rounded-lg border transition-colors',
         selected
           ? 'border-brand-500 bg-brand-500/10'
-          : 'border-surface-200 hover:border-surface-300 bg-white/50'
+          : 'border-surface-200 hover:border-surface-300 bg-white/50 dark:bg-surface-900/50'
       )}
     >
       <div className="flex items-start gap-3">
@@ -228,7 +228,7 @@ function ScoreIndicator({
   return (
     <div className="flex items-center gap-2">
       <span className="text-sm text-surface-600 w-20">{label}</span>
-      <div className="flex-1 h-2 bg-white rounded-full overflow-hidden">
+      <div className="flex-1 h-2 bg-white rounded-full overflow-hidden dark:bg-surface-900">
         <div
           className={clsx(
             'h-full transition-all',
@@ -401,7 +401,7 @@ export function VendorRiskAssessmentWizard({
                 type="text"
                 value={state.title}
                 onChange={(e) => setState({ ...state, title: e.target.value })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               />
             </div>
             <div>
@@ -410,7 +410,7 @@ export function VendorRiskAssessmentWizard({
                 value={state.description}
                 onChange={(e) => setState({ ...state, description: e.target.value })}
                 rows={3}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
                 placeholder="Describe the risk scenario in 1-2 sentences..."
               />
             </div>
@@ -422,7 +422,7 @@ export function VendorRiskAssessmentWizard({
                 type="text"
                 value={state.assessor}
                 onChange={(e) => setState({ ...state, assessor: e.target.value })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               />
             </div>
           </div>
@@ -579,7 +579,7 @@ export function VendorRiskAssessmentWizard({
                       ),
                     })
                   }
-                  className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                  className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
                 >
                   {options.map((opt) => (
                     <option key={opt.value} value={opt.value}>
@@ -631,7 +631,7 @@ export function VendorRiskAssessmentWizard({
               <ScoreIndicator score={impactScore} maxScore={25} label="Impact" />
             </div>
 
-            <div className="p-4 bg-white/50 rounded-lg">
+            <div className="p-4 bg-white/50 rounded-lg dark:bg-surface-900/50">
               <h4 className="font-medium text-surface-800 mb-2">Recommended Action</h4>
               <p className="text-surface-600">
                 {riskLevel === 'Critical'
@@ -668,7 +668,7 @@ export function VendorRiskAssessmentWizard({
         </div>
 
         {/* Progress */}
-        <div className="px-4 py-3 border-b border-surface-200 bg-white/30">
+        <div className="px-4 py-3 border-b border-surface-200 bg-white/30 dark:bg-surface-900/30">
           <div className="flex items-center gap-2">
             {steps.map((_, i) => (
               <div key={i} className="flex items-center">
@@ -679,7 +679,7 @@ export function VendorRiskAssessmentWizard({
                       ? 'bg-brand-500 text-white'
                       : i === step
                         ? 'bg-brand-500/20 text-brand-400 border border-brand-500'
-                        : 'bg-white text-surface-500'
+                        : 'bg-white text-surface-500 dark:bg-surface-900'
                   )}
                 >
                   {i < step ? <CheckCircleIcon className="w-5 h-5" /> : i + 1}

--- a/frontend/src/components/vendor/VendorSecurityScanPanel.tsx
+++ b/frontend/src/components/vendor/VendorSecurityScanPanel.tsx
@@ -203,7 +203,7 @@ function ScoreGauge({ score, size = 'lg' }: { score: number; size?: 'sm' | 'lg' 
     return (
       <div className="flex items-center gap-2">
         <div className={clsx('text-lg font-bold', getColor(score))}>{score}</div>
-        <div className="w-16 h-2 bg-white rounded-full overflow-hidden">
+        <div className="w-16 h-2 bg-white rounded-full overflow-hidden dark:bg-surface-900">
           <div
             className={clsx(
               'h-full',
@@ -301,7 +301,7 @@ function StatusBadgeWithLink({
         href={url}
         target="_blank"
         rel="noopener noreferrer"
-        className="hover:bg-white rounded px-1 -mx-1 transition-colors group"
+        className="hover:bg-white rounded px-1 -mx-1 transition-colors group dark:bg-surface-900 dark:hover:bg-surface-800"
         title={`Open ${label}`}
       >
         {content}
@@ -389,7 +389,7 @@ function SubdomainCrawlModal({
         </div>
         <button
           onClick={onClose}
-          className="p-2 text-surface-600 hover:text-surface-800 hover:bg-white rounded-lg transition-colors"
+          className="p-2 text-surface-600 hover:text-surface-800 hover:bg-white rounded-lg transition-colors dark:bg-surface-900 dark:hover:bg-surface-800"
         >
           <XMarkIcon className="w-5 h-5" />
         </button>
@@ -415,7 +415,7 @@ function SubdomainCrawlModal({
         {crawlResult && (
           <>
             {/* Stats Bar */}
-            <div className="flex items-center gap-6 p-4 bg-white/50 border-b border-surface-200">
+            <div className="flex items-center gap-6 p-4 bg-white/50 border-b border-surface-200 dark:bg-surface-900/50">
               <div>
                 <div className="text-2xl font-bold text-surface-900">
                   {crawlResult.pages.length}
@@ -462,7 +462,7 @@ function SubdomainCrawlModal({
             {/* Table */}
             <div className="overflow-auto max-h-[calc(85vh-280px)]">
               <table className="w-full text-sm">
-                <thead className="sticky top-0 bg-white z-10">
+                <thead className="sticky top-0 bg-white z-10 dark:bg-surface-900">
                   <tr className="border-b border-surface-200">
                     <th className="px-4 py-2 text-left text-xs font-medium text-surface-600 uppercase">
                       Page
@@ -479,7 +479,10 @@ function SubdomainCrawlModal({
                 <tbody className="divide-y divide-surface-200">
                   {(activeTab === 'pages' ? crawlResult.pages : crawlResult.externalLinks).map(
                     (page, idx) => (
-                      <tr key={idx} className="hover:bg-white/50">
+                      <tr
+                        key={idx}
+                        className="hover:bg-white/50 dark:bg-surface-900/50 dark:hover:bg-surface-800/50"
+                      >
                         <td className="px-4 py-3">
                           <div className="flex items-start gap-2">
                             <DocumentTextIcon className="w-4 h-4 text-surface-500 mt-0.5 flex-shrink-0" />
@@ -672,7 +675,7 @@ function SubdomainSection({
             'px-3 py-2 rounded-lg text-left transition-colors',
             filter === 'all'
               ? 'bg-brand-500/20 border border-brand-500/50'
-              : 'bg-white border border-surface-200 hover:border-surface-300'
+              : 'bg-white border border-surface-200 hover:border-surface-300 dark:bg-surface-900'
           )}
         >
           <div className="text-lg font-semibold text-surface-900">
@@ -686,7 +689,7 @@ function SubdomainSection({
             'px-3 py-2 rounded-lg text-left transition-colors',
             filter === 'sensitive'
               ? 'bg-red-500/20 border border-red-500/50'
-              : 'bg-white border border-surface-200 hover:border-surface-300'
+              : 'bg-white border border-surface-200 hover:border-surface-300 dark:bg-surface-900'
           )}
         >
           <div
@@ -705,7 +708,7 @@ function SubdomainSection({
             'px-3 py-2 rounded-lg text-left transition-colors',
             filter === 'ssl'
               ? 'bg-green-500/20 border border-green-500/50'
-              : 'bg-white border border-surface-200 hover:border-surface-300'
+              : 'bg-white border border-surface-200 hover:border-surface-300 dark:bg-surface-900'
           )}
         >
           <div className="text-lg font-semibold text-green-600">{sslSubdomains.length}</div>
@@ -717,7 +720,7 @@ function SubdomainSection({
             'px-3 py-2 rounded-lg text-left transition-colors',
             filter === 'nossl'
               ? 'bg-yellow-500/20 border border-yellow-500/50'
-              : 'bg-white border border-surface-200 hover:border-surface-300'
+              : 'bg-white border border-surface-200 hover:border-surface-300 dark:bg-surface-900'
           )}
         >
           <div
@@ -733,10 +736,10 @@ function SubdomainSection({
       </div>
 
       {/* Table */}
-      <div className="bg-white/50 rounded-lg border border-surface-200 overflow-hidden">
+      <div className="bg-white/50 rounded-lg border border-surface-200 overflow-hidden dark:bg-surface-900/50">
         <table className="w-full text-sm">
           <thead>
-            <tr className="border-b border-surface-200 bg-white">
+            <tr className="border-b border-surface-200 bg-white dark:bg-surface-900">
               <th className="px-4 py-2 text-left text-xs font-medium text-surface-600 uppercase tracking-wider">
                 Subdomain
               </th>
@@ -874,7 +877,7 @@ function FindingCard({
       case 'Low':
         return 'border-blue-500/50 bg-blue-500/5';
       default:
-        return 'border-surface-200 bg-white/50';
+        return 'border-surface-200 bg-white/50 dark:bg-surface-900/50';
     }
   };
 
@@ -1025,7 +1028,7 @@ export function VendorSecurityScanPanel({
 
   if (scanning) {
     return (
-      <div className="bg-white border border-surface-200 rounded-lg p-8">
+      <div className="bg-white border border-surface-200 rounded-lg p-8 dark:bg-surface-900">
         <div className="flex flex-col items-center justify-center">
           <ArrowPathIcon className="w-12 h-12 text-brand-400 animate-spin mb-4" />
           <h3 className="text-lg font-medium text-surface-900 mb-2">Scanning {vendorName}...</h3>
@@ -1040,7 +1043,7 @@ export function VendorSecurityScanPanel({
 
   if (!result) {
     return (
-      <div className="bg-white border border-surface-200 rounded-lg p-6">
+      <div className="bg-white border border-surface-200 rounded-lg p-6 dark:bg-surface-900">
         <div className="flex items-center gap-4 mb-4">
           <GlobeAltIcon className="w-8 h-8 text-brand-400" />
           <div>
@@ -1079,7 +1082,7 @@ export function VendorSecurityScanPanel({
   }
 
   return (
-    <div className="bg-white border border-surface-200 rounded-lg">
+    <div className="bg-white border border-surface-200 rounded-lg dark:bg-surface-900">
       {/* Header */}
       <div className="flex items-center justify-between p-4 border-b border-surface-200">
         <div className="flex items-center gap-3">
@@ -1317,7 +1320,7 @@ export function VendorSecurityScanPanel({
 
       {/* Recommendations */}
       {result.recommendations.length > 0 && (
-        <div className="p-4 bg-white/30 border-t border-surface-200">
+        <div className="p-4 bg-white/30 border-t border-surface-200 dark:bg-surface-900/30">
           <h4 className="text-sm font-medium text-surface-700 mb-2">Top Recommendations</h4>
           <ul className="space-y-1">
             {result.recommendations.slice(0, 5).map((rec, i) => (

--- a/frontend/src/pages/AIRiskAssistant.tsx
+++ b/frontend/src/pages/AIRiskAssistant.tsx
@@ -44,7 +44,7 @@ export default function AIRiskAssistant() {
         <h1 className="text-2xl font-semibold text-white">AI Risk Assistant</h1>
         <p className="text-surface-600">
           The AI module is not enabled for this environment. Ask an administrator to set
-          <code className="mx-1 text-xs bg-white px-2 py-1 rounded">
+          <code className="mx-1 text-xs bg-white px-2 py-1 rounded dark:bg-surface-900">
             VITE_ENABLE_AI_MODULE=true
           </code>
           and provide AI provider API keys.

--- a/frontend/src/pages/AccountSettings.tsx
+++ b/frontend/src/pages/AccountSettings.tsx
@@ -46,7 +46,7 @@ export default function AccountSettings() {
                   'w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors',
                   activeTab === tab.id
                     ? 'bg-brand-600/20 text-brand-400'
-                    : 'text-surface-600 hover:bg-white hover:text-surface-900'
+                    : 'text-surface-600 hover:bg-white hover:text-surface-900 dark:bg-surface-900 dark:hover:bg-surface-800'
                 )}
               >
                 <tab.icon className="w-5 h-5" />
@@ -166,7 +166,7 @@ function NotificationPreferences() {
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             {/* Email */}
-            <label className="flex flex-col p-4 bg-white/50 rounded-lg cursor-pointer hover:bg-white border-2 transition-colors border-transparent has-[:checked]:border-brand-500">
+            <label className="flex flex-col p-4 bg-white/50 rounded-lg cursor-pointer hover:bg-white border-2 transition-colors border-transparent has-[:checked]:border-brand-500 dark:bg-surface-900/50 dark:hover:bg-surface-800">
               <div className="flex items-center justify-between mb-2">
                 <span className="text-surface-900 font-medium flex items-center gap-2">
                   <svg
@@ -195,7 +195,7 @@ function NotificationPreferences() {
             </label>
 
             {/* In-App */}
-            <label className="flex flex-col p-4 bg-white/50 rounded-lg cursor-pointer hover:bg-white border-2 transition-colors border-transparent has-[:checked]:border-brand-500">
+            <label className="flex flex-col p-4 bg-white/50 rounded-lg cursor-pointer hover:bg-white border-2 transition-colors border-transparent has-[:checked]:border-brand-500 dark:bg-surface-900/50 dark:hover:bg-surface-800">
               <div className="flex items-center justify-between mb-2">
                 <span className="text-surface-900 font-medium flex items-center gap-2">
                   <BellIcon className="w-5 h-5 text-surface-600" />
@@ -212,7 +212,7 @@ function NotificationPreferences() {
             </label>
 
             {/* Slack */}
-            <label className="flex flex-col p-4 bg-white/50 rounded-lg cursor-pointer hover:bg-white border-2 transition-colors border-transparent has-[:checked]:border-brand-500">
+            <label className="flex flex-col p-4 bg-white/50 rounded-lg cursor-pointer hover:bg-white border-2 transition-colors border-transparent has-[:checked]:border-brand-500 dark:bg-surface-900/50 dark:hover:bg-surface-800">
               <div className="flex items-center justify-between mb-2">
                 <span className="text-surface-900 font-medium flex items-center gap-2">
                   <svg className="w-5 h-5 text-surface-600" viewBox="0 0 24 24" fill="currentColor">
@@ -233,7 +233,7 @@ function NotificationPreferences() {
 
           {/* Slack User ID - only shown when Slack is enabled */}
           {riskTaskPrefs.slack && (
-            <div className="p-4 bg-white/30 rounded-lg border border-surface-200">
+            <div className="p-4 bg-white/30 rounded-lg border border-surface-200 dark:bg-surface-900/30">
               <label className="label">Slack User ID</label>
               <Input
                 type="text"
@@ -268,7 +268,7 @@ function NotificationPreferences() {
                   'flex-1 min-w-[200px] p-3 rounded-lg cursor-pointer border-2 transition-colors',
                   riskTaskPrefs.digestMode === option.value
                     ? 'border-brand-500 bg-brand-500/10'
-                    : 'border-surface-200 bg-white/50 hover:border-surface-300'
+                    : 'border-surface-200 bg-white/50 hover:border-surface-300 dark:bg-surface-900/50'
                 )}
               >
                 <div className="flex items-center gap-2">
@@ -305,7 +305,7 @@ function NotificationPreferences() {
           <h3 className="text-sm font-medium text-surface-700">Email Notifications</h3>
 
           <div className="space-y-3">
-            <label className="flex items-center justify-between p-3 bg-white/50 rounded-lg cursor-pointer hover:bg-white">
+            <label className="flex items-center justify-between p-3 bg-white/50 rounded-lg cursor-pointer hover:bg-white dark:bg-surface-900/50 dark:hover:bg-surface-800">
               <div>
                 <span className="text-surface-900 font-medium">Email Notifications</span>
                 <p className="text-surface-500 text-sm">Receive notifications via email</p>
@@ -318,7 +318,7 @@ function NotificationPreferences() {
               />
             </label>
 
-            <label className="flex items-center justify-between p-3 bg-white/50 rounded-lg cursor-pointer hover:bg-white">
+            <label className="flex items-center justify-between p-3 bg-white/50 rounded-lg cursor-pointer hover:bg-white dark:bg-surface-900/50 dark:hover:bg-surface-800">
               <div>
                 <span className="text-surface-900 font-medium">Compliance Alerts</span>
                 <p className="text-surface-500 text-sm">
@@ -333,7 +333,7 @@ function NotificationPreferences() {
               />
             </label>
 
-            <label className="flex items-center justify-between p-3 bg-white/50 rounded-lg cursor-pointer hover:bg-white">
+            <label className="flex items-center justify-between p-3 bg-white/50 rounded-lg cursor-pointer hover:bg-white dark:bg-surface-900/50 dark:hover:bg-surface-800">
               <div>
                 <span className="text-surface-900 font-medium">Evidence Reminders</span>
                 <p className="text-surface-500 text-sm">
@@ -348,7 +348,7 @@ function NotificationPreferences() {
               />
             </label>
 
-            <label className="flex items-center justify-between p-3 bg-white/50 rounded-lg cursor-pointer hover:bg-white">
+            <label className="flex items-center justify-between p-3 bg-white/50 rounded-lg cursor-pointer hover:bg-white dark:bg-surface-900/50 dark:hover:bg-surface-800">
               <div>
                 <span className="text-surface-900 font-medium">Risk Alerts</span>
                 <p className="text-surface-500 text-sm">
@@ -363,7 +363,7 @@ function NotificationPreferences() {
               />
             </label>
 
-            <label className="flex items-center justify-between p-3 bg-white/50 rounded-lg cursor-pointer hover:bg-white">
+            <label className="flex items-center justify-between p-3 bg-white/50 rounded-lg cursor-pointer hover:bg-white dark:bg-surface-900/50 dark:hover:bg-surface-800">
               <div>
                 <span className="text-surface-900 font-medium">Weekly Digest</span>
                 <p className="text-surface-500 text-sm">Summary of activity sent weekly</p>
@@ -379,7 +379,7 @@ function NotificationPreferences() {
 
           <h3 className="text-sm font-medium text-surface-700 pt-4">In-App Notifications</h3>
 
-          <label className="flex items-center justify-between p-3 bg-white/50 rounded-lg cursor-pointer hover:bg-white">
+          <label className="flex items-center justify-between p-3 bg-white/50 rounded-lg cursor-pointer hover:bg-white dark:bg-surface-900/50 dark:hover:bg-surface-800">
             <div>
               <span className="text-surface-900 font-medium">In-App Notifications</span>
               <p className="text-surface-500 text-sm">Show notifications in the app</p>
@@ -539,7 +539,7 @@ function SecuritySettings() {
         <p className="text-surface-600 text-sm">Manage your active sessions across devices</p>
 
         <div className="space-y-3">
-          <div className="flex items-center justify-between p-3 bg-white/50 rounded-lg">
+          <div className="flex items-center justify-between p-3 bg-white/50 rounded-lg dark:bg-surface-900/50">
             <div className="flex items-center gap-3">
               <ComputerDesktopIcon className="w-8 h-8 text-surface-600" />
               <div>

--- a/frontend/src/pages/AnswerTemplates.tsx
+++ b/frontend/src/pages/AnswerTemplates.tsx
@@ -162,14 +162,14 @@ export default function AnswerTemplates() {
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             placeholder="Search templates..."
-            className="w-full pl-10 pr-4 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+            className="w-full pl-10 pr-4 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
           />
         </div>
 
         <SelectNative
           value={categoryFilter}
           onChange={(e) => setCategoryFilter(e.target.value)}
-          className="px-4 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+          className="px-4 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
         >
           <option value="">All Categories</option>
           {CATEGORIES.map((cat) => (
@@ -195,10 +195,10 @@ export default function AnswerTemplates() {
           Array.from({ length: 6 }).map((_, i) => (
             <div
               key={i}
-              className="bg-white border border-surface-200 rounded-xl p-5 animate-pulse"
+              className="bg-white border border-surface-200 rounded-xl p-5 animate-pulse dark:bg-surface-900"
             >
               <div className="h-5 bg-surface-200 rounded w-3/4 mb-3" />
-              <div className="h-16 bg-white rounded mb-3" />
+              <div className="h-16 bg-white rounded mb-3 dark:bg-surface-900" />
               <div className="h-4 bg-surface-200 rounded w-1/2" />
             </div>
           ))
@@ -215,7 +215,7 @@ export default function AnswerTemplates() {
             <div
               key={template.id}
               className={clsx(
-                'bg-white border rounded-xl p-5 cursor-pointer transition-all hover:border-surface-300',
+                'bg-white border rounded-xl p-5 cursor-pointer transition-all hover:border-surface-300 dark:bg-surface-900',
                 selectedTemplate?.id === template.id
                   ? 'border-brand-500 ring-2 ring-brand-500/20'
                   : 'border-surface-200'
@@ -264,12 +264,12 @@ export default function AnswerTemplates() {
       </div>
       {/* Template Detail Panel */}
       {selectedTemplate && (
-        <div className="fixed inset-y-0 right-0 w-full max-w-lg bg-white border-l border-surface-200 shadow-xl z-40 overflow-y-auto">
-          <div className="sticky top-0 bg-white border-b border-surface-200 px-6 py-4 flex items-center justify-between">
+        <div className="fixed inset-y-0 right-0 w-full max-w-lg bg-white border-l border-surface-200 shadow-xl z-40 overflow-y-auto dark:bg-surface-900">
+          <div className="sticky top-0 bg-white border-b border-surface-200 px-6 py-4 flex items-center justify-between dark:bg-surface-900">
             <h2 className="text-lg font-semibold text-surface-900">Template Details</h2>
             <button
               onClick={() => setSelectedTemplate(null)}
-              className="p-2 text-surface-600 hover:text-surface-800 rounded-lg hover:bg-white"
+              className="p-2 text-surface-600 hover:text-surface-800 rounded-lg hover:bg-white dark:bg-surface-900 dark:hover:bg-surface-800"
             >
               <XMarkIcon className="w-5 h-5" />
             </button>
@@ -292,7 +292,7 @@ export default function AnswerTemplates() {
 
             <div>
               <label className="block text-sm font-medium text-surface-600 mb-2">Content</label>
-              <div className="bg-white rounded-lg p-4 text-sm text-surface-800 whitespace-pre-wrap font-mono">
+              <div className="bg-white rounded-lg p-4 text-sm text-surface-800 whitespace-pre-wrap font-mono dark:bg-surface-900">
                 {selectedTemplate.content}
               </div>
             </div>
@@ -455,13 +455,13 @@ function TemplateModal({
 
   return (
     <Dialog open onClose={onClose}>
-      <div className="sticky top-0 bg-white border-b border-surface-200 px-6 py-4 flex items-center justify-between">
+      <div className="sticky top-0 bg-white border-b border-surface-200 px-6 py-4 flex items-center justify-between dark:bg-surface-900">
         <h2 className="text-lg font-semibold text-surface-900">
           {template ? 'Edit Template' : 'Create Template'}
         </h2>
         <button
           onClick={onClose}
-          className="p-2 text-surface-600 hover:text-surface-800 rounded-lg hover:bg-white"
+          className="p-2 text-surface-600 hover:text-surface-800 rounded-lg hover:bg-white dark:bg-surface-900 dark:hover:bg-surface-800"
         >
           <XMarkIcon className="w-5 h-5" />
         </button>
@@ -477,7 +477,7 @@ function TemplateModal({
             required
             value={formData.title}
             onChange={(e) => setFormData((prev) => ({ ...prev, title: e.target.value }))}
-            className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+            className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
             placeholder="e.g., SOC 2 Compliance Response"
           />
         </div>
@@ -487,7 +487,7 @@ function TemplateModal({
           <SelectNative
             value={formData.category}
             onChange={(e) => setFormData((prev) => ({ ...prev, category: e.target.value }))}
-            className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+            className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
           >
             <option value="">Select category...</option>
             {CATEGORIES.map((cat) => (
@@ -511,7 +511,7 @@ function TemplateModal({
             value={formData.content}
             onChange={(e) => setFormData((prev) => ({ ...prev, content: e.target.value }))}
             rows={8}
-            className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 font-mono text-sm"
+            className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 font-mono text-sm dark:bg-surface-900"
             placeholder="Enter template content...
 
 Example:
@@ -543,7 +543,7 @@ Example:
             type="text"
             value={formData.tags}
             onChange={(e) => setFormData((prev) => ({ ...prev, tags: e.target.value }))}
-            className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+            className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
             placeholder="encryption, data-protection, audit (comma-separated)"
           />
         </div>

--- a/frontend/src/pages/AssessmentDetail.tsx
+++ b/frontend/src/pages/AssessmentDetail.tsx
@@ -60,7 +60,7 @@ function AssessmentForm({ assessment, onSave, onCancel }: AssessmentFormProps) {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
-      <div className="bg-white border border-surface-200 rounded-lg p-6 space-y-6">
+      <div className="bg-white border border-surface-200 rounded-lg p-6 space-y-6 dark:bg-surface-900">
         {/* Basic Information */}
         <div>
           <h3 className="text-lg font-medium text-surface-900 mb-4">Basic Information</h3>
@@ -70,7 +70,7 @@ function AssessmentForm({ assessment, onSave, onCancel }: AssessmentFormProps) {
               <SelectNative
                 value={formData.vendorId}
                 onChange={(e) => setFormData({ ...formData, vendorId: e.target.value })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
                 required
               >
                 <option value="">Select a vendor...</option>
@@ -88,7 +88,7 @@ function AssessmentForm({ assessment, onSave, onCancel }: AssessmentFormProps) {
               <SelectNative
                 value={formData.assessmentType}
                 onChange={(e) => setFormData({ ...formData, assessmentType: e.target.value })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
                 required
               >
                 <option value="initial_onboarding">Initial Onboarding</option>
@@ -103,7 +103,7 @@ function AssessmentForm({ assessment, onSave, onCancel }: AssessmentFormProps) {
               <SelectNative
                 value={formData.status}
                 onChange={(e) => setFormData({ ...formData, status: e.target.value })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
                 required
               >
                 <option value="pending">Pending</option>
@@ -119,7 +119,7 @@ function AssessmentForm({ assessment, onSave, onCancel }: AssessmentFormProps) {
               <SelectNative
                 value={formData.inherentRiskScore || ''}
                 onChange={(e) => setFormData({ ...formData, inherentRiskScore: e.target.value })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               >
                 <option value="">Select risk level...</option>
                 <option value="very_low">Very Low</option>
@@ -142,7 +142,7 @@ function AssessmentForm({ assessment, onSave, onCancel }: AssessmentFormProps) {
                 type="date"
                 value={formData.dueDate || ''}
                 onChange={(e) => setFormData({ ...formData, dueDate: e.target.value })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               />
             </div>
             <div>
@@ -153,7 +153,7 @@ function AssessmentForm({ assessment, onSave, onCancel }: AssessmentFormProps) {
                 type="date"
                 value={formData.completedAt || ''}
                 onChange={(e) => setFormData({ ...formData, completedAt: e.target.value })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               />
             </div>
           </div>
@@ -175,7 +175,7 @@ function AssessmentForm({ assessment, onSave, onCancel }: AssessmentFormProps) {
                 onChange={(e) =>
                   setFormData({ ...formData, overallScore: parseInt(e.target.value) || undefined })
                 }
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               />
             </div>
             <div>
@@ -185,7 +185,7 @@ function AssessmentForm({ assessment, onSave, onCancel }: AssessmentFormProps) {
               <SelectNative
                 value={formData.residualRiskScore || ''}
                 onChange={(e) => setFormData({ ...formData, residualRiskScore: e.target.value })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               >
                 <option value="">Select risk level...</option>
                 <option value="very_low">Very Low</option>
@@ -202,7 +202,7 @@ function AssessmentForm({ assessment, onSave, onCancel }: AssessmentFormProps) {
               <SelectNative
                 value={formData.securityRisk || ''}
                 onChange={(e) => setFormData({ ...formData, securityRisk: e.target.value })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               >
                 <option value="">Select risk level...</option>
                 <option value="very_low">Very Low</option>
@@ -219,7 +219,7 @@ function AssessmentForm({ assessment, onSave, onCancel }: AssessmentFormProps) {
               <SelectNative
                 value={formData.complianceRisk || ''}
                 onChange={(e) => setFormData({ ...formData, complianceRisk: e.target.value })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               >
                 <option value="">Select risk level...</option>
                 <option value="very_low">Very Low</option>
@@ -236,7 +236,7 @@ function AssessmentForm({ assessment, onSave, onCancel }: AssessmentFormProps) {
               <SelectNative
                 value={formData.operationalRisk || ''}
                 onChange={(e) => setFormData({ ...formData, operationalRisk: e.target.value })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               >
                 <option value="">Select risk level...</option>
                 <option value="very_low">Very Low</option>
@@ -253,7 +253,7 @@ function AssessmentForm({ assessment, onSave, onCancel }: AssessmentFormProps) {
               <SelectNative
                 value={formData.financialRisk || ''}
                 onChange={(e) => setFormData({ ...formData, financialRisk: e.target.value })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               >
                 <option value="">Select risk level...</option>
                 <option value="very_low">Very Low</option>
@@ -275,7 +275,7 @@ function AssessmentForm({ assessment, onSave, onCancel }: AssessmentFormProps) {
               <SelectNative
                 value={formData.outcome || ''}
                 onChange={(e) => setFormData({ ...formData, outcome: e.target.value })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               >
                 <option value="">Select outcome...</option>
                 <option value="approved">Approved</option>
@@ -292,7 +292,7 @@ function AssessmentForm({ assessment, onSave, onCancel }: AssessmentFormProps) {
                 type="text"
                 value={formData.outcomeNotes || ''}
                 onChange={(e) => setFormData({ ...formData, outcomeNotes: e.target.value })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
                 placeholder="Additional notes about the outcome..."
               />
             </div>
@@ -306,7 +306,7 @@ function AssessmentForm({ assessment, onSave, onCancel }: AssessmentFormProps) {
             value={typeof formData.findings === 'string' ? formData.findings : ''}
             onChange={(e) => setFormData({ ...formData, findings: e.target.value })}
             rows={4}
-            className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+            className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
             placeholder="Document any findings, issues, or concerns discovered during the assessment..."
           />
         </div>
@@ -318,7 +318,7 @@ function AssessmentForm({ assessment, onSave, onCancel }: AssessmentFormProps) {
             value={formData.recommendations || ''}
             onChange={(e) => setFormData({ ...formData, recommendations: e.target.value })}
             rows={4}
-            className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+            className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
             placeholder="Provide recommendations for improvement or remediation..."
           />
         </div>
@@ -354,7 +354,7 @@ function AssessmentView({
 }) {
   return (
     <div className="space-y-6">
-      <div className="bg-white border border-surface-200 rounded-lg p-6 space-y-6">
+      <div className="bg-white border border-surface-200 rounded-lg p-6 space-y-6 dark:bg-surface-900">
         {/* Header */}
         <div className="flex items-start justify-between">
           <div>
@@ -366,13 +366,13 @@ function AssessmentView({
           <div className="flex items-center gap-2">
             <button
               onClick={onEdit}
-              className="p-2 text-surface-600 hover:text-surface-900 hover:bg-white rounded-lg transition-colors"
+              className="p-2 text-surface-600 hover:text-surface-900 hover:bg-white rounded-lg transition-colors dark:bg-surface-900 dark:hover:bg-surface-800"
             >
               <PencilIcon className="w-5 h-5" />
             </button>
             <button
               onClick={onDelete}
-              className="p-2 text-red-600 hover:text-red-700 hover:bg-white rounded-lg transition-colors"
+              className="p-2 text-red-600 hover:text-red-700 hover:bg-white rounded-lg transition-colors dark:bg-surface-900 dark:hover:bg-surface-800"
             >
               <TrashIcon className="w-5 h-5" />
             </button>
@@ -743,7 +743,7 @@ export default function AssessmentDetail() {
       <div className="flex items-center gap-4">
         <button
           onClick={() => navigate('/assessments')}
-          className="p-2 text-surface-600 hover:text-surface-900 hover:bg-white rounded-lg transition-colors"
+          className="p-2 text-surface-600 hover:text-surface-900 hover:bg-white rounded-lg transition-colors dark:bg-surface-900 dark:hover:bg-surface-800"
         >
           <ArrowLeftIcon className="w-5 h-5" />
         </button>

--- a/frontend/src/pages/Assessments.tsx
+++ b/frontend/src/pages/Assessments.tsx
@@ -60,7 +60,7 @@ export default function Assessments() {
 
       {/* Assessments List */}
       {assessments.length === 0 ? (
-        <div className="bg-white border border-surface-200 rounded-lg p-12 text-center">
+        <div className="bg-white border border-surface-200 rounded-lg p-12 text-center dark:bg-surface-900">
           <DocumentCheckIcon className="w-12 h-12 text-surface-600 mx-auto mb-4" />
           <h3 className="text-lg font-medium text-surface-700 mb-2">No assessments yet</h3>
           <p className="text-surface-500 mb-6">
@@ -74,9 +74,9 @@ export default function Assessments() {
           </Button>
         </div>
       ) : (
-        <div className="bg-white border border-surface-200 rounded-lg overflow-hidden">
+        <div className="bg-white border border-surface-200 rounded-lg overflow-hidden dark:bg-surface-900">
           <table className="w-full">
-            <thead className="bg-white border-b border-surface-200">
+            <thead className="bg-white border-b border-surface-200 dark:bg-surface-900">
               <tr>
                 <th className="px-6 py-3 text-left text-xs font-medium text-surface-600 uppercase tracking-wider">
                   Vendor
@@ -100,7 +100,7 @@ export default function Assessments() {
                 <tr
                   key={assessment.id}
                   onClick={() => navigate(`/assessments/${assessment.id}`)}
-                  className="hover:bg-white cursor-pointer transition-colors"
+                  className="hover:bg-white cursor-pointer transition-colors dark:bg-surface-900 dark:hover:bg-surface-800"
                 >
                   <td className="px-6 py-4 text-sm font-medium text-surface-900">
                     {assessment.vendor?.name}

--- a/frontend/src/pages/AssetDetail.tsx
+++ b/frontend/src/pages/AssetDetail.tsx
@@ -254,7 +254,7 @@ export default function AssetDetail() {
       {/* Asset Details */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Main Info */}
-        <div className="lg:col-span-2 bg-white rounded-xl border border-surface-200 p-6 space-y-6">
+        <div className="lg:col-span-2 bg-white rounded-xl border border-surface-200 p-6 space-y-6 dark:bg-surface-900">
           {asset.description && (
             <div>
               <h3 className="text-sm font-medium text-surface-600 mb-2">Description</h3>
@@ -325,7 +325,7 @@ export default function AssetDetail() {
         {/* Sidebar */}
         <div className="space-y-4">
           {/* Quick Stats */}
-          <div className="bg-white rounded-xl border border-surface-200 p-6">
+          <div className="bg-white rounded-xl border border-surface-200 p-6 dark:bg-surface-900">
             <h3 className="text-lg font-medium text-white mb-4">Risk Summary</h3>
             <div className="space-y-3">
               <div className="flex justify-between items-center">
@@ -345,7 +345,7 @@ export default function AssetDetail() {
           </div>
 
           {/* Timestamps */}
-          <div className="bg-white rounded-xl border border-surface-200 p-6">
+          <div className="bg-white rounded-xl border border-surface-200 p-6 dark:bg-surface-900">
             <h3 className="text-lg font-medium text-white mb-4">Timeline</h3>
             <div className="space-y-3 text-sm">
               <div className="flex justify-between">
@@ -366,7 +366,7 @@ export default function AssetDetail() {
       </div>
       {/* Associated Risks */}
       {asset.risks && asset.risks.length > 0 && (
-        <div className="bg-white rounded-xl border border-surface-200 p-6">
+        <div className="bg-white rounded-xl border border-surface-200 p-6 dark:bg-surface-900">
           <h3 className="text-lg font-medium text-white mb-4">Associated Risks</h3>
           <div className="space-y-2">
             {asset.risks.map((risk) => (
@@ -404,7 +404,7 @@ export default function AssetDetail() {
         </div>
       )}
       {/* BC/DR Information */}
-      <div className="bg-white rounded-xl border border-surface-200 p-6">
+      <div className="bg-white rounded-xl border border-surface-200 p-6 dark:bg-surface-900">
         <div className="flex items-center justify-between mb-4">
           <h3 className="text-lg font-medium text-white flex items-center gap-2">
             <ShieldAlert className="w-5 h-5 text-brand-400" />

--- a/frontend/src/pages/Assets.tsx
+++ b/frontend/src/pages/Assets.tsx
@@ -206,7 +206,7 @@ export default function Assets() {
       {/* Stats Cards */}
       {stats && (
         <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-          <div className="bg-white rounded-xl border border-surface-200 p-4">
+          <div className="bg-white rounded-xl border border-surface-200 p-4 dark:bg-surface-900">
             <div className="flex items-center gap-3">
               <div className="p-2 bg-brand-500/20 rounded-lg">
                 <Server className="w-5 h-5 text-brand-400" />
@@ -217,7 +217,7 @@ export default function Assets() {
               </div>
             </div>
           </div>
-          <div className="bg-white rounded-xl border border-surface-200 p-4">
+          <div className="bg-white rounded-xl border border-surface-200 p-4 dark:bg-surface-900">
             <div className="flex items-center gap-3">
               <div className="p-2 bg-emerald-500/20 rounded-lg">
                 <CheckCircle className="w-5 h-5 text-emerald-600" />
@@ -230,7 +230,7 @@ export default function Assets() {
               </div>
             </div>
           </div>
-          <div className="bg-white rounded-xl border border-surface-200 p-4">
+          <div className="bg-white rounded-xl border border-surface-200 p-4 dark:bg-surface-900">
             <div className="flex items-center gap-3">
               <div className="p-2 bg-red-500/20 rounded-lg">
                 <AlertTriangle className="w-5 h-5 text-red-600" />
@@ -243,7 +243,7 @@ export default function Assets() {
               </div>
             </div>
           </div>
-          <div className="bg-white rounded-xl border border-surface-200 p-4">
+          <div className="bg-white rounded-xl border border-surface-200 p-4 dark:bg-surface-900">
             <div className="flex items-center gap-3">
               <div className="p-2 bg-amber-500/20 rounded-lg">
                 <RefreshCw className="w-5 h-5 text-amber-600" />
@@ -257,7 +257,7 @@ export default function Assets() {
         </div>
       )}
       {/* Search and Filters */}
-      <div className="bg-white rounded-xl border border-surface-200 p-4">
+      <div className="bg-white rounded-xl border border-surface-200 p-4 dark:bg-surface-900">
         <div className="flex flex-col lg:flex-row gap-4">
           {/* Search */}
           <div className="flex-1 relative">
@@ -328,7 +328,7 @@ export default function Assets() {
         </div>
       </div>
       {/* Assets Table */}
-      <div className="bg-white rounded-xl border border-surface-200 overflow-hidden">
+      <div className="bg-white rounded-xl border border-surface-200 overflow-hidden dark:bg-surface-900">
         {isLoading ? (
           <SkeletonTable rows={10} columns={7} className="border-none" />
         ) : data?.assets.length === 0 ? (

--- a/frontend/src/pages/AuditAnalytics.tsx
+++ b/frontend/src/pages/AuditAnalytics.tsx
@@ -55,7 +55,7 @@ function StatCard({
   color?: string;
 }) {
   return (
-    <div className="bg-white rounded-lg p-6 border border-surface-200">
+    <div className="bg-white rounded-lg p-6 border border-surface-200 dark:bg-surface-900">
       <div className="flex items-center justify-between">
         <div>
           <p className="text-surface-600 text-sm">{title}</p>
@@ -139,7 +139,7 @@ export default function AuditAnalytics() {
       {/* Charts Row */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Findings by Severity */}
-        <div className="bg-white rounded-lg p-6 border border-surface-200">
+        <div className="bg-white rounded-lg p-6 border border-surface-200 dark:bg-surface-900">
           <h3 className="text-lg font-semibold text-white mb-4">Findings by Severity</h3>
           <div className="h-64">
             <LazyRechartsWrapper height={256}>
@@ -179,7 +179,7 @@ export default function AuditAnalytics() {
         </div>
 
         {/* Findings Trend */}
-        <div className="bg-white rounded-lg p-6 border border-surface-200">
+        <div className="bg-white rounded-lg p-6 border border-surface-200 dark:bg-surface-900">
           <h3 className="text-lg font-semibold text-white mb-4">Findings Trend</h3>
           <div className="h-64">
             <LazyRechartsWrapper height={256}>
@@ -211,7 +211,7 @@ export default function AuditAnalytics() {
       {/* Additional Metrics */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Avg Remediation Time */}
-        <div className="bg-white rounded-lg p-6 border border-surface-200">
+        <div className="bg-white rounded-lg p-6 border border-surface-200 dark:bg-surface-900">
           <div className="flex items-center gap-3 mb-4">
             <ClockIcon className="h-6 w-6 text-brand-400" />
             <h3 className="text-lg font-semibold text-white">Avg Remediation Time</h3>
@@ -223,7 +223,7 @@ export default function AuditAnalytics() {
         </div>
 
         {/* Completion Rate */}
-        <div className="bg-white rounded-lg p-6 border border-surface-200">
+        <div className="bg-white rounded-lg p-6 border border-surface-200 dark:bg-surface-900">
           <div className="flex items-center gap-3 mb-4">
             <CheckCircleIcon className="h-6 w-6 text-green-600" />
             <h3 className="text-lg font-semibold text-white">Audit Completion Rate</h3>
@@ -237,7 +237,7 @@ export default function AuditAnalytics() {
         </div>
 
         {/* Request Status */}
-        <div className="bg-white rounded-lg p-6 border border-surface-200">
+        <div className="bg-white rounded-lg p-6 border border-surface-200 dark:bg-surface-900">
           <div className="flex items-center gap-3 mb-4">
             <DocumentMagnifyingGlassIcon className="h-6 w-6 text-blue-600" />
             <h3 className="text-lg font-semibold text-white">Request Completion</h3>
@@ -255,7 +255,7 @@ export default function AuditAnalytics() {
       </div>
 
       {/* Findings by Category */}
-      <div className="bg-white rounded-lg p-6 border border-surface-200">
+      <div className="bg-white rounded-lg p-6 border border-surface-200 dark:bg-surface-900">
         <h3 className="text-lg font-semibold text-white mb-4">Findings by Category</h3>
         <div className="h-64">
           <LazyRechartsWrapper height={256}>

--- a/frontend/src/pages/AuditCalendar.tsx
+++ b/frontend/src/pages/AuditCalendar.tsx
@@ -36,7 +36,7 @@ const statusColors: Record<string, string> = {
   scheduled: 'bg-blue-500/20 text-blue-600',
   in_progress: 'bg-purple-500/20 text-purple-600',
   completed: 'bg-green-500/20 text-green-600',
-  deferred: 'bg-gray-500/20 text-gray-400',
+  deferred: 'bg-gray-500/20 text-gray-400 dark:bg-surface-500/20 dark:text-surface-500',
   cancelled: 'bg-red-500/20 text-red-600',
 };
 
@@ -114,7 +114,7 @@ export default function AuditCalendar() {
 
       {/* Capacity Overview */}
       {capacity && (
-        <div className="bg-white rounded-lg p-4 border border-surface-200">
+        <div className="bg-white rounded-lg p-4 border border-surface-200 dark:bg-surface-900">
           <h3 className="text-sm font-medium text-surface-600 mb-2">
             {currentYear} Capacity Overview
           </h3>
@@ -142,9 +142,9 @@ export default function AuditCalendar() {
 
       {/* Calendar Grid */}
       {isLoading ? (
-        <div className="animate-pulse bg-white rounded-lg h-96" />
+        <div className="animate-pulse bg-white rounded-lg h-96 dark:bg-surface-900" />
       ) : (
-        <div className="bg-white rounded-lg border border-surface-200 overflow-hidden">
+        <div className="bg-white rounded-lg border border-surface-200 overflow-hidden dark:bg-surface-900">
           {/* Year Headers */}
           <div className="grid grid-cols-3 border-b border-surface-200">
             {years.map((year) => (
@@ -186,7 +186,7 @@ export default function AuditCalendar() {
                             {!entry.linkedAuditId && entry.status === 'planned' && (
                               <button
                                 onClick={() => convertToAuditMutation.mutate(entry.id)}
-                                className="p-1 hover:bg-white/10 rounded"
+                                className="p-1 hover:bg-white/10 rounded dark:bg-surface-900/10 dark:hover:bg-surface-800/10"
                                 title="Convert to Audit"
                               >
                                 <PlayIcon className="h-3 w-3" />

--- a/frontend/src/pages/AuditDetail.tsx
+++ b/frontend/src/pages/AuditDetail.tsx
@@ -285,7 +285,7 @@ export default function AuditDetail() {
       </div>
       {/* Status and Key Info */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-        <div className="bg-white rounded-lg border border-surface-200 p-4">
+        <div className="bg-white rounded-lg border border-surface-200 p-4 dark:bg-surface-900">
           <p className="text-surface-600 text-sm mb-1">Status</p>
           {isEditing ? (
             <SelectNative
@@ -311,19 +311,19 @@ export default function AuditDetail() {
             </span>
           )}
         </div>
-        <div className="bg-white rounded-lg border border-surface-200 p-4">
+        <div className="bg-white rounded-lg border border-surface-200 p-4 dark:bg-surface-900">
           <p className="text-surface-600 text-sm mb-1">Start Date</p>
           <p className="text-white font-medium">
             {audit?.plannedStartDate ? new Date(audit.plannedStartDate).toLocaleDateString() : '—'}
           </p>
         </div>
-        <div className="bg-white rounded-lg border border-surface-200 p-4">
+        <div className="bg-white rounded-lg border border-surface-200 p-4 dark:bg-surface-900">
           <p className="text-surface-600 text-sm mb-1">End Date</p>
           <p className="text-white font-medium">
             {audit?.plannedEndDate ? new Date(audit.plannedEndDate).toLocaleDateString() : '—'}
           </p>
         </div>
-        <div className="bg-white rounded-lg border border-surface-200 p-4">
+        <div className="bg-white rounded-lg border border-surface-200 p-4 dark:bg-surface-900">
           <p className="text-surface-600 text-sm mb-1">Findings</p>
           <p className="text-white font-medium">
             {audit?._count?.findings || findingsArray.length}
@@ -332,7 +332,7 @@ export default function AuditDetail() {
       </div>
       {/* Description */}
       {(audit?.description || isEditing) && (
-        <div className="bg-white rounded-lg border border-surface-200 p-6">
+        <div className="bg-white rounded-lg border border-surface-200 p-6 dark:bg-surface-900">
           <h2 className="text-lg font-semibold text-white mb-4">Description</h2>
           {isEditing ? (
             <Textarea
@@ -350,7 +350,7 @@ export default function AuditDetail() {
       {/* Two Column Layout */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Findings */}
-        <div className="bg-white rounded-lg border border-surface-200 p-6">
+        <div className="bg-white rounded-lg border border-surface-200 p-6 dark:bg-surface-900">
           <div className="flex items-center justify-between mb-4">
             <h2 className="text-lg font-semibold text-white">Findings</h2>
             <Link
@@ -397,7 +397,7 @@ export default function AuditDetail() {
         </div>
 
         {/* Requests */}
-        <div className="bg-white rounded-lg border border-surface-200 p-6">
+        <div className="bg-white rounded-lg border border-surface-200 p-6 dark:bg-surface-900">
           <div className="flex items-center justify-between mb-4">
             <h2 className="text-lg font-semibold text-white">Evidence Requests</h2>
             <Link
@@ -444,24 +444,24 @@ export default function AuditDetail() {
       {/* Stats Grid - only show for existing audits */}
       {!isNewAudit && audit && (
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-          <div className="bg-white rounded-lg border border-surface-200 p-4 text-center">
+          <div className="bg-white rounded-lg border border-surface-200 p-4 text-center dark:bg-surface-900">
             <ClipboardDocumentListIcon className="w-8 h-8 mx-auto mb-2 text-blue-600" />
             <p className="text-2xl font-bold text-white">
               {audit._count?.requests || requestsArray.length}
             </p>
             <p className="text-surface-600 text-sm">Requests</p>
           </div>
-          <div className="bg-white rounded-lg border border-surface-200 p-4 text-center">
+          <div className="bg-white rounded-lg border border-surface-200 p-4 text-center dark:bg-surface-900">
             <DocumentTextIcon className="w-8 h-8 mx-auto mb-2 text-purple-600" />
             <p className="text-2xl font-bold text-white">{audit._count?.evidence || 0}</p>
             <p className="text-surface-600 text-sm">Evidence</p>
           </div>
-          <div className="bg-white rounded-lg border border-surface-200 p-4 text-center">
+          <div className="bg-white rounded-lg border border-surface-200 p-4 text-center dark:bg-surface-900">
             <CheckCircleIcon className="w-8 h-8 mx-auto mb-2 text-green-600" />
             <p className="text-2xl font-bold text-white">{audit._count?.testResults || 0}</p>
             <p className="text-surface-600 text-sm">Tests</p>
           </div>
-          <div className="bg-white rounded-lg border border-surface-200 p-4 text-center">
+          <div className="bg-white rounded-lg border border-surface-200 p-4 text-center dark:bg-surface-900">
             <ExclamationTriangleIcon className="w-8 h-8 mx-auto mb-2 text-orange-600" />
             <p className="text-2xl font-bold text-white">
               {audit._count?.findings || findingsArray.length}

--- a/frontend/src/pages/AuditFindings.tsx
+++ b/frontend/src/pages/AuditFindings.tsx
@@ -252,22 +252,22 @@ export default function AuditFindings() {
       {/* Stats Cards */}
       {statsData && (
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-          <div className="bg-white rounded-lg p-4 border border-surface-200">
+          <div className="bg-white rounded-lg p-4 border border-surface-200 dark:bg-surface-900">
             <p className="text-surface-600 text-sm">Total Findings</p>
             <p className="text-2xl font-bold text-white mt-1">{statsData.total}</p>
           </div>
-          <div className="bg-white rounded-lg p-4 border border-surface-200">
+          <div className="bg-white rounded-lg p-4 border border-surface-200 dark:bg-surface-900">
             <p className="text-surface-600 text-sm">Overdue</p>
             <p className="text-2xl font-bold text-red-600 mt-1">{statsData.overdue}</p>
           </div>
-          <div className="bg-white rounded-lg p-4 border border-surface-200">
+          <div className="bg-white rounded-lg p-4 border border-surface-200 dark:bg-surface-900">
             <p className="text-surface-600 text-sm">Critical/High</p>
             <p className="text-2xl font-bold text-orange-600 mt-1">
               {(statsData.bySeverity.find((s) => s.severity === 'critical')?.count || 0) +
                 (statsData.bySeverity.find((s) => s.severity === 'high')?.count || 0)}
             </p>
           </div>
-          <div className="bg-white rounded-lg p-4 border border-surface-200">
+          <div className="bg-white rounded-lg p-4 border border-surface-200 dark:bg-surface-900">
             <p className="text-surface-600 text-sm">Open</p>
             <p className="text-2xl font-bold text-yellow-600 mt-1">
               {statsData.byStatus.find((s) => s.status === 'open')?.count || 0}
@@ -325,7 +325,7 @@ export default function AuditFindings() {
         )}
       </div>
       {showFilters && (
-        <div className="bg-white rounded-lg p-4 border border-surface-200 grid grid-cols-1 md:grid-cols-4 gap-4">
+        <div className="bg-white rounded-lg p-4 border border-surface-200 grid grid-cols-1 md:grid-cols-4 gap-4 dark:bg-surface-900">
           <div>
             <label className="block text-sm font-medium text-surface-700 mb-1">Audit</label>
             <SelectNative
@@ -402,7 +402,7 @@ export default function AuditFindings() {
           }}
         />
       ) : (
-        <div className="bg-white rounded-lg border border-surface-200 overflow-hidden">
+        <div className="bg-white rounded-lg border border-surface-200 overflow-hidden dark:bg-surface-900">
           <table className="w-full">
             <thead className="bg-surface-200">
               <tr>

--- a/frontend/src/pages/AuditLog.tsx
+++ b/frontend/src/pages/AuditLog.tsx
@@ -423,7 +423,7 @@ export default function AuditLog() {
                 logs.map((log: any) => {
                   const actionConfig = ACTION_CONFIG[log.action] || {
                     color: 'text-surface-600',
-                    bg: 'bg-white',
+                    bg: 'bg-white dark:bg-surface-900',
                   };
                   const EntityIcon = ENTITY_ICONS[log.entityType] || DocumentIcon;
                   const isExpanded = expandedRow === log.id;
@@ -431,7 +431,7 @@ export default function AuditLog() {
                   return (
                     <React.Fragment key={log.id}>
                       <tr
-                        className="border-b border-surface-200/50 hover:bg-white/30 transition-colors cursor-pointer"
+                        className="border-b border-surface-200/50 hover:bg-white/30 transition-colors cursor-pointer dark:bg-surface-900/30 dark:hover:bg-surface-800/30"
                         onClick={() => setExpandedRow(isExpanded ? null : log.id)}
                       >
                         <td className="px-4 py-3">
@@ -505,7 +505,7 @@ export default function AuditLog() {
 
                       {/* Expanded Details */}
                       {isExpanded && (
-                        <tr className="bg-white/20">
+                        <tr className="bg-white/20 dark:bg-surface-900/20">
                           <td colSpan={6} className="px-4 py-4">
                             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                               {/* Left - Details */}
@@ -548,7 +548,7 @@ export default function AuditLog() {
                                     <h4 className="text-sm font-medium text-surface-700">
                                       Changes
                                     </h4>
-                                    <pre className="text-xs text-surface-600 bg-white/50 p-3 rounded-lg overflow-auto max-h-[200px]">
+                                    <pre className="text-xs text-surface-600 bg-white/50 p-3 rounded-lg overflow-auto max-h-[200px] dark:bg-surface-900/50">
                                       {JSON.stringify(log.changes, null, 2)}
                                     </pre>
                                   </>
@@ -558,7 +558,7 @@ export default function AuditLog() {
                                     <h4 className="text-sm font-medium text-surface-700">
                                       Metadata
                                     </h4>
-                                    <pre className="text-xs text-surface-600 bg-white/50 p-3 rounded-lg overflow-auto max-h-[200px]">
+                                    <pre className="text-xs text-surface-600 bg-white/50 p-3 rounded-lg overflow-auto max-h-[200px] dark:bg-surface-900/50">
                                       {JSON.stringify(log.metadata, null, 2)}
                                     </pre>
                                   </>

--- a/frontend/src/pages/AuditRequests.tsx
+++ b/frontend/src/pages/AuditRequests.tsx
@@ -53,7 +53,7 @@ const statusColors: Record<string, string> = {
 };
 
 const priorityColors: Record<string, string> = {
-  low: 'text-gray-400',
+  low: 'text-gray-400 dark:text-surface-500',
   medium: 'text-yellow-600',
   high: 'text-orange-600',
   critical: 'text-red-600',
@@ -178,7 +178,7 @@ export default function AuditRequests() {
             <p className="text-surface-600 mt-1">Create a new evidence or documentation request</p>
           </div>
         </div>
-        <div className="bg-white border border-surface-200 rounded-lg p-6">
+        <div className="bg-white border border-surface-200 rounded-lg p-6 dark:bg-surface-900">
           <form onSubmit={handleCreateRequest} className="space-y-4">
             <div>
               <label className="block text-sm font-medium text-surface-700 mb-1">
@@ -311,14 +311,14 @@ export default function AuditRequests() {
             placeholder="Search requests..."
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
-            className="w-full pl-10 pr-4 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 placeholder-surface-500 focus:outline-none focus:ring-2 focus:ring-brand-500"
+            className="w-full pl-10 pr-4 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 placeholder-surface-500 focus:outline-none focus:ring-2 focus:ring-brand-500 dark:bg-surface-900"
           />
         </div>
 
         <SelectNative
           value={statusFilter}
           onChange={(e) => setStatusFilter(e.target.value)}
-          className="px-4 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:ring-2 focus:ring-brand-500"
+          className="px-4 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:ring-2 focus:ring-brand-500 dark:bg-surface-900"
         >
           <option value="">All Statuses</option>
           <option value="open">Open</option>
@@ -333,7 +333,7 @@ export default function AuditRequests() {
         <SelectNative
           value={priorityFilter}
           onChange={(e) => setPriorityFilter(e.target.value)}
-          className="px-4 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:ring-2 focus:ring-brand-500"
+          className="px-4 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:ring-2 focus:ring-brand-500 dark:bg-surface-900"
         >
           <option value="">All Priorities</option>
           <option value="low">Low</option>
@@ -371,7 +371,7 @@ export default function AuditRequests() {
             <Link
               key={request.id}
               to={`/audit-requests/${request.id}`}
-              className="block bg-white border border-surface-200 rounded-lg p-6 hover:border-brand-500 transition-colors"
+              className="block bg-white border border-surface-200 rounded-lg p-6 hover:border-brand-500 transition-colors dark:bg-surface-900"
             >
               <div className="flex items-start justify-between mb-4">
                 <div className="flex-1">

--- a/frontend/src/pages/AuditTemplates.tsx
+++ b/frontend/src/pages/AuditTemplates.tsx
@@ -152,7 +152,7 @@ export default function AuditTemplates() {
         <SelectNative
           value={selectedType}
           onChange={(e) => setSelectedType(e.target.value)}
-          className="bg-white border border-surface-300 rounded-lg px-3 py-2 text-white"
+          className="bg-white border border-surface-300 rounded-lg px-3 py-2 text-white dark:bg-surface-900"
         >
           <option value="">All Types</option>
           {Object.entries(auditTypeLabels).map(([value, label]) => (
@@ -166,7 +166,10 @@ export default function AuditTemplates() {
       {isLoading ? (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {[1, 2, 3].map((i) => (
-            <div key={i} className="animate-pulse bg-white rounded-lg p-6 h-48" />
+            <div
+              key={i}
+              className="animate-pulse bg-white rounded-lg p-6 h-48 dark:bg-surface-900"
+            />
           ))}
         </div>
       ) : (
@@ -174,7 +177,7 @@ export default function AuditTemplates() {
           {(templates as AuditTemplate[]).map((template) => (
             <div
               key={template.id}
-              className="bg-white rounded-lg p-6 border border-surface-200 hover:border-surface-500 transition-colors"
+              className="bg-white rounded-lg p-6 border border-surface-200 hover:border-surface-500 transition-colors dark:bg-surface-900"
             >
               <div className="flex items-start justify-between">
                 <div className="flex items-center gap-3">

--- a/frontend/src/pages/AuditWorkpapers.tsx
+++ b/frontend/src/pages/AuditWorkpapers.tsx
@@ -185,7 +185,10 @@ export default function AuditWorkpapers() {
         {Object.entries(statusConfig).map(([status, config]) => {
           const count = workpapers.filter((w) => w.status === status).length;
           return (
-            <div key={status} className="bg-white rounded-lg p-4 border border-surface-200">
+            <div
+              key={status}
+              className="bg-white rounded-lg p-4 border border-surface-200 dark:bg-surface-900"
+            >
               <div className="flex items-center gap-2">
                 <config.icon className={clsx('h-5 w-5', config.color)} />
                 <span className="text-surface-600 text-sm">{config.label}</span>
@@ -199,13 +202,13 @@ export default function AuditWorkpapers() {
       {isLoading ? (
         <div className="animate-pulse space-y-4">
           {[1, 2, 3].map((i) => (
-            <div key={i} className="bg-white rounded-lg h-20" />
+            <div key={i} className="bg-white rounded-lg h-20 dark:bg-surface-900" />
           ))}
         </div>
       ) : (
-        <div className="bg-white rounded-lg border border-surface-200 overflow-hidden">
+        <div className="bg-white rounded-lg border border-surface-200 overflow-hidden dark:bg-surface-900">
           <table className="w-full">
-            <thead className="bg-white">
+            <thead className="bg-white dark:bg-surface-900">
               <tr>
                 <th className="text-left px-4 py-3 text-sm font-medium text-surface-600">Number</th>
                 <th className="text-left px-4 py-3 text-sm font-medium text-surface-600">Title</th>

--- a/frontend/src/pages/AuditorLogin.tsx
+++ b/frontend/src/pages/AuditorLogin.tsx
@@ -91,7 +91,7 @@ export default function AuditorLogin() {
         </div>
 
         {/* Login Card */}
-        <div className="bg-white/10 backdrop-blur-xl rounded-2xl shadow-2xl border border-white/20 p-8">
+        <div className="bg-white/10 backdrop-blur-xl rounded-2xl shadow-2xl border border-white/20 p-8 dark:bg-surface-900/10">
           <form onSubmit={handleSubmit} className="space-y-6">
             {/* Error Message */}
             {displayError && (
@@ -119,7 +119,7 @@ export default function AuditorLogin() {
                   value={accessCode}
                   onChange={(e) => setAccessCode(e.target.value)}
                   placeholder="Enter your access code"
-                  className="w-full px-4 py-3 bg-white/5 border border-white/20 rounded-xl text-white placeholder-purple-300/50 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all pr-24"
+                  className="w-full px-4 py-3 bg-white/5 border border-white/20 rounded-xl text-white placeholder-purple-300/50 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all pr-24 dark:bg-surface-900/5"
                   autoComplete="off"
                   autoFocus
                 />

--- a/frontend/src/pages/AuditorPortal.tsx
+++ b/frontend/src/pages/AuditorPortal.tsx
@@ -136,7 +136,7 @@ function AuditorPortalContent() {
 
   const getPriorityBadge = (priority: AuditRequest['priority']) => {
     const styles: Record<AuditRequest['priority'], string> = {
-      low: 'text-gray-500',
+      low: 'text-gray-500 dark:text-surface-400',
       medium: 'text-yellow-500',
       high: 'text-orange-500',
       critical: 'text-red-500',
@@ -324,7 +324,7 @@ function AuditorPortalContent() {
                     {requests.slice(0, 5).map((request) => (
                       <li
                         key={request.id}
-                        className="px-6 py-4 hover:bg-gray-50 dark:hover:bg-gray-750 cursor-pointer transition-colors"
+                        className="px-6 py-4 hover:bg-gray-50 dark:hover:bg-gray-750 cursor-pointer transition-colors dark:bg-surface-900"
                         onClick={() => setSelectedRequest(request)}
                       >
                         <div className="flex items-center justify-between">
@@ -343,7 +343,7 @@ function AuditorPortalContent() {
                           </div>
                           <div className="flex items-center gap-3">
                             {getStatusBadge(request.status)}
-                            <ChevronRightIcon className="w-5 h-5 text-gray-400" />
+                            <ChevronRightIcon className="w-5 h-5 text-gray-400 dark:text-surface-500" />
                           </div>
                         </div>
                       </li>
@@ -384,7 +384,10 @@ function AuditorPortalContent() {
                     </thead>
                     <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
                       {requests.map((request) => (
-                        <tr key={request.id} className="hover:bg-gray-50 dark:hover:bg-gray-750">
+                        <tr
+                          key={request.id}
+                          className="hover:bg-gray-50 dark:hover:bg-gray-750 dark:bg-surface-900"
+                        >
                           <td className="px-6 py-4">
                             <div className="max-w-xs">
                               <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
@@ -412,14 +415,14 @@ function AuditorPortalContent() {
                           <td className="px-6 py-4 text-right">
                             <div className="flex items-center justify-end gap-2">
                               <button
-                                className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                                className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 dark:text-surface-500"
                                 title="View Details"
                               >
                                 <EyeIcon className="w-4 h-4" />
                               </button>
                               {session.permissions.canSubmitComments && (
                                 <button
-                                  className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                                  className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 dark:text-surface-500"
                                   title="Add Comment"
                                 >
                                   <ChatBubbleLeftIcon className="w-4 h-4" />
@@ -428,7 +431,7 @@ function AuditorPortalContent() {
                               {session.permissions.canDownloadEvidence &&
                                 request.evidenceCount > 0 && (
                                   <button
-                                    className="p-2 text-gray-400 hover:text-purple-600 dark:hover:text-purple-600"
+                                    className="p-2 text-gray-400 hover:text-purple-600 dark:hover:text-purple-600 dark:text-surface-500"
                                     title="Download Evidence"
                                   >
                                     <DocumentArrowDownIcon className="w-4 h-4" />

--- a/frontend/src/pages/Audits.tsx
+++ b/frontend/src/pages/Audits.tsx
@@ -44,7 +44,7 @@ const statusColors: Record<string, string> = {
   testing: 'bg-orange-100 text-orange-800',
   reporting: 'bg-purple-100 text-purple-800',
   completed: 'bg-green-100 text-green-800',
-  cancelled: 'bg-gray-100 text-gray-800',
+  cancelled: 'bg-gray-100 text-gray-800 dark:bg-surface-800 dark:text-surface-100',
 };
 
 const auditTypeLabels: Record<string, string> = {
@@ -111,14 +111,14 @@ export default function Audits() {
             placeholder="Search audits..."
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
-            className="w-full pl-10 pr-4 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 placeholder-surface-500 focus:outline-none focus:ring-2 focus:ring-brand-500"
+            className="w-full pl-10 pr-4 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 placeholder-surface-500 focus:outline-none focus:ring-2 focus:ring-brand-500 dark:bg-surface-900"
           />
         </div>
 
         <SelectNative
           value={statusFilter}
           onChange={(e) => setStatusFilter(e.target.value)}
-          className="px-4 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:ring-2 focus:ring-brand-500"
+          className="px-4 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:ring-2 focus:ring-brand-500 dark:bg-surface-900"
         >
           <option value="">All Statuses</option>
           <option value="planning">Planning</option>
@@ -132,7 +132,7 @@ export default function Audits() {
         <SelectNative
           value={typeFilter}
           onChange={(e) => setTypeFilter(e.target.value)}
-          className="px-4 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:ring-2 focus:ring-brand-500"
+          className="px-4 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:ring-2 focus:ring-brand-500 dark:bg-surface-900"
         >
           <option value="">All Types</option>
           <option value="internal">Internal</option>
@@ -162,7 +162,7 @@ export default function Audits() {
             <Link
               key={audit.id}
               to={`/audits/${audit.id}`}
-              className="block bg-white border border-surface-200 rounded-lg p-6 hover:border-brand-500 transition-colors"
+              className="block bg-white border border-surface-200 rounded-lg p-6 hover:border-brand-500 transition-colors dark:bg-surface-900"
             >
               <div className="flex items-start justify-between mb-4">
                 <div>

--- a/frontend/src/pages/AwarenessTraining.tsx
+++ b/frontend/src/pages/AwarenessTraining.tsx
@@ -190,7 +190,7 @@ export default function AwarenessTraining() {
                   className={`px-4 py-2 rounded-lg text-sm font-medium transition-all ${
                     categoryFilter === cat
                       ? 'bg-brand-500/10 text-brand-500 dark:text-brand-400 border border-brand-500/30'
-                      : 'text-gray-600 dark:text-surface-600 hover:text-gray-900 dark:hover:text-surface-800 hover:bg-gray-100 dark:hover:bg-white'
+                      : 'text-gray-600 dark:text-surface-600 hover:text-gray-900 dark:hover:text-surface-800 hover:bg-gray-100 dark:hover:bg-white dark:bg-surface-900'
                   }`}
                 >
                   {cat === 'all' ? 'All Modules' : getCategoryLabel(cat as any)}
@@ -510,7 +510,7 @@ function TrainingViewer({
           )}
           <button
             onClick={() => setIsFullscreen(!isFullscreen)}
-            className="p-2 text-gray-500 dark:text-surface-600 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-surface-200 rounded-lg transition-colors"
+            className="p-2 text-gray-500 dark:text-surface-600 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-surface-200 rounded-lg transition-colors dark:bg-surface-800"
             title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
           >
             {isFullscreen ? (

--- a/frontend/src/pages/BCDRDashboard.tsx
+++ b/frontend/src/pages/BCDRDashboard.tsx
@@ -399,7 +399,7 @@ export default function BCDRDashboard() {
                 <Link
                   key={test.id}
                   to={`/bcdr/tests/${test.id}`}
-                  className="flex items-center justify-between p-3 rounded-lg bg-white/50 hover:bg-surface-200/50 transition-colors"
+                  className="flex items-center justify-between p-3 rounded-lg bg-white/50 hover:bg-surface-200/50 transition-colors dark:bg-surface-900/50"
                 >
                   <div>
                     <p className="text-surface-900 font-medium">{test.name}</p>
@@ -584,35 +584,35 @@ export default function BCDRDashboard() {
         <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
           <Link
             to="/bcdr/processes/new"
-            className="p-4 rounded-lg bg-white/50 hover:bg-surface-200/50 transition-colors text-center"
+            className="p-4 rounded-lg bg-white/50 hover:bg-surface-200/50 transition-colors text-center dark:bg-surface-900/50"
           >
             <ShieldExclamationIcon className="w-8 h-8 mx-auto mb-2 text-brand-400" />
             <span className="text-surface-800 text-sm">Add Process</span>
           </Link>
           <Link
             to="/bcdr/plans/new"
-            className="p-4 rounded-lg bg-white/50 hover:bg-surface-200/50 transition-colors text-center"
+            className="p-4 rounded-lg bg-white/50 hover:bg-surface-200/50 transition-colors text-center dark:bg-surface-900/50"
           >
             <DocumentTextIcon className="w-8 h-8 mx-auto mb-2 text-blue-600" />
             <span className="text-surface-800 text-sm">Create Plan</span>
           </Link>
           <Link
             to="/bcdr/tests/new"
-            className="p-4 rounded-lg bg-white/50 hover:bg-surface-200/50 transition-colors text-center"
+            className="p-4 rounded-lg bg-white/50 hover:bg-surface-200/50 transition-colors text-center dark:bg-surface-900/50"
           >
             <BeakerIcon className="w-8 h-8 mx-auto mb-2 text-purple-600" />
             <span className="text-surface-800 text-sm">Schedule Test</span>
           </Link>
           <Link
             to="/bcdr/runbooks/new"
-            className="p-4 rounded-lg bg-white/50 hover:bg-surface-200/50 transition-colors text-center"
+            className="p-4 rounded-lg bg-white/50 hover:bg-surface-200/50 transition-colors text-center dark:bg-surface-900/50"
           >
             <BookOpenIcon className="w-8 h-8 mx-auto mb-2 text-teal-600" />
             <span className="text-surface-800 text-sm">Create Runbook</span>
           </Link>
           <Link
             to="/bcdr/recovery-teams"
-            className="p-4 rounded-lg bg-white/50 hover:bg-surface-200/50 transition-colors text-center"
+            className="p-4 rounded-lg bg-white/50 hover:bg-surface-200/50 transition-colors text-center dark:bg-surface-900/50"
           >
             <UserGroupIcon className="w-8 h-8 mx-auto mb-2 text-green-600" />
             <span className="text-surface-800 text-sm">Recovery Teams</span>

--- a/frontend/src/pages/BCDRPlanDetail.tsx
+++ b/frontend/src/pages/BCDRPlanDetail.tsx
@@ -514,7 +514,7 @@ export default function BCDRPlanDetail() {
                 <Link
                   key={process.id}
                   to={`/bcdr/processes/${process.id}`}
-                  className="flex items-center justify-between p-4 rounded-lg bg-white/50 hover:bg-surface-200/50 transition-colors"
+                  className="flex items-center justify-between p-4 rounded-lg bg-white/50 hover:bg-surface-200/50 transition-colors dark:bg-surface-900/50"
                 >
                   <div className="flex items-center gap-3">
                     <ShieldExclamationIcon className="w-5 h-5 text-surface-600" />
@@ -540,7 +540,7 @@ export default function BCDRPlanDetail() {
             <h3 className="text-lg font-semibold text-surface-900">DR Tests</h3>
             <Link
               to="/bcdr/tests/new"
-              className="inline-flex items-center rounded-md border border-surface-300 bg-white px-3 h-8 text-small font-medium !text-surface-900 hover:bg-surface-100 transition-colors"
+              className="inline-flex items-center rounded-md border border-surface-300 bg-white px-3 h-8 text-small font-medium !text-surface-900 hover:bg-surface-100 transition-colors dark:bg-surface-900"
             >
               Schedule Test
             </Link>
@@ -551,7 +551,7 @@ export default function BCDRPlanDetail() {
                 <Link
                   key={test.id}
                   to={`/bcdr/tests/${test.id}`}
-                  className="flex items-center justify-between p-4 rounded-lg bg-white/50 hover:bg-surface-200/50 transition-colors"
+                  className="flex items-center justify-between p-4 rounded-lg bg-white/50 hover:bg-surface-200/50 transition-colors dark:bg-surface-900/50"
                 >
                   <div className="flex items-center gap-3">
                     {test.result === 'passed' ? (
@@ -599,7 +599,7 @@ export default function BCDRPlanDetail() {
                 <Link
                   key={control.id}
                   to={`/controls/${control.id}`}
-                  className="flex items-center justify-between p-4 rounded-lg bg-white/50 hover:bg-surface-200/50 transition-colors"
+                  className="flex items-center justify-between p-4 rounded-lg bg-white/50 hover:bg-surface-200/50 transition-colors dark:bg-surface-900/50"
                 >
                   <div>
                     <p className="text-surface-900 font-medium">{control.title}</p>

--- a/frontend/src/pages/BusinessProcessDetail.tsx
+++ b/frontend/src/pages/BusinessProcessDetail.tsx
@@ -322,21 +322,21 @@ export default function BusinessProcessDetail() {
             <div className="card p-6">
               <h3 className="text-lg font-semibold text-surface-900 mb-4">Recovery Objectives</h3>
               <div className="grid grid-cols-3 gap-4">
-                <div className="p-4 rounded-lg bg-white/50">
+                <div className="p-4 rounded-lg bg-white/50 dark:bg-surface-900/50">
                   <p className="text-surface-600 text-sm">RTO</p>
                   <p className="text-2xl font-bold text-surface-900">
                     {process.rto_hours || 'N/A'}h
                   </p>
                   <p className="text-surface-500 text-xs">Recovery Time Objective</p>
                 </div>
-                <div className="p-4 rounded-lg bg-white/50">
+                <div className="p-4 rounded-lg bg-white/50 dark:bg-surface-900/50">
                   <p className="text-surface-600 text-sm">RPO</p>
                   <p className="text-2xl font-bold text-surface-900">
                     {process.rpo_hours || 'N/A'}h
                   </p>
                   <p className="text-surface-500 text-xs">Recovery Point Objective</p>
                 </div>
-                <div className="p-4 rounded-lg bg-white/50">
+                <div className="p-4 rounded-lg bg-white/50 dark:bg-surface-900/50">
                   <p className="text-surface-600 text-sm">MTPD</p>
                   <p className="text-2xl font-bold text-surface-900">
                     {process.mtpd_hours || 'N/A'}h
@@ -463,7 +463,7 @@ export default function BusinessProcessDetail() {
                 <Link
                   key={dep.id}
                   to={`/bcdr/processes/${dep.dependent_process_id}`}
-                  className="flex items-center justify-between p-4 rounded-lg bg-white/50 hover:bg-surface-200/50 transition-colors"
+                  className="flex items-center justify-between p-4 rounded-lg bg-white/50 hover:bg-surface-200/50 transition-colors dark:bg-surface-900/50"
                 >
                   <div className="flex items-center gap-3">
                     <LinkIcon className="w-5 h-5 text-surface-600" />
@@ -489,7 +489,7 @@ export default function BusinessProcessDetail() {
                 <Link
                   key={asset.id}
                   to={`/assets/${asset.asset_id}`}
-                  className="flex items-center justify-between p-4 rounded-lg bg-white/50 hover:bg-surface-200/50 transition-colors"
+                  className="flex items-center justify-between p-4 rounded-lg bg-white/50 hover:bg-surface-200/50 transition-colors dark:bg-surface-900/50"
                 >
                   <div className="flex items-center gap-3">
                     <CubeIcon className="w-5 h-5 text-surface-600" />
@@ -515,7 +515,7 @@ export default function BusinessProcessDetail() {
                 <Link
                   key={plan.id}
                   to={`/bcdr/plans/${plan.id}`}
-                  className="flex items-center justify-between p-4 rounded-lg bg-white/50 hover:bg-surface-200/50 transition-colors"
+                  className="flex items-center justify-between p-4 rounded-lg bg-white/50 hover:bg-surface-200/50 transition-colors dark:bg-surface-900/50"
                 >
                   <div className="flex items-center gap-3">
                     <DocumentTextIcon className="w-5 h-5 text-surface-600" />

--- a/frontend/src/pages/BusinessProcesses.tsx
+++ b/frontend/src/pages/BusinessProcesses.tsx
@@ -166,7 +166,7 @@ export default function BusinessProcesses() {
         ) : (
           <div className="overflow-x-auto">
             <table className="w-full">
-              <thead className="bg-white/50">
+              <thead className="bg-white/50 dark:bg-surface-900/50">
                 <tr>
                   <th className="text-left p-4 text-surface-700 font-medium">Process</th>
                   <th className="text-left p-4 text-surface-700 font-medium">Criticality</th>
@@ -179,7 +179,10 @@ export default function BusinessProcesses() {
               </thead>
               <tbody className="divide-y divide-surface-200">
                 {processes.map((process: BusinessProcess) => (
-                  <tr key={process.id} className="hover:bg-white/30 transition-colors">
+                  <tr
+                    key={process.id}
+                    className="hover:bg-white/30 transition-colors dark:bg-surface-900/30 dark:hover:bg-surface-800/30"
+                  >
                     <td className="p-4">
                       <Link
                         to={`/bcdr/processes/${process.id}`}

--- a/frontend/src/pages/CommunicationPlans.tsx
+++ b/frontend/src/pages/CommunicationPlans.tsx
@@ -223,7 +223,7 @@ export default function CommunicationPlans() {
                     {(contacts as EscalationContact[]).map((contact) => (
                       <div
                         key={contact.id}
-                        className="p-4 rounded-lg bg-white/50 border border-surface-200"
+                        className="p-4 rounded-lg bg-white/50 border border-surface-200 dark:bg-surface-900/50"
                       >
                         <div className="flex items-start justify-between mb-2">
                           <div>

--- a/frontend/src/pages/ConfigAsCode.tsx
+++ b/frontend/src/pages/ConfigAsCode.tsx
@@ -383,7 +383,7 @@ function ExportImportContent({
               value={importConfig}
               onChange={(e) => setImportConfig(e.target.value)}
               placeholder="Paste your configuration here or upload a file..."
-              className="w-full h-64 px-4 py-3 bg-white border border-surface-200 rounded-lg text-surface-800 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+              className="w-full h-64 px-4 py-3 bg-white border border-surface-200 rounded-lg text-surface-800 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 dark:bg-surface-900"
             />
           </div>
 
@@ -410,7 +410,7 @@ function ExportImportContent({
         </div>
       </div>
       {/* Info Section */}
-      <div className="bg-white border border-surface-200 rounded-lg p-4">
+      <div className="bg-white border border-surface-200 rounded-lg p-4 dark:bg-surface-900">
         <div className="flex items-start gap-3">
           <CodeBracketIcon className="w-5 h-5 text-brand-400 flex-shrink-0 mt-0.5" />
           <div>

--- a/frontend/src/pages/ContractDetail.tsx
+++ b/frontend/src/pages/ContractDetail.tsx
@@ -79,7 +79,7 @@ function ContractForm({ contract, onSave, onCancel }: ContractFormProps) {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
-      <div className="bg-white border border-surface-200 rounded-lg p-6 space-y-6">
+      <div className="bg-white border border-surface-200 rounded-lg p-6 space-y-6 dark:bg-surface-900">
         {/* Basic Information */}
         <div>
           <h3 className="text-lg font-medium text-surface-900 mb-4">Basic Information</h3>
@@ -92,7 +92,7 @@ function ContractForm({ contract, onSave, onCancel }: ContractFormProps) {
                 type="text"
                 value={formData.title}
                 onChange={(e) => setFormData({ ...formData, title: e.target.value })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
                 required
               />
             </div>
@@ -103,7 +103,7 @@ function ContractForm({ contract, onSave, onCancel }: ContractFormProps) {
               <SelectNative
                 value={formData.contractType}
                 onChange={(e) => setFormData({ ...formData, contractType: e.target.value })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
                 required
               >
                 <option value="msa">MSA</option>
@@ -119,7 +119,7 @@ function ContractForm({ contract, onSave, onCancel }: ContractFormProps) {
               <SelectNative
                 value={formData.status}
                 onChange={(e) => setFormData({ ...formData, status: e.target.value })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
                 required
               >
                 <option value="active">Active</option>
@@ -134,7 +134,7 @@ function ContractForm({ contract, onSave, onCancel }: ContractFormProps) {
                 type="text"
                 value={formData.vendorId}
                 onChange={(e) => setFormData({ ...formData, vendorId: e.target.value })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
                 required
               />
             </div>
@@ -148,7 +148,7 @@ function ContractForm({ contract, onSave, onCancel }: ContractFormProps) {
             value={formData.description || ''}
             onChange={(e) => setFormData({ ...formData, description: e.target.value })}
             rows={3}
-            className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+            className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
           />
         </div>
 
@@ -169,7 +169,7 @@ function ContractForm({ contract, onSave, onCancel }: ContractFormProps) {
                     contractValue: parseFloat(e.target.value) || undefined,
                   })
                 }
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               />
             </div>
             <div>
@@ -177,7 +177,7 @@ function ContractForm({ contract, onSave, onCancel }: ContractFormProps) {
               <SelectNative
                 value={formData.currency}
                 onChange={(e) => setFormData({ ...formData, currency: e.target.value })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               >
                 <option value="USD">USD</option>
                 <option value="EUR">EUR</option>
@@ -199,7 +199,7 @@ function ContractForm({ contract, onSave, onCancel }: ContractFormProps) {
                 type="date"
                 value={formData.startDate}
                 onChange={(e) => setFormData({ ...formData, startDate: e.target.value })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
                 required
               />
             </div>
@@ -209,7 +209,7 @@ function ContractForm({ contract, onSave, onCancel }: ContractFormProps) {
                 type="date"
                 value={formData.endDate}
                 onChange={(e) => setFormData({ ...formData, endDate: e.target.value })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
                 required
               />
             </div>
@@ -221,7 +221,7 @@ function ContractForm({ contract, onSave, onCancel }: ContractFormProps) {
                 type="date"
                 value={formData.renewalDate || ''}
                 onChange={(e) => setFormData({ ...formData, renewalDate: e.target.value })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               />
             </div>
           </div>
@@ -231,7 +231,7 @@ function ContractForm({ contract, onSave, onCancel }: ContractFormProps) {
                 type="checkbox"
                 checked={formData.autoRenew}
                 onChange={(e) => setFormData({ ...formData, autoRenew: e.target.checked })}
-                className="w-4 h-4 bg-white border-surface-200 rounded text-brand-600 focus:ring-brand-500"
+                className="w-4 h-4 bg-white border-surface-200 rounded text-brand-600 focus:ring-brand-500 dark:bg-surface-900"
               />
               <span className="text-sm text-surface-700">Auto-renew contract</span>
             </label>
@@ -247,7 +247,7 @@ function ContractForm({ contract, onSave, onCancel }: ContractFormProps) {
                 type="checkbox"
                 checked={formData.requiresSoc2}
                 onChange={(e) => setFormData({ ...formData, requiresSoc2: e.target.checked })}
-                className="w-4 h-4 bg-white border-surface-200 rounded text-brand-600 focus:ring-brand-500"
+                className="w-4 h-4 bg-white border-surface-200 rounded text-brand-600 focus:ring-brand-500 dark:bg-surface-900"
               />
               <span className="text-sm text-surface-700">SOC 2 Required</span>
             </label>
@@ -256,7 +256,7 @@ function ContractForm({ contract, onSave, onCancel }: ContractFormProps) {
                 type="checkbox"
                 checked={formData.requiresIso27001}
                 onChange={(e) => setFormData({ ...formData, requiresIso27001: e.target.checked })}
-                className="w-4 h-4 bg-white border-surface-200 rounded text-brand-600 focus:ring-brand-500"
+                className="w-4 h-4 bg-white border-surface-200 rounded text-brand-600 focus:ring-brand-500 dark:bg-surface-900"
               />
               <span className="text-sm text-surface-700">ISO 27001 Required</span>
             </label>
@@ -265,7 +265,7 @@ function ContractForm({ contract, onSave, onCancel }: ContractFormProps) {
                 type="checkbox"
                 checked={formData.requiresHipaa}
                 onChange={(e) => setFormData({ ...formData, requiresHipaa: e.target.checked })}
-                className="w-4 h-4 bg-white border-surface-200 rounded text-brand-600 focus:ring-brand-500"
+                className="w-4 h-4 bg-white border-surface-200 rounded text-brand-600 focus:ring-brand-500 dark:bg-surface-900"
               />
               <span className="text-sm text-surface-700">HIPAA Required</span>
             </label>
@@ -274,7 +274,7 @@ function ContractForm({ contract, onSave, onCancel }: ContractFormProps) {
                 type="checkbox"
                 checked={formData.requiresGdpr}
                 onChange={(e) => setFormData({ ...formData, requiresGdpr: e.target.checked })}
-                className="w-4 h-4 bg-white border-surface-200 rounded text-brand-600 focus:ring-brand-500"
+                className="w-4 h-4 bg-white border-surface-200 rounded text-brand-600 focus:ring-brand-500 dark:bg-surface-900"
               />
               <span className="text-sm text-surface-700">GDPR Required</span>
             </label>
@@ -312,7 +312,7 @@ function ContractView({
 }) {
   return (
     <div className="space-y-6">
-      <div className="bg-white border border-surface-200 rounded-lg p-6 space-y-6">
+      <div className="bg-white border border-surface-200 rounded-lg p-6 space-y-6 dark:bg-surface-900">
         {/* Header */}
         <div className="flex items-start justify-between">
           <div>
@@ -322,13 +322,13 @@ function ContractView({
           <div className="flex items-center gap-2">
             <button
               onClick={onEdit}
-              className="p-2 text-surface-600 hover:text-surface-900 hover:bg-white rounded-lg transition-colors"
+              className="p-2 text-surface-600 hover:text-surface-900 hover:bg-white rounded-lg transition-colors dark:bg-surface-900 dark:hover:bg-surface-800"
             >
               <PencilIcon className="w-5 h-5" />
             </button>
             <button
               onClick={onDelete}
-              className="p-2 text-red-600 hover:text-red-700 hover:bg-white rounded-lg transition-colors"
+              className="p-2 text-red-600 hover:text-red-700 hover:bg-white rounded-lg transition-colors dark:bg-surface-900 dark:hover:bg-surface-800"
             >
               <TrashIcon className="w-5 h-5" />
             </button>
@@ -550,7 +550,7 @@ export default function ContractDetail() {
       <div className="flex items-center gap-4">
         <button
           onClick={() => navigate('/contracts')}
-          className="p-2 text-surface-600 hover:text-surface-900 hover:bg-white rounded-lg transition-colors"
+          className="p-2 text-surface-600 hover:text-surface-900 hover:bg-white rounded-lg transition-colors dark:bg-surface-900 dark:hover:bg-surface-800"
         >
           <ArrowLeftIcon className="w-5 h-5" />
         </button>
@@ -590,7 +590,7 @@ export default function ContractDetail() {
         <div className="flex justify-end gap-2">
           <button
             onClick={() => setShowDeleteConfirm(false)}
-            className="px-4 py-2 bg-white text-surface-900 rounded-lg hover:bg-surface-200 transition-colors"
+            className="px-4 py-2 bg-white text-surface-900 rounded-lg hover:bg-surface-200 transition-colors dark:bg-surface-900"
           >
             Cancel
           </button>

--- a/frontend/src/pages/Contracts.tsx
+++ b/frontend/src/pages/Contracts.tsx
@@ -65,7 +65,7 @@ export default function Contracts() {
           }}
         />
       ) : (
-        <div className="bg-white border border-surface-200 rounded-xl overflow-hidden">
+        <div className="bg-white border border-surface-200 rounded-xl overflow-hidden dark:bg-surface-900">
           <table className="w-full">
             <thead className="bg-surface-200/50 border-b border-surface-200">
               <tr>

--- a/frontend/src/pages/ControlDetail.tsx
+++ b/frontend/src/pages/ControlDetail.tsx
@@ -303,7 +303,7 @@ export default function ControlDetail() {
       </div>
       {/* Edit Modal */}
       <Dialog open={isEditing} onClose={() => setIsEditing(false)}>
-        <div className="p-4 border-b border-surface-200 flex items-center justify-between sticky top-0 bg-white">
+        <div className="p-4 border-b border-surface-200 flex items-center justify-between sticky top-0 bg-white dark:bg-surface-900">
           <h2 className="text-lg font-semibold text-surface-900">Edit Control</h2>
           <button onClick={() => setIsEditing(false)} className="p-1 hover:bg-surface-200 rounded">
             <XMarkIcon className="w-5 h-5 text-surface-600" />
@@ -425,7 +425,7 @@ export default function ControlDetail() {
             </div>
           )}
         </div>
-        <div className="p-4 border-t border-surface-200 flex justify-end gap-3 sticky bottom-0 bg-white">
+        <div className="p-4 border-t border-surface-200 flex justify-end gap-3 sticky bottom-0 bg-white dark:bg-surface-900">
           <Button variant="secondary" onClick={() => setIsEditing(false)}>
             Cancel
           </Button>
@@ -518,7 +518,7 @@ export default function ControlDetail() {
                 {control?.evidenceLinks?.map((link: any) => (
                   <div
                     key={link.id}
-                    className="flex items-center justify-between p-3 bg-white rounded-lg group"
+                    className="flex items-center justify-between p-3 bg-white rounded-lg group dark:bg-surface-900"
                   >
                     <Link
                       to={`/evidence/${link.evidence.id}`}
@@ -589,7 +589,7 @@ export default function ControlDetail() {
                 {control?.policyLinks?.map((link: any) => (
                   <div
                     key={link.id}
-                    className="flex items-center justify-between p-3 bg-white rounded-lg group"
+                    className="flex items-center justify-between p-3 bg-white rounded-lg group dark:bg-surface-900"
                   >
                     <Link
                       to={`/policies/${link.policy?.id}`}
@@ -655,7 +655,7 @@ export default function ControlDetail() {
                 {implementation?.tests?.map((test: any) => (
                   <div
                     key={test.id}
-                    className="flex items-start justify-between p-3 bg-white rounded-lg"
+                    className="flex items-start justify-between p-3 bg-white rounded-lg dark:bg-surface-900"
                   >
                     <div>
                       <div className="flex items-center gap-2">
@@ -751,7 +751,7 @@ export default function ControlDetail() {
                     <div
                       key={mapping.id}
                       role="listitem"
-                      className="group relative p-2 bg-white rounded-lg"
+                      className="group relative p-2 bg-white rounded-lg dark:bg-surface-900"
                     >
                       <div className="flex items-start justify-between gap-2">
                         <div className="flex-1 min-w-0">
@@ -784,7 +784,7 @@ export default function ControlDetail() {
                             {isMenuOpen && (
                               <div
                                 role="menu"
-                                className="absolute right-0 top-full mt-1 w-32 rounded-md border border-surface-200 bg-white shadow-lg z-10"
+                                className="absolute right-0 top-full mt-1 w-32 rounded-md border border-surface-200 bg-white shadow-lg z-10 dark:bg-surface-900"
                               >
                                 {canEditMappings && (
                                   <button
@@ -799,7 +799,7 @@ export default function ControlDetail() {
                                         frameworkId: mapping.frameworkId,
                                       });
                                     }}
-                                    className="w-full text-left px-3 py-2 text-xs text-surface-800 hover:bg-white first:rounded-t-md"
+                                    className="w-full text-left px-3 py-2 text-xs text-surface-800 hover:bg-white first:rounded-t-md dark:bg-surface-900 dark:hover:bg-surface-800"
                                   >
                                     Edit
                                   </button>
@@ -820,7 +820,7 @@ export default function ControlDetail() {
                                         },
                                       });
                                     }}
-                                    className="w-full text-left px-3 py-2 text-xs text-surface-800 hover:bg-white"
+                                    className="w-full text-left px-3 py-2 text-xs text-surface-800 hover:bg-white dark:bg-surface-900 dark:hover:bg-surface-800"
                                   >
                                     Copy to framework…
                                   </button>
@@ -832,7 +832,7 @@ export default function ControlDetail() {
                                     setMappingMenuOpenId(null);
                                     setHistoryDrawerMappingId(mapping.id);
                                   }}
-                                  className="flex items-center gap-2 w-full text-left px-3 py-2 text-xs text-surface-800 hover:bg-white"
+                                  className="flex items-center gap-2 w-full text-left px-3 py-2 text-xs text-surface-800 hover:bg-white dark:bg-surface-900 dark:hover:bg-surface-800"
                                 >
                                   <ClockIcon className="w-3.5 h-3.5" aria-hidden="true" />
                                   History
@@ -845,7 +845,7 @@ export default function ControlDetail() {
                                       setMappingMenuOpenId(null);
                                       setMappingDeleteConfirmId(mapping.id);
                                     }}
-                                    className="w-full text-left px-3 py-2 text-xs text-red-600 hover:bg-white last:rounded-b-md"
+                                    className="w-full text-left px-3 py-2 text-xs text-red-600 hover:bg-white last:rounded-b-md dark:bg-surface-900 dark:hover:bg-surface-800"
                                   >
                                     Delete
                                   </button>
@@ -856,7 +856,7 @@ export default function ControlDetail() {
                         )}
                       </div>
                       {isConfirmingDelete && (
-                        <div className="mt-2 p-2 bg-white border border-surface-200 rounded">
+                        <div className="mt-2 p-2 bg-white border border-surface-200 rounded dark:bg-surface-900">
                           <p className="text-xs text-surface-700 mb-2">Delete this mapping?</p>
                           <div className="flex justify-end gap-2">
                             <button
@@ -1169,7 +1169,7 @@ function LinkPolicyModal({
                 'flex items-center gap-3 p-3 rounded-lg cursor-pointer transition-colors',
                 selectedPolicyIds.includes(policy.id)
                   ? 'bg-brand-500/20 border border-brand-500/50'
-                  : 'bg-white hover:bg-surface-200'
+                  : 'bg-white hover:bg-surface-200 dark:bg-surface-900'
               )}
             >
               <input

--- a/frontend/src/pages/CustomDashboards.tsx
+++ b/frontend/src/pages/CustomDashboards.tsx
@@ -189,7 +189,7 @@ export default function CustomDashboards() {
               </div>
 
               {/* Mini preview */}
-              <div className="mt-3 bg-white rounded p-2">
+              <div className="mt-3 bg-white rounded p-2 dark:bg-surface-900">
                 <div className="grid grid-cols-6 gap-1 h-12">
                   {dashboard.widgets?.slice(0, 6).map((widget, i) => (
                     <div

--- a/frontend/src/pages/DRTestDetail.tsx
+++ b/frontend/src/pages/DRTestDetail.tsx
@@ -487,13 +487,13 @@ export default function DRTestDetail() {
             <div className="card p-6">
               <h3 className="text-lg font-semibold text-surface-900 mb-4">Recovery Metrics</h3>
               <div className="grid grid-cols-3 gap-4">
-                <div className="p-4 rounded-lg bg-white/50">
+                <div className="p-4 rounded-lg bg-white/50 dark:bg-surface-900/50">
                   <p className="text-surface-600 text-sm">Target RTO</p>
                   <p className="text-2xl font-bold text-surface-900">
                     {test.target_rto_minutes ? `${test.target_rto_minutes}m` : 'N/A'}
                   </p>
                 </div>
-                <div className="p-4 rounded-lg bg-white/50">
+                <div className="p-4 rounded-lg bg-white/50 dark:bg-surface-900/50">
                   <p className="text-surface-600 text-sm">Actual Recovery Time</p>
                   <p
                     className={clsx(
@@ -510,7 +510,7 @@ export default function DRTestDetail() {
                       : 'N/A'}
                   </p>
                 </div>
-                <div className="p-4 rounded-lg bg-white/50">
+                <div className="p-4 rounded-lg bg-white/50 dark:bg-surface-900/50">
                   <p className="text-surface-600 text-sm">RTO Met</p>
                   <p
                     className={clsx(
@@ -623,7 +623,7 @@ export default function DRTestDetail() {
               {test.findings.map((finding) => (
                 <div
                   key={finding.id}
-                  className="p-4 rounded-lg bg-white/50 border border-surface-200"
+                  className="p-4 rounded-lg bg-white/50 border border-surface-200 dark:bg-surface-900/50"
                 >
                   <div className="flex items-start justify-between mb-2">
                     <h4 className="text-surface-900 font-medium">{finding.title}</h4>
@@ -687,7 +687,7 @@ export default function DRTestDetail() {
               {test.participants.map((participant) => (
                 <div
                   key={participant.id}
-                  className="flex items-center justify-between p-4 rounded-lg bg-white/50"
+                  className="flex items-center justify-between p-4 rounded-lg bg-white/50 dark:bg-surface-900/50"
                 >
                   <div className="flex items-center gap-3">
                     <div className="w-10 h-10 rounded-full bg-surface-200 flex items-center justify-center">

--- a/frontend/src/pages/DRTests.tsx
+++ b/frontend/src/pages/DRTests.tsx
@@ -240,7 +240,7 @@ export default function DRTests() {
         ) : (
           <div className="overflow-x-auto">
             <table className="w-full">
-              <thead className="bg-white/50">
+              <thead className="bg-white/50 dark:bg-surface-900/50">
                 <tr>
                   <th className="text-left p-4 text-surface-700 font-medium">Test</th>
                   <th className="text-left p-4 text-surface-700 font-medium">Type</th>
@@ -256,7 +256,10 @@ export default function DRTests() {
                   const ResultIcon = test.result ? resultColors[test.result]?.icon : null;
 
                   return (
-                    <tr key={test.id} className="hover:bg-white/30 transition-colors">
+                    <tr
+                      key={test.id}
+                      className="hover:bg-white/30 transition-colors dark:bg-surface-900/30 dark:hover:bg-surface-800/30"
+                    >
                       <td className="p-4">
                         <Link
                           to={`/bcdr/tests/${test.id}`}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -310,7 +310,7 @@ export default function Dashboard() {
                   className="fixed inset-0 z-10"
                   onClick={() => setShowDashboardSelector(false)}
                 />
-                <div className="absolute left-0 mt-2 w-64 bg-white border border-surface-200 rounded-lg shadow-xl z-20">
+                <div className="absolute left-0 mt-2 w-64 bg-white border border-surface-200 rounded-lg shadow-xl z-20 dark:bg-surface-900">
                   <div className="p-3 border-b border-surface-200">
                     <p className="text-sm font-medium text-surface-700">My Dashboards</p>
                   </div>
@@ -387,7 +387,7 @@ export default function Dashboard() {
                 'w-full flex items-center justify-between p-3 rounded-lg border transition-all',
                 config.widgets[widget]
                   ? 'bg-brand-500/10 border-brand-500/30 text-surface-900'
-                  : 'bg-white border-surface-200 text-surface-600'
+                  : 'bg-white border-surface-200 text-surface-600 dark:bg-surface-900'
               )}
             >
               <span className="font-medium">{WIDGET_LABELS[widget]}</span>
@@ -762,7 +762,7 @@ export default function Dashboard() {
                           </span>
                           <span className="text-sm text-surface-700">{String(count)}</span>
                         </div>
-                        <div className="w-full h-1.5 bg-white rounded-full overflow-hidden">
+                        <div className="w-full h-1.5 bg-white rounded-full overflow-hidden dark:bg-surface-900">
                           <div
                             className="h-full bg-brand-500 rounded-full"
                             style={{ width: `${percentage}%` }}
@@ -905,15 +905,15 @@ const VendorRiskSummary = memo(function VendorRiskSummary({ data }: VendorRiskSu
     <div className="space-y-4">
       {/* Summary Stats */}
       <div className="grid grid-cols-3 gap-4">
-        <div className="text-center p-3 bg-white/50 rounded-lg">
+        <div className="text-center p-3 bg-white/50 rounded-lg dark:bg-surface-900/50">
           <p className="text-2xl font-bold text-surface-900">{stats.total}</p>
           <p className="text-xs text-surface-600">Total Vendors</p>
         </div>
-        <div className="text-center p-3 bg-white/50 rounded-lg">
+        <div className="text-center p-3 bg-white/50 rounded-lg dark:bg-surface-900/50">
           <p className="text-2xl font-bold text-green-600">{stats.active}</p>
           <p className="text-xs text-surface-600">Active</p>
         </div>
-        <div className="text-center p-3 bg-white/50 rounded-lg">
+        <div className="text-center p-3 bg-white/50 rounded-lg dark:bg-surface-900/50">
           <p className="text-2xl font-bold text-yellow-600">{stats.pendingReview}</p>
           <p className="text-xs text-surface-600">Pending Review</p>
         </div>
@@ -922,7 +922,7 @@ const VendorRiskSummary = memo(function VendorRiskSummary({ data }: VendorRiskSu
       {/* Criticality Breakdown */}
       <div>
         <p className="text-sm text-surface-600 mb-2">By Criticality</p>
-        <div className="flex gap-1 h-3 rounded-full overflow-hidden bg-white">
+        <div className="flex gap-1 h-3 rounded-full overflow-hidden bg-white dark:bg-surface-900">
           {criticialityData.map(
             (item) =>
               item.count > 0 && (
@@ -955,7 +955,7 @@ const VendorRiskSummary = memo(function VendorRiskSummary({ data }: VendorRiskSu
             <Link
               key={vendor.id}
               to={`/vendors/${vendor.id}`}
-              className="flex items-center justify-between p-2 bg-white/50 rounded-lg hover:bg-surface-200 transition-colors"
+              className="flex items-center justify-between p-2 bg-white/50 rounded-lg hover:bg-surface-200 transition-colors dark:bg-surface-900/50"
             >
               <div className="flex items-center gap-2">
                 <div

--- a/frontend/src/pages/DeveloperDocs.tsx
+++ b/frontend/src/pages/DeveloperDocs.tsx
@@ -78,8 +78,8 @@ function CopyButton({ text }: { text: string }) {
 
 function CodeBlock({ code, language = 'bash' }: { code: string; language?: string }) {
   return (
-    <div className="relative bg-white rounded-lg overflow-hidden my-4">
-      <div className="absolute top-0 left-0 px-3 py-1 text-xs text-surface-500 bg-white rounded-br">
+    <div className="relative bg-white rounded-lg overflow-hidden my-4 dark:bg-surface-900">
+      <div className="absolute top-0 left-0 px-3 py-1 text-xs text-surface-500 bg-white rounded-br dark:bg-surface-900">
         {language}
       </div>
       <CopyButton text={code} />
@@ -101,7 +101,7 @@ function ApiDocs() {
           API requests require authentication via API key or JWT token.
         </p>
 
-        <div className="bg-white/50 border border-surface-200 rounded-lg p-4">
+        <div className="bg-white/50 border border-surface-200 rounded-lg p-4 dark:bg-surface-900/50">
           <h4 className="font-semibold text-surface-800 mb-2">Base URL</h4>
           <code className="text-brand-400">https://api.gigachad-grc.com/v1</code>
         </div>
@@ -121,7 +121,7 @@ function ApiDocs() {
         <h3 className="text-xl font-bold text-surface-900 mb-4">Common Endpoints</h3>
 
         <div className="space-y-4">
-          <div className="bg-white rounded-lg overflow-hidden">
+          <div className="bg-white rounded-lg overflow-hidden dark:bg-surface-900">
             <table className="w-full text-sm">
               <thead className="bg-surface-200">
                 <tr>
@@ -241,7 +241,7 @@ function ApiDocs() {
 
       <section>
         <h3 className="text-xl font-bold text-surface-900 mb-4">Rate Limits</h3>
-        <div className="bg-white rounded-lg overflow-hidden">
+        <div className="bg-white rounded-lg overflow-hidden dark:bg-surface-900">
           <table className="w-full text-sm">
             <thead className="bg-surface-200">
               <tr>
@@ -321,7 +321,7 @@ function ArchitectureDocs() {
           ].map((service) => (
             <div
               key={service.name}
-              className="bg-white/50 border border-surface-200 rounded-lg p-4"
+              className="bg-white/50 border border-surface-200 rounded-lg p-4 dark:bg-surface-900/50"
             >
               <h4 className="font-semibold text-surface-800">{service.name}</h4>
               <p className="text-surface-600 text-sm mt-1">{service.desc}</p>
@@ -333,7 +333,7 @@ function ArchitectureDocs() {
 
       <section>
         <h3 className="text-xl font-bold text-surface-900 mb-4">Technology Stack</h3>
-        <div className="bg-white rounded-lg overflow-hidden">
+        <div className="bg-white rounded-lg overflow-hidden dark:bg-surface-900">
           <table className="w-full text-sm">
             <thead className="bg-surface-200">
               <tr>
@@ -375,7 +375,7 @@ function ArchitectureDocs() {
 
       <section>
         <h3 className="text-xl font-bold text-surface-900 mb-4">Data Flow</h3>
-        <div className="bg-white/50 border border-surface-200 rounded-lg p-4">
+        <div className="bg-white/50 border border-surface-200 rounded-lg p-4 dark:bg-surface-900/50">
           <ol className="space-y-3 text-surface-700">
             <li className="flex gap-3">
               <span className="flex-shrink-0 w-6 h-6 bg-brand-600 text-white rounded-full flex items-center justify-center text-sm font-bold">
@@ -460,7 +460,7 @@ function ConfigurationDocs() {
 
       <section>
         <h3 className="text-xl font-bold text-surface-900 mb-4">Required Environment Variables</h3>
-        <div className="bg-white rounded-lg overflow-hidden">
+        <div className="bg-white rounded-lg overflow-hidden dark:bg-surface-900">
           <table className="w-full text-sm">
             <thead className="bg-surface-200">
               <tr>
@@ -555,7 +555,7 @@ VITE_KEYCLOAK_CLIENT_ID=grc-frontend`}
 
       <section>
         <h3 className="text-xl font-bold text-surface-900 mb-4">Optional Configuration</h3>
-        <div className="bg-white rounded-lg overflow-hidden">
+        <div className="bg-white rounded-lg overflow-hidden dark:bg-surface-900">
           <table className="w-full text-sm">
             <thead className="bg-surface-200">
               <tr>
@@ -654,34 +654,55 @@ docker-compose logs -f`}
         <h3 className="text-xl font-bold text-surface-900 mb-4">Production Checklist</h3>
         <ul className="space-y-2 text-surface-700">
           <li className="flex gap-3">
-            <input type="checkbox" className="mt-1 w-4 h-4 bg-white border-surface-300 rounded" />
+            <input
+              type="checkbox"
+              className="mt-1 w-4 h-4 bg-white border-surface-300 rounded dark:bg-surface-900"
+            />
             <span>
               Generate unique ENCRYPTION_KEY using{' '}
               <code className="text-brand-400 text-sm">openssl rand -hex 32</code>
             </span>
           </li>
           <li className="flex gap-3">
-            <input type="checkbox" className="mt-1 w-4 h-4 bg-white border-surface-300 rounded" />
+            <input
+              type="checkbox"
+              className="mt-1 w-4 h-4 bg-white border-surface-300 rounded dark:bg-surface-900"
+            />
             <span>Configure SSL/TLS certificates (Let's Encrypt or custom)</span>
           </li>
           <li className="flex gap-3">
-            <input type="checkbox" className="mt-1 w-4 h-4 bg-white border-surface-300 rounded" />
+            <input
+              type="checkbox"
+              className="mt-1 w-4 h-4 bg-white border-surface-300 rounded dark:bg-surface-900"
+            />
             <span>Set up database backups (daily recommended)</span>
           </li>
           <li className="flex gap-3">
-            <input type="checkbox" className="mt-1 w-4 h-4 bg-white border-surface-300 rounded" />
+            <input
+              type="checkbox"
+              className="mt-1 w-4 h-4 bg-white border-surface-300 rounded dark:bg-surface-900"
+            />
             <span>Configure firewall rules (allow ports 80, 443)</span>
           </li>
           <li className="flex gap-3">
-            <input type="checkbox" className="mt-1 w-4 h-4 bg-white border-surface-300 rounded" />
+            <input
+              type="checkbox"
+              className="mt-1 w-4 h-4 bg-white border-surface-300 rounded dark:bg-surface-900"
+            />
             <span>Set up monitoring and alerting</span>
           </li>
           <li className="flex gap-3">
-            <input type="checkbox" className="mt-1 w-4 h-4 bg-white border-surface-300 rounded" />
+            <input
+              type="checkbox"
+              className="mt-1 w-4 h-4 bg-white border-surface-300 rounded dark:bg-surface-900"
+            />
             <span>Configure log aggregation</span>
           </li>
           <li className="flex gap-3">
-            <input type="checkbox" className="mt-1 w-4 h-4 bg-white border-surface-300 rounded" />
+            <input
+              type="checkbox"
+              className="mt-1 w-4 h-4 bg-white border-surface-300 rounded dark:bg-surface-900"
+            />
             <span>Test disaster recovery procedures</span>
           </li>
         </ul>
@@ -830,7 +851,7 @@ npm run format`}
 
       <section>
         <h3 className="text-xl font-bold text-surface-900 mb-4">Useful Commands</h3>
-        <div className="bg-white rounded-lg overflow-hidden">
+        <div className="bg-white rounded-lg overflow-hidden dark:bg-surface-900">
           <table className="w-full text-sm">
             <thead className="bg-surface-200">
               <tr>
@@ -925,7 +946,7 @@ export default function DeveloperDocs() {
                   className={`w-full flex items-center gap-3 px-4 py-3 rounded-lg text-left transition-colors ${
                     isActive
                       ? 'bg-brand-600/20 text-brand-400 border border-brand-500/30'
-                      : 'text-surface-600 hover:bg-white hover:text-surface-800'
+                      : 'text-surface-600 hover:bg-white hover:text-surface-800 dark:bg-surface-900 dark:hover:bg-surface-800'
                   }`}
                 >
                   <Icon className="w-5 h-5" />
@@ -941,7 +962,7 @@ export default function DeveloperDocs() {
 
         {/* Main Content */}
         <main className="flex-1 min-w-0">
-          <div className="bg-white/30 border border-surface-200 rounded-xl p-6 lg:p-8">
+          <div className="bg-white/30 border border-surface-200 rounded-xl p-6 lg:p-8 dark:bg-surface-900/30">
             {currentSection && (
               <div className="flex items-center gap-3 mb-6 pb-6 border-b border-surface-200">
                 <div className="p-2 bg-brand-600/20 rounded-lg">

--- a/frontend/src/pages/DisabledModulePage.tsx
+++ b/frontend/src/pages/DisabledModulePage.tsx
@@ -23,7 +23,7 @@ export default function DisabledModulePage({ moduleId }: DisabledModulePageProps
     <div className="min-h-[60vh] flex items-center justify-center p-6">
       <div className="max-w-lg w-full text-center">
         {/* Icon */}
-        <div className="mx-auto w-20 h-20 rounded-full bg-white flex items-center justify-center mb-6">
+        <div className="mx-auto w-20 h-20 rounded-full bg-white flex items-center justify-center mb-6 dark:bg-surface-900">
           <LockClosedIcon className="w-10 h-10 text-surface-600" />
         </div>
 
@@ -41,7 +41,7 @@ export default function DisabledModulePage({ moduleId }: DisabledModulePageProps
         </p>
 
         {/* How to Enable */}
-        <div className="bg-white/50 rounded-lg p-4 mb-6 text-left">
+        <div className="bg-white/50 rounded-lg p-4 mb-6 text-left dark:bg-surface-900/50">
           <h3 className="text-sm font-semibold text-surface-800 mb-2 flex items-center gap-2">
             <Cog6ToothIcon className="w-4 h-4" />
             How to Enable This Module
@@ -51,7 +51,7 @@ export default function DisabledModulePage({ moduleId }: DisabledModulePageProps
               To enable this module, an administrator needs to update the environment configuration:
             </p>
             {moduleDefinition && (
-              <code className="block bg-white px-3 py-2 rounded text-xs text-green-600 font-mono">
+              <code className="block bg-white px-3 py-2 rounded text-xs text-green-600 font-mono dark:bg-surface-900">
                 {moduleDefinition.envVar}=true
               </code>
             )}

--- a/frontend/src/pages/EmployeeDetail.tsx
+++ b/frontend/src/pages/EmployeeDetail.tsx
@@ -47,14 +47,14 @@ function formatDate(dateString: string | null | undefined): string {
 }
 
 function getScoreColor(score: number | undefined): string {
-  if (score === undefined) return 'text-gray-400';
+  if (score === undefined) return 'text-gray-400 dark:text-surface-500';
   if (score >= 80) return 'text-green-500';
   if (score >= 60) return 'text-yellow-500';
   return 'text-red-500';
 }
 
 function getScoreBgColor(score: number | undefined): string {
-  if (score === undefined) return 'bg-gray-500/20';
+  if (score === undefined) return 'bg-gray-500/20 dark:bg-surface-500/20';
   if (score >= 80) return 'bg-green-500/20';
   if (score >= 60) return 'bg-yellow-500/20';
   return 'bg-red-500/20';
@@ -76,7 +76,7 @@ function StatusBadge({ status }: { status: string | undefined }) {
     declined: { color: 'bg-red-500/20 text-red-600', icon: XCircleIcon },
   };
   const config = configs[status] || {
-    color: 'bg-gray-500/20 text-gray-400',
+    color: 'bg-gray-500/20 text-gray-400 dark:bg-surface-500/20 dark:text-surface-500',
     icon: ExclamationTriangleIcon,
   };
   const Icon = config.icon;
@@ -374,7 +374,11 @@ export default function EmployeeDetail() {
                         <td className="p-3 text-foreground">{training.courseName}</td>
                         <td className="p-3 text-center">
                           <span
-                            className={`text-xs px-2 py-0.5 rounded ${training.courseType === 'required' ? 'bg-red-500/20 text-red-600' : 'bg-gray-500/20 text-gray-400'}`}
+                            className={`text-xs px-2 py-0.5 rounded ${
+                              training.courseType === 'required'
+                                ? 'bg-red-500/20 dark:bg-red-500/20 text-red-600 dark:text-red-400'
+                                : 'bg-surface-500/20 dark:bg-surface-500/20 text-surface-500 dark:text-surface-400'
+                            }`}
                           >
                             {training.courseType || 'optional'}
                           </span>

--- a/frontend/src/pages/Employees.tsx
+++ b/frontend/src/pages/Employees.tsx
@@ -49,14 +49,14 @@ interface Employee {
 }
 
 function getScoreColor(score: number | undefined): string {
-  if (score === undefined) return 'text-gray-400';
+  if (score === undefined) return 'text-gray-400 dark:text-surface-500';
   if (score >= 80) return 'text-green-500';
   if (score >= 60) return 'text-yellow-500';
   return 'text-red-500';
 }
 
 function getScoreBgColor(score: number | undefined): string {
-  if (score === undefined) return 'bg-gray-500/20';
+  if (score === undefined) return 'bg-gray-500/20 dark:bg-surface-500/20';
   if (score >= 80) return 'bg-green-500/20';
   if (score >= 60) return 'bg-yellow-500/20';
   return 'bg-red-500/20';
@@ -88,7 +88,7 @@ function getStatusBadge(status: string | undefined) {
       );
     default:
       return (
-        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-gray-500/20 text-gray-400">
+        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-gray-500/20 text-gray-400 dark:bg-surface-500/20 dark:text-surface-500">
           <ExclamationTriangleIcon className="h-3 w-3" />
           None
         </span>
@@ -108,31 +108,51 @@ function DataSourceIcons({ dataSources }: { dataSources: Employee['dataSources']
   return (
     <div className="flex items-center gap-1">
       <div
-        className={`p-1 rounded ${sources.hasHris ? 'text-blue-600' : 'text-gray-600'}`}
+        className={`p-1 rounded ${
+          sources.hasHris
+            ? 'text-blue-600 dark:text-blue-300'
+            : 'text-surface-600 dark:text-surface-300'
+        }`}
         title="HRIS"
       >
         <BuildingOffice2Icon className="h-4 w-4" />
       </div>
       <div
-        className={`p-1 rounded ${sources.hasBackgroundCheck ? 'text-green-600' : 'text-gray-600'}`}
+        className={`p-1 rounded ${
+          sources.hasBackgroundCheck
+            ? 'text-green-600 dark:text-green-300'
+            : 'text-surface-600 dark:text-surface-300'
+        }`}
         title="Background Check"
       >
         <ShieldCheckIcon className="h-4 w-4" />
       </div>
       <div
-        className={`p-1 rounded ${sources.hasTraining ? 'text-purple-600' : 'text-gray-600'}`}
+        className={`p-1 rounded ${
+          sources.hasTraining
+            ? 'text-purple-600 dark:text-purple-300'
+            : 'text-surface-600 dark:text-surface-300'
+        }`}
         title="Training"
       >
         <AcademicCapIcon className="h-4 w-4" />
       </div>
       <div
-        className={`p-1 rounded ${sources.hasAssets ? 'text-orange-600' : 'text-gray-600'}`}
+        className={`p-1 rounded ${
+          sources.hasAssets
+            ? 'text-orange-600 dark:text-orange-300'
+            : 'text-surface-600 dark:text-surface-300'
+        }`}
         title="Assets"
       >
         <ComputerDesktopIcon className="h-4 w-4" />
       </div>
       <div
-        className={`p-1 rounded ${sources.hasAccess ? 'text-cyan-600' : 'text-gray-600'}`}
+        className={`p-1 rounded ${
+          sources.hasAccess
+            ? 'text-cyan-600 dark:text-cyan-300'
+            : 'text-surface-600 dark:text-surface-300'
+        }`}
         title="Access"
       >
         <KeyIcon className="h-4 w-4" />
@@ -336,7 +356,7 @@ export default function Employees() {
         <div className="overflow-x-auto">
           <table className="w-full">
             <thead>
-              <tr className="border-b border-border bg-white/50">
+              <tr className="border-b border-border bg-white/50 dark:bg-surface-900/50">
                 <th className="text-left p-4 font-medium text-muted-foreground">Employee</th>
                 <th className="text-left p-4 font-medium text-muted-foreground">Department</th>
                 <th className="text-center p-4 font-medium text-muted-foreground">Score</th>
@@ -364,7 +384,10 @@ export default function Employees() {
                 </tr>
               ) : (
                 employees.map((employee) => (
-                  <tr key={employee.id} className="border-b border-border hover:bg-white/30">
+                  <tr
+                    key={employee.id}
+                    className="border-b border-border hover:bg-white/30 dark:bg-surface-900/30 dark:hover:bg-surface-800/30"
+                  >
                     <td className="p-4">
                       <div className="flex items-center gap-3">
                         <div className="h-10 w-10 rounded-full bg-surface-200 flex items-center justify-center">

--- a/frontend/src/pages/Evidence.tsx
+++ b/frontend/src/pages/Evidence.tsx
@@ -219,7 +219,7 @@ export default function Evidence() {
                 )}
               >
                 <div className="flex items-start gap-3">
-                  <div className="p-2 bg-white rounded-lg">
+                  <div className="p-2 bg-white rounded-lg dark:bg-surface-900">
                     <Icon className="w-6 h-6 text-surface-600" />
                   </div>
                   <div className="flex-1 min-w-0">
@@ -419,7 +419,7 @@ function UploadModal({
       <div className="fixed inset-0 bg-black/60" onClick={onClose} />
       {/* Modal content - positioned on top */}
       <div className="relative min-h-screen flex items-center justify-center p-4">
-        <div className="relative bg-white border border-surface-200 rounded-xl w-full max-w-lg p-6 shadow-2xl">
+        <div className="relative bg-white border border-surface-200 rounded-xl w-full max-w-lg p-6 shadow-2xl dark:bg-surface-900">
           <div className="flex items-center justify-between mb-6">
             <h2 className="text-lg font-semibold text-surface-900">Upload Evidence</h2>
             <button onClick={onClose} className="text-surface-600 hover:text-surface-900">

--- a/frontend/src/pages/EvidenceDetail.tsx
+++ b/frontend/src/pages/EvidenceDetail.tsx
@@ -227,7 +227,7 @@ export default function EvidenceDetail() {
         </Link>
         <div className="flex items-start justify-between">
           <div className="flex items-start gap-4">
-            <div className="p-3 bg-white rounded-lg">
+            <div className="p-3 bg-white rounded-lg dark:bg-surface-900">
               <Icon className="w-8 h-8 text-surface-600" />
             </div>
             <div>
@@ -326,7 +326,7 @@ export default function EvidenceDetail() {
                 {evidence?.controlLinks?.map((link: any) => (
                   <div
                     key={link.id}
-                    className="flex items-center gap-3 p-3 bg-white rounded-lg group"
+                    className="flex items-center gap-3 p-3 bg-white rounded-lg group dark:bg-surface-900"
                   >
                     <Link
                       to={`/controls/${link.control?.id}`}
@@ -378,7 +378,7 @@ export default function EvidenceDetail() {
                   </span>
                 </div>
                 {evidence.reviewNotes && (
-                  <div className="mt-3 p-3 bg-white rounded-lg">
+                  <div className="mt-3 p-3 bg-white rounded-lg dark:bg-surface-900">
                     <p className="text-sm text-surface-500 mb-1">Notes:</p>
                     <p className="text-sm text-surface-700">{evidence.reviewNotes}</p>
                   </div>
@@ -622,8 +622,11 @@ export default function EvidenceDetail() {
 
           {/* Keyboard hint */}
           <p className="absolute bottom-4 left-1/2 -translate-x-1/2 text-white/40 text-sm">
-            Press <kbd className="px-1.5 py-0.5 bg-white/10 rounded text-xs">ESC</kbd> or click
-            anywhere to close
+            Press{' '}
+            <kbd className="px-1.5 py-0.5 bg-white/10 rounded text-xs dark:bg-surface-900/10">
+              ESC
+            </kbd>{' '}
+            or click anywhere to close
           </p>
         </div>
       )}
@@ -744,7 +747,7 @@ function ExcelPreview({ evidenceId }: { evidenceId: string }) {
     <div className="overflow-hidden">
       {/* Sheet tabs */}
       {sheets.length > 1 && (
-        <div className="flex gap-1 p-2 bg-white border-b border-surface-200 overflow-x-auto">
+        <div className="flex gap-1 p-2 bg-white border-b border-surface-200 overflow-x-auto dark:bg-surface-900">
           {sheets.map((sheet, index) => (
             <button
               key={sheet.name}
@@ -767,7 +770,10 @@ function ExcelPreview({ evidenceId }: { evidenceId: string }) {
         <table className="w-full text-sm">
           <tbody>
             {currentSheet?.data.slice(0, 100).map((row, rowIndex) => (
-              <tr key={rowIndex} className={rowIndex === 0 ? 'bg-white font-semibold' : ''}>
+              <tr
+                key={rowIndex}
+                className={rowIndex === 0 ? 'bg-white font-semibold dark:bg-surface-900' : ''}
+              >
                 {row.map((cell, cellIndex) => (
                   <td
                     key={cellIndex}

--- a/frontend/src/pages/FrameworkDetail.tsx
+++ b/frontend/src/pages/FrameworkDetail.tsx
@@ -539,7 +539,7 @@ export default function FrameworkDetail() {
 
         <div className="space-y-4">
           {/* Instructions */}
-          <div className="p-4 bg-white/50 rounded-lg border border-surface-200">
+          <div className="p-4 bg-white/50 rounded-lg border border-surface-200 dark:bg-surface-900/50">
             <p className="text-sm text-surface-700 mb-2">
               Upload a CSV, Excel (.xlsx, .xls), or JSON file with the following columns:
             </p>
@@ -762,7 +762,9 @@ function RequirementRow({
       <div
         className={clsx(
           'flex items-center gap-3 p-4 transition-colors cursor-pointer',
-          isSelected ? 'bg-brand-500/20 border-l-2 border-brand-500' : 'hover:bg-white/50',
+          isSelected
+            ? 'bg-brand-500/20 border-l-2 border-brand-500'
+            : 'hover:bg-white/50 dark:bg-surface-900/50 dark:hover:bg-surface-800/50',
           directlyMatchesFilter && !isSelected && 'bg-surface-200/30'
         )}
         style={{ paddingLeft: `${level * 24 + 16}px` }}
@@ -1070,7 +1072,7 @@ function RequirementDetailPanel({
                   <SelectNative
                     value={selectedOwner}
                     onChange={(e) => setSelectedOwner(e.target.value)}
-                    className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-sm text-surface-900 focus:outline-none focus:border-brand-500"
+                    className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-sm text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
                   >
                     <option value="">Unassigned</option>
                     {users?.map((user: any) => (
@@ -1087,7 +1089,7 @@ function RequirementDetailPanel({
                   <SelectNative
                     value={priority}
                     onChange={(e) => setPriority(e.target.value)}
-                    className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-sm text-surface-900 focus:outline-none focus:border-brand-500"
+                    className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-sm text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
                   >
                     <option value="">Not Set</option>
                     <option value="high">High</option>
@@ -1103,7 +1105,7 @@ function RequirementDetailPanel({
                     type="date"
                     value={dueDate}
                     onChange={(e) => setDueDate(e.target.value)}
-                    className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-sm text-surface-900 focus:outline-none focus:border-brand-500"
+                    className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-sm text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
                   />
                 </div>
 
@@ -1115,14 +1117,14 @@ function RequirementDetailPanel({
                     onChange={(e) => setOwnerNotes(e.target.value)}
                     rows={3}
                     placeholder="Add notes about this requirement..."
-                    className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-sm text-surface-900 focus:outline-none focus:border-brand-500 resize-none"
+                    className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-sm text-surface-900 focus:outline-none focus:border-brand-500 resize-none dark:bg-surface-900"
                   />
                 </div>
               </div>
             ) : (
               <div className="space-y-2">
                 {/* Current Owner */}
-                <div className="flex items-center gap-2 p-2 bg-white/50 rounded-lg">
+                <div className="flex items-center gap-2 p-2 bg-white/50 rounded-lg dark:bg-surface-900/50">
                   <UserIcon className="w-4 h-4 text-surface-500" />
                   <span className="text-sm text-surface-700">
                     {currentOwner?.displayName || 'Unassigned'}
@@ -1131,7 +1133,7 @@ function RequirementDetailPanel({
 
                 {/* Priority */}
                 {currentPriority && (
-                  <div className="flex items-center gap-2 p-2 bg-white/50 rounded-lg">
+                  <div className="flex items-center gap-2 p-2 bg-white/50 rounded-lg dark:bg-surface-900/50">
                     <FlagIcon
                       className={clsx(
                         'w-4 h-4',
@@ -1150,7 +1152,7 @@ function RequirementDetailPanel({
 
                 {/* Due Date */}
                 {currentDueDate && (
-                  <div className="flex items-center gap-2 p-2 bg-white/50 rounded-lg">
+                  <div className="flex items-center gap-2 p-2 bg-white/50 rounded-lg dark:bg-surface-900/50">
                     <CalendarIcon className="w-4 h-4 text-surface-500" />
                     <span className="text-sm text-surface-700">
                       Due: {new Date(currentDueDate).toLocaleDateString()}
@@ -1160,7 +1162,7 @@ function RequirementDetailPanel({
 
                 {/* Notes */}
                 {currentNotes && (
-                  <div className="p-2 bg-white/50 rounded-lg">
+                  <div className="p-2 bg-white/50 rounded-lg dark:bg-surface-900/50">
                     <p className="text-xs text-surface-500 mb-1">Notes</p>
                     <p className="text-sm text-surface-700">{currentNotes}</p>
                   </div>
@@ -1207,7 +1209,7 @@ function RequirementDetailPanel({
                     <div
                       key={mapping.id}
                       role="listitem"
-                      className="group relative bg-white/50 rounded-lg hover:bg-white transition-colors"
+                      className="group relative bg-white/50 rounded-lg hover:bg-white transition-colors dark:bg-surface-900/50 dark:hover:bg-surface-800"
                     >
                       <div className="flex items-start gap-2 p-3">
                         <Link
@@ -1256,7 +1258,7 @@ function RequirementDetailPanel({
                             {isMenuOpen && (
                               <div
                                 role="menu"
-                                className="absolute right-0 top-7 z-10 min-w-[10rem] bg-white border border-surface-200 rounded-lg shadow-lg py-1"
+                                className="absolute right-0 top-7 z-10 min-w-[10rem] bg-white border border-surface-200 rounded-lg shadow-lg py-1 dark:bg-surface-900"
                               >
                                 {canEditMappings && (
                                   <button
@@ -1327,7 +1329,7 @@ function RequirementDetailPanel({
                           <div
                             role="alertdialog"
                             aria-label="Confirm mapping deletion"
-                            className="bg-white/60 border border-red-500/30 rounded-md p-2 text-xs text-surface-800"
+                            className="bg-white/60 border border-red-500/30 rounded-md p-2 text-xs text-surface-800 dark:bg-surface-900/60"
                           >
                             <p className="mb-2">Remove this mapping?</p>
                             <div className="flex justify-end gap-2">

--- a/frontend/src/pages/FrameworkLibrary.tsx
+++ b/frontend/src/pages/FrameworkLibrary.tsx
@@ -99,7 +99,9 @@ function RequirementTree({
             <div
               className={clsx(
                 'flex items-start gap-2 py-2 px-3 rounded-lg transition-colors',
-                req.isCategory ? 'bg-white/50 hover:bg-white' : 'hover:bg-white/30'
+                req.isCategory
+                  ? 'bg-white/50 dark:bg-surface-900/50 hover:bg-white dark:hover:bg-surface-800'
+                  : 'hover:bg-white/30 dark:hover:bg-surface-800/30'
               )}
             >
               {hasChildren ? (
@@ -183,7 +185,7 @@ function FrameworkPreviewModal({
         </div>
         <button
           onClick={onClose}
-          className="p-2 text-surface-600 hover:text-surface-800 hover:bg-white rounded-lg transition-colors"
+          className="p-2 text-surface-600 hover:text-surface-800 hover:bg-white rounded-lg transition-colors dark:bg-surface-900 dark:hover:bg-surface-800"
         >
           <XCircleIcon className="w-6 h-6" />
         </button>
@@ -194,13 +196,13 @@ function FrameworkPreviewModal({
         <div className="mb-6">
           <p className="text-surface-700">{framework.description}</p>
           <div className="flex items-center gap-4 mt-4">
-            <div className="px-3 py-1.5 bg-white rounded-lg">
+            <div className="px-3 py-1.5 bg-white rounded-lg dark:bg-surface-900">
               <span className="text-sm text-surface-600">Requirements:</span>
               <span className="ml-2 font-semibold text-surface-900">
                 {framework.requirementCount}
               </span>
             </div>
-            <div className="px-3 py-1.5 bg-white rounded-lg">
+            <div className="px-3 py-1.5 bg-white rounded-lg dark:bg-surface-900">
               <span className="text-sm text-surface-600">Categories:</span>
               <span className="ml-2 font-semibold text-surface-900">{framework.categoryCount}</span>
             </div>
@@ -209,7 +211,7 @@ function FrameworkPreviewModal({
 
         <div>
           <h3 className="text-lg font-medium text-surface-900 mb-4">Requirements Structure</h3>
-          <div className="bg-white/30 rounded-lg p-4 max-h-[400px] overflow-y-auto">
+          <div className="bg-white/30 rounded-lg p-4 max-h-[400px] overflow-y-auto dark:bg-surface-900/30">
             <RequirementTree requirements={framework.requirements} />
           </div>
         </div>
@@ -248,10 +250,10 @@ function FrameworkCard({
   return (
     <div
       className={clsx(
-        'group bg-white/50 border rounded-xl p-5 transition-all duration-200',
+        'group bg-white/50 border rounded-xl p-5 transition-all duration-200 dark:bg-surface-900/50',
         framework.isActivated
           ? 'border-green-500/30 bg-green-500/5'
-          : 'border-surface-200 hover:border-surface-300 hover:bg-white/70'
+          : 'border-surface-200 hover:border-surface-300 hover:bg-white/70 dark:bg-surface-900/70 dark:hover:bg-surface-800/70'
       )}
     >
       <div className="flex items-start justify-between mb-4">
@@ -468,7 +470,7 @@ export default function FrameworkLibrary() {
             placeholder="Search frameworks..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full pl-10 pr-4 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 placeholder-surface-500 focus:outline-none focus:ring-2 focus:ring-brand-500/50 focus:border-brand-500"
+            className="w-full pl-10 pr-4 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 placeholder-surface-500 focus:outline-none focus:ring-2 focus:ring-brand-500/50 focus:border-brand-500 dark:bg-surface-900"
           />
         </div>
 
@@ -477,7 +479,7 @@ export default function FrameworkLibrary() {
           <SelectNative
             value={categoryFilter}
             onChange={(e) => setCategoryFilter(e.target.value)}
-            className="px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:ring-2 focus:ring-brand-500/50"
+            className="px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:ring-2 focus:ring-brand-500/50 dark:bg-surface-900"
           >
             <option value="all">All Categories</option>
             {categories.map((cat) => (
@@ -493,7 +495,7 @@ export default function FrameworkLibrary() {
             type="checkbox"
             checked={showActivatedOnly}
             onChange={(e) => setShowActivatedOnly(e.target.checked)}
-            className="w-4 h-4 rounded border-surface-300 bg-white text-brand-500 focus:ring-brand-500/50"
+            className="w-4 h-4 rounded border-surface-300 bg-white text-brand-500 focus:ring-brand-500/50 dark:bg-surface-900"
           />
           <span className="text-sm text-surface-700">Show activated only</span>
         </label>
@@ -515,7 +517,7 @@ export default function FrameworkLibrary() {
           ))}
         </div>
       ) : (
-        <div className="text-center py-16 bg-white/30 rounded-xl border border-surface-200">
+        <div className="text-center py-16 bg-white/30 rounded-xl border border-surface-200 dark:bg-surface-900/30">
           <BookOpenIcon className="w-12 h-12 text-surface-500 mx-auto mb-4" />
           <h3 className="text-lg font-medium text-surface-800 mb-2">No frameworks found</h3>
           <p className="text-surface-600">

--- a/frontend/src/pages/HelpArticle.tsx
+++ b/frontend/src/pages/HelpArticle.tsx
@@ -45,14 +45,14 @@ function TrustCenterCustomDomainArticle() {
         <h2 className="text-2xl font-bold text-surface-900 mb-4">Summary</h2>
         <p className="text-surface-700">
           Custom domain URLs allow you to use your own branded domain (like{' '}
-          <code className="bg-white px-1.5 py-0.5 rounded text-brand-400">
+          <code className="bg-white px-1.5 py-0.5 rounded text-brand-400 dark:bg-surface-900">
             trust.yourcompany.com
           </code>
           ) instead of the default GigaChad GRC URL when sharing your Trust Center with prospects,
           customers, and partners.
         </p>
 
-        <div className="bg-white/50 border border-surface-200 rounded-lg p-4 mt-4">
+        <div className="bg-white/50 border border-surface-200 rounded-lg p-4 mt-4 dark:bg-surface-900/50">
           <h4 className="font-semibold text-surface-800 mb-2">
             Benefits of using a custom domain:
           </h4>
@@ -90,7 +90,10 @@ function TrustCenterCustomDomainArticle() {
             { text: 'Trust Center content - Your Trust Center has been configured', done: false },
           ].map((item, i) => (
             <li key={i} className="flex items-start gap-3 text-surface-700">
-              <input type="checkbox" className="mt-1 w-4 h-4 bg-white border-surface-300 rounded" />
+              <input
+                type="checkbox"
+                className="mt-1 w-4 h-4 bg-white border-surface-300 rounded dark:bg-surface-900"
+              />
               <span>{item.text}</span>
             </li>
           ))}
@@ -138,7 +141,7 @@ function TrustCenterCustomDomainArticle() {
             </span>
             <span>
               Enter your desired custom domain (e.g.,{' '}
-              <code className="bg-white px-1.5 py-0.5 rounded text-brand-400">
+              <code className="bg-white px-1.5 py-0.5 rounded text-brand-400 dark:bg-surface-900">
                 trust.yourcompany.com
               </code>
               )
@@ -156,8 +159,9 @@ function TrustCenterCustomDomainArticle() {
         <div className="bg-blue-500/10 border border-blue-500/30 rounded-lg p-4 mt-4">
           <p className="text-blue-600 text-sm">
             <strong>Tip:</strong> We recommend using a subdomain like{' '}
-            <code className="bg-white px-1 rounded">trust</code> or{' '}
-            <code className="bg-white px-1 rounded">security</code> rather than your root domain.
+            <code className="bg-white px-1 rounded dark:bg-surface-900">trust</code> or{' '}
+            <code className="bg-white px-1 rounded dark:bg-surface-900">security</code> rather than
+            your root domain.
           </p>
         </div>
       </section>
@@ -172,7 +176,7 @@ function TrustCenterCustomDomainArticle() {
         </p>
 
         {/* DNS Record Table */}
-        <div className="bg-white rounded-lg overflow-hidden mb-6">
+        <div className="bg-white rounded-lg overflow-hidden mb-6 dark:bg-surface-900">
           <table className="w-full text-sm">
             <thead className="bg-surface-200">
               <tr>
@@ -217,8 +221,8 @@ function TrustCenterCustomDomainArticle() {
           <h3 className="text-lg font-semibold text-surface-800">Provider-Specific Instructions</h3>
 
           {/* Cloudflare */}
-          <details className="bg-white/50 border border-surface-200 rounded-lg">
-            <summary className="px-4 py-3 cursor-pointer text-surface-800 font-medium hover:bg-white rounded-lg">
+          <details className="bg-white/50 border border-surface-200 rounded-lg dark:bg-surface-900/50">
+            <summary className="px-4 py-3 cursor-pointer text-surface-800 font-medium hover:bg-white rounded-lg dark:bg-surface-900 dark:hover:bg-surface-800">
               Cloudflare
             </summary>
             <div className="px-4 pb-4 text-sm text-surface-600 space-y-2">
@@ -233,7 +237,7 @@ function TrustCenterCustomDomainArticle() {
                 </li>
                 <li>
                   Set Type to CNAME, Name to your subdomain, Target to{' '}
-                  <code className="bg-white px-1 rounded text-brand-400">
+                  <code className="bg-white px-1 rounded text-brand-400 dark:bg-surface-900">
                     trust.gigachad-grc.com
                   </code>
                 </li>
@@ -254,8 +258,8 @@ function TrustCenterCustomDomainArticle() {
           </details>
 
           {/* GoDaddy */}
-          <details className="bg-white/50 border border-surface-200 rounded-lg">
-            <summary className="px-4 py-3 cursor-pointer text-surface-800 font-medium hover:bg-white rounded-lg">
+          <details className="bg-white/50 border border-surface-200 rounded-lg dark:bg-surface-900/50">
+            <summary className="px-4 py-3 cursor-pointer text-surface-800 font-medium hover:bg-white rounded-lg dark:bg-surface-900 dark:hover:bg-surface-800">
               GoDaddy
             </summary>
             <div className="px-4 pb-4 text-sm text-surface-600 space-y-2">
@@ -272,7 +276,7 @@ function TrustCenterCustomDomainArticle() {
                 </li>
                 <li>
                   Set Type to CNAME, Name to your subdomain, Value to{' '}
-                  <code className="bg-white px-1 rounded text-brand-400">
+                  <code className="bg-white px-1 rounded text-brand-400 dark:bg-surface-900">
                     trust.gigachad-grc.com
                   </code>
                 </li>
@@ -285,8 +289,8 @@ function TrustCenterCustomDomainArticle() {
           </details>
 
           {/* Route 53 */}
-          <details className="bg-white/50 border border-surface-200 rounded-lg">
-            <summary className="px-4 py-3 cursor-pointer text-surface-800 font-medium hover:bg-white rounded-lg">
+          <details className="bg-white/50 border border-surface-200 rounded-lg dark:bg-surface-900/50">
+            <summary className="px-4 py-3 cursor-pointer text-surface-800 font-medium hover:bg-white rounded-lg dark:bg-surface-900 dark:hover:bg-surface-800">
               Amazon Route 53
             </summary>
             <div className="px-4 pb-4 text-sm text-surface-600 space-y-2">
@@ -301,7 +305,7 @@ function TrustCenterCustomDomainArticle() {
                 </li>
                 <li>
                   Enter your subdomain, select CNAME, enter{' '}
-                  <code className="bg-white px-1 rounded text-brand-400">
+                  <code className="bg-white px-1 rounded text-brand-400 dark:bg-surface-900">
                     trust.gigachad-grc.com
                   </code>
                 </li>
@@ -314,8 +318,8 @@ function TrustCenterCustomDomainArticle() {
           </details>
 
           {/* Namecheap */}
-          <details className="bg-white/50 border border-surface-200 rounded-lg">
-            <summary className="px-4 py-3 cursor-pointer text-surface-800 font-medium hover:bg-white rounded-lg">
+          <details className="bg-white/50 border border-surface-200 rounded-lg dark:bg-surface-900/50">
+            <summary className="px-4 py-3 cursor-pointer text-surface-800 font-medium hover:bg-white rounded-lg dark:bg-surface-900 dark:hover:bg-surface-800">
               Namecheap
             </summary>
             <div className="px-4 pb-4 text-sm text-surface-600 space-y-2">
@@ -332,7 +336,7 @@ function TrustCenterCustomDomainArticle() {
                 </li>
                 <li>
                   Select CNAME, enter your subdomain, value{' '}
-                  <code className="bg-white px-1 rounded text-brand-400">
+                  <code className="bg-white px-1 rounded text-brand-400 dark:bg-surface-900">
                     trust.gigachad-grc.com
                   </code>
                 </li>
@@ -342,8 +346,8 @@ function TrustCenterCustomDomainArticle() {
           </details>
 
           {/* Google Domains */}
-          <details className="bg-white/50 border border-surface-200 rounded-lg">
-            <summary className="px-4 py-3 cursor-pointer text-surface-800 font-medium hover:bg-white rounded-lg">
+          <details className="bg-white/50 border border-surface-200 rounded-lg dark:bg-surface-900/50">
+            <summary className="px-4 py-3 cursor-pointer text-surface-800 font-medium hover:bg-white rounded-lg dark:bg-surface-900 dark:hover:bg-surface-800">
               Google Domains / Squarespace
             </summary>
             <div className="px-4 pb-4 text-sm text-surface-600 space-y-2">
@@ -358,7 +362,7 @@ function TrustCenterCustomDomainArticle() {
                 </li>
                 <li>
                   Add CNAME record with your subdomain pointing to{' '}
-                  <code className="bg-white px-1 rounded text-brand-400">
+                  <code className="bg-white px-1 rounded text-brand-400 dark:bg-surface-900">
                     trust.gigachad-grc.com
                   </code>
                 </li>
@@ -404,7 +408,7 @@ function TrustCenterCustomDomainArticle() {
             <span className="text-brand-400">•</span>
             <span>
               Or run from terminal:{' '}
-              <code className="bg-white px-2 py-0.5 rounded text-brand-400">
+              <code className="bg-white px-2 py-0.5 rounded text-brand-400 dark:bg-surface-900">
                 dig trust.yourcompany.com CNAME
               </code>
             </span>
@@ -457,8 +461,11 @@ function TrustCenterCustomDomainArticle() {
               a: 'Contact your IT administrator with the CNAME record details: Type=CNAME, Host=trust, Value=trust.gigachad-grc.com',
             },
           ].map((faq, i) => (
-            <details key={i} className="bg-white/50 border border-surface-200 rounded-lg">
-              <summary className="px-4 py-3 cursor-pointer text-surface-800 font-medium hover:bg-white rounded-lg">
+            <details
+              key={i}
+              className="bg-white/50 border border-surface-200 rounded-lg dark:bg-surface-900/50"
+            >
+              <summary className="px-4 py-3 cursor-pointer text-surface-800 font-medium hover:bg-white rounded-lg dark:bg-surface-900 dark:hover:bg-surface-800">
                 {faq.q}
               </summary>
               <div className="px-4 pb-4 text-sm text-surface-600">{faq.a}</div>
@@ -473,7 +480,7 @@ function TrustCenterCustomDomainArticle() {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <Link
             to="/trust-center/settings"
-            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors dark:bg-surface-900/50 dark:hover:bg-surface-800"
           >
             <GlobeAltIcon className="w-5 h-5 text-surface-600" />
             <span className="text-surface-800">Trust Center Settings</span>
@@ -481,7 +488,7 @@ function TrustCenterCustomDomainArticle() {
           </Link>
           <Link
             to="/trust-center"
-            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors dark:bg-surface-900/50 dark:hover:bg-surface-800"
           >
             <GlobeAltIcon className="w-5 h-5 text-surface-600" />
             <span className="text-surface-800">Manage Trust Center Content</span>
@@ -506,7 +513,7 @@ function TrustCenterGettingStartedArticle() {
           need for repetitive security questionnaires.
         </p>
 
-        <div className="bg-white/50 border border-surface-200 rounded-lg p-4 mt-4">
+        <div className="bg-white/50 border border-surface-200 rounded-lg p-4 mt-4 dark:bg-surface-900/50">
           <h4 className="font-semibold text-surface-800 mb-2">What you can showcase:</h4>
           <ul className="text-surface-600 space-y-1 text-sm list-disc list-inside">
             <li>
@@ -623,7 +630,7 @@ function TrustCenterGettingStartedArticle() {
         <p className="text-surface-700 mb-4">
           Select which sections to display on your Trust Center:
         </p>
-        <div className="bg-white rounded-lg overflow-hidden mb-4">
+        <div className="bg-white rounded-lg overflow-hidden mb-4 dark:bg-surface-900">
           <table className="w-full text-sm">
             <thead className="bg-surface-200">
               <tr>
@@ -749,7 +756,7 @@ function TrustCenterGettingStartedArticle() {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <Link
             to="/help/trust-center/custom-domain"
-            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors dark:bg-surface-900/50 dark:hover:bg-surface-800"
           >
             <GlobeAltIcon className="w-5 h-5 text-surface-600" />
             <span className="text-surface-800">Set Up a Custom URL</span>
@@ -757,7 +764,7 @@ function TrustCenterGettingStartedArticle() {
           </Link>
           <Link
             to="/trust-center/settings"
-            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors dark:bg-surface-900/50 dark:hover:bg-surface-800"
           >
             <GlobeAltIcon className="w-5 h-5 text-surface-600" />
             <span className="text-surface-800">Trust Center Settings</span>
@@ -782,7 +789,7 @@ function IntegrationsOverviewArticle() {
           systems.
         </p>
 
-        <div className="bg-white/50 border border-surface-200 rounded-lg p-4 mt-4">
+        <div className="bg-white/50 border border-surface-200 rounded-lg p-4 mt-4 dark:bg-surface-900/50">
           <h4 className="font-semibold text-surface-800 mb-2">Integration categories:</h4>
           <ul className="text-surface-600 space-y-1 text-sm list-disc list-inside">
             <li>
@@ -844,7 +851,7 @@ function IntegrationsOverviewArticle() {
         </p>
 
         <div className="space-y-4">
-          <div className="bg-white/50 border border-surface-200 rounded-lg p-4">
+          <div className="bg-white/50 border border-surface-200 rounded-lg p-4 dark:bg-surface-900/50">
             <h4 className="font-semibold text-surface-800 mb-2">Quick Setup (No-Code)</h4>
             <p className="text-surface-600 text-sm mb-2">
               Best for standard integrations. Enter your credentials and select what data to
@@ -858,7 +865,7 @@ function IntegrationsOverviewArticle() {
             </ul>
           </div>
 
-          <div className="bg-white/50 border border-surface-200 rounded-lg p-4">
+          <div className="bg-white/50 border border-surface-200 rounded-lg p-4 dark:bg-surface-900/50">
             <h4 className="font-semibold text-surface-800 mb-2">Advanced Builder (Low-Code)</h4>
             <p className="text-surface-600 text-sm mb-2">
               For custom configurations. Build API calls visually with response mapping.
@@ -871,7 +878,7 @@ function IntegrationsOverviewArticle() {
             </ul>
           </div>
 
-          <div className="bg-white/50 border border-surface-200 rounded-lg p-4">
+          <div className="bg-white/50 border border-surface-200 rounded-lg p-4 dark:bg-surface-900/50">
             <h4 className="font-semibold text-surface-800 mb-2">Raw API (Code)</h4>
             <p className="text-surface-600 text-sm mb-2">
               For engineers. Write custom API calls or JavaScript code directly.
@@ -892,7 +899,7 @@ function IntegrationsOverviewArticle() {
         <p className="text-surface-700 mb-4">
           Each integration can collect different types of evidence. Common evidence types include:
         </p>
-        <div className="bg-white rounded-lg overflow-hidden mb-4">
+        <div className="bg-white rounded-lg overflow-hidden mb-4 dark:bg-surface-900">
           <table className="w-full text-sm">
             <thead className="bg-surface-200">
               <tr>
@@ -1002,7 +1009,7 @@ function IntegrationsOverviewArticle() {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <Link
             to="/integrations"
-            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors dark:bg-surface-900/50 dark:hover:bg-surface-800"
           >
             <LinkIcon className="w-5 h-5 text-surface-600" />
             <span className="text-surface-800">Browse Integrations</span>
@@ -1010,7 +1017,7 @@ function IntegrationsOverviewArticle() {
           </Link>
           <Link
             to="/evidence"
-            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors dark:bg-surface-900/50 dark:hover:bg-surface-800"
           >
             <ClipboardDocumentIcon className="w-5 h-5 text-surface-600" />
             <span className="text-surface-800">View Evidence</span>
@@ -1035,7 +1042,7 @@ function ComplianceFrameworksArticle() {
           requirements.
         </p>
 
-        <div className="bg-white/50 border border-surface-200 rounded-lg p-4 mt-4">
+        <div className="bg-white/50 border border-surface-200 rounded-lg p-4 mt-4 dark:bg-surface-900/50">
           <h4 className="font-semibold text-surface-800 mb-2">Supported frameworks include:</h4>
           <div className="grid grid-cols-2 md:grid-cols-3 gap-2 text-surface-600 text-sm">
             <span>• SOC 2 Type I & II</span>
@@ -1126,7 +1133,7 @@ function ComplianceFrameworksArticle() {
           </li>
         </ol>
 
-        <div className="bg-white/50 border border-surface-200 rounded-lg p-4 mt-4">
+        <div className="bg-white/50 border border-surface-200 rounded-lg p-4 mt-4 dark:bg-surface-900/50">
           <h4 className="font-semibold text-surface-800 mb-2">Control mapping example:</h4>
           <p className="text-surface-600 text-sm">
             A "Multi-Factor Authentication" control might satisfy:
@@ -1146,7 +1153,7 @@ function ComplianceFrameworksArticle() {
         <p className="text-surface-700 mb-4">
           Monitor your compliance posture with real-time dashboards:
         </p>
-        <div className="bg-white rounded-lg overflow-hidden mb-4">
+        <div className="bg-white rounded-lg overflow-hidden mb-4 dark:bg-surface-900">
           <table className="w-full text-sm">
             <thead className="bg-surface-200">
               <tr>
@@ -1236,7 +1243,7 @@ function ComplianceFrameworksArticle() {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <Link
             to="/frameworks"
-            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors dark:bg-surface-900/50 dark:hover:bg-surface-800"
           >
             <ShieldCheckIcon className="w-5 h-5 text-surface-600" />
             <span className="text-surface-800">View Frameworks</span>
@@ -1244,7 +1251,7 @@ function ComplianceFrameworksArticle() {
           </Link>
           <Link
             to="/controls"
-            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors dark:bg-surface-900/50 dark:hover:bg-surface-800"
           >
             <ShieldCheckIcon className="w-5 h-5 text-surface-600" />
             <span className="text-surface-800">Manage Controls</span>
@@ -1269,7 +1276,7 @@ function VendorManagementArticle() {
           security program.
         </p>
 
-        <div className="bg-white/50 border border-surface-200 rounded-lg p-4 mt-4">
+        <div className="bg-white/50 border border-surface-200 rounded-lg p-4 mt-4 dark:bg-surface-900/50">
           <h4 className="font-semibold text-surface-800 mb-2">Key TPRM capabilities:</h4>
           <ul className="text-surface-600 space-y-1 text-sm list-disc list-inside">
             <li>
@@ -1338,7 +1345,7 @@ function VendorManagementArticle() {
         <p className="text-surface-700 mb-4">
           Determine the appropriate level of due diligence based on data access and business impact:
         </p>
-        <div className="bg-white rounded-lg overflow-hidden mb-4">
+        <div className="bg-white rounded-lg overflow-hidden mb-4 dark:bg-surface-900">
           <table className="w-full text-sm">
             <thead className="bg-surface-200">
               <tr>
@@ -1496,7 +1503,7 @@ function VendorManagementArticle() {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <Link
             to="/vendors"
-            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors dark:bg-surface-900/50 dark:hover:bg-surface-800"
           >
             <BuildingOfficeIcon className="w-5 h-5 text-surface-600" />
             <span className="text-surface-800">Manage Vendors</span>
@@ -1504,7 +1511,7 @@ function VendorManagementArticle() {
           </Link>
           <Link
             to="/contracts"
-            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors dark:bg-surface-900/50 dark:hover:bg-surface-800"
           >
             <ClipboardDocumentIcon className="w-5 h-5 text-surface-600" />
             <span className="text-surface-800">View Contracts</span>
@@ -1528,7 +1535,7 @@ function AuditManagementArticle() {
           ensure timely remediation of identified issues.
         </p>
 
-        <div className="bg-white/50 border border-surface-200 rounded-lg p-4 mt-4">
+        <div className="bg-white/50 border border-surface-200 rounded-lg p-4 mt-4 dark:bg-surface-900/50">
           <h4 className="font-semibold text-surface-800 mb-2">Audit management features:</h4>
           <ul className="text-surface-600 space-y-1 text-sm list-disc list-inside">
             <li>
@@ -1643,7 +1650,7 @@ function AuditManagementArticle() {
       <section className="mb-8">
         <h2 className="text-2xl font-bold text-surface-900 mb-4">Step 3: Track Audit Progress</h2>
         <p className="text-surface-700 mb-4">Monitor your audit status with the dashboard:</p>
-        <div className="bg-white rounded-lg overflow-hidden mb-4">
+        <div className="bg-white rounded-lg overflow-hidden mb-4 dark:bg-surface-900">
           <table className="w-full text-sm">
             <thead className="bg-surface-200">
               <tr>
@@ -1776,7 +1783,7 @@ function AuditManagementArticle() {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <Link
             to="/audits"
-            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors dark:bg-surface-900/50 dark:hover:bg-surface-800"
           >
             <ClipboardDocumentListIcon className="w-5 h-5 text-surface-600" />
             <span className="text-surface-800">View Audits</span>
@@ -1784,7 +1791,7 @@ function AuditManagementArticle() {
           </Link>
           <Link
             to="/audit"
-            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors dark:bg-surface-900/50 dark:hover:bg-surface-800"
           >
             <ClipboardDocumentListIcon className="w-5 h-5 text-surface-600" />
             <span className="text-surface-800">Audit Log</span>
@@ -1912,7 +1919,7 @@ function CloudDeploymentArticle() {
             </span>
             <div>
               <span>Configure redirect URIs:</span>
-              <div className="bg-white rounded p-3 mt-2 text-sm font-mono text-surface-700">
+              <div className="bg-white rounded p-3 mt-2 text-sm font-mono text-surface-700 dark:bg-surface-900">
                 https://your-app.vercel.app/login/callback
               </div>
             </div>
@@ -2005,7 +2012,7 @@ function CloudDeploymentArticle() {
           Step 4: Run Database Migrations
         </h2>
         <p className="text-surface-700 mb-4">After first deployment, run:</p>
-        <div className="bg-white rounded p-4 font-mono text-sm text-surface-700">
+        <div className="bg-white rounded p-4 font-mono text-sm text-surface-700 dark:bg-surface-900">
           npx prisma migrate deploy
         </div>
       </section>
@@ -2015,7 +2022,7 @@ function CloudDeploymentArticle() {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <Link
             to="/help/deployment/supabase-vercel-migration"
-            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors dark:bg-surface-900/50 dark:hover:bg-surface-800"
           >
             <BookOpenIcon className="w-5 h-5 text-surface-600" />
             <span className="text-surface-800">Full Migration Guide</span>
@@ -2023,7 +2030,7 @@ function CloudDeploymentArticle() {
           </Link>
           <Link
             to="/settings"
-            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors dark:bg-surface-900/50 dark:hover:bg-surface-800"
           >
             <Cog6ToothIcon className="w-5 h-5 text-surface-600" />
             <span className="text-surface-800">Settings</span>
@@ -2048,7 +2055,7 @@ function SupabaseVercelMigrationArticle() {
         </p>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-6">
-          <div className="bg-white/50 border border-surface-200 rounded-lg p-4">
+          <div className="bg-white/50 border border-surface-200 rounded-lg p-4 dark:bg-surface-900/50">
             <h4 className="font-semibold text-surface-800 mb-2">Previous Architecture</h4>
             <ul className="text-surface-600 text-sm space-y-1">
               <li>• 6 NestJS microservices</li>
@@ -2101,7 +2108,7 @@ function SupabaseVercelMigrationArticle() {
           ].map((item) => (
             <div
               key={item.phase}
-              className="flex items-start gap-4 p-4 bg-white/50 border border-surface-200 rounded-lg"
+              className="flex items-start gap-4 p-4 bg-white/50 border border-surface-200 rounded-lg dark:bg-surface-900/50"
             >
               <span className="bg-brand-600 text-white w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold flex-shrink-0">
                 {item.phase}
@@ -2125,7 +2132,7 @@ function SupabaseVercelMigrationArticle() {
           Supabase uses two connection strings - pooled for queries and direct for migrations:
         </p>
         <div className="space-y-4">
-          <div className="bg-white rounded-lg p-4">
+          <div className="bg-white rounded-lg p-4 dark:bg-surface-900">
             <h4 className="font-mono text-brand-400 text-sm mb-2">
               DATABASE_URL (Pooled - Port 6543)
             </h4>
@@ -2136,7 +2143,7 @@ function SupabaseVercelMigrationArticle() {
               postgres://postgres.[ref]:[password]@aws-0-region.pooler.supabase.com:6543/postgres
             </code>
           </div>
-          <div className="bg-white rounded-lg p-4">
+          <div className="bg-white rounded-lg p-4 dark:bg-surface-900">
             <h4 className="font-mono text-brand-400 text-sm mb-2">
               DIRECT_URL (Direct - Port 5432)
             </h4>
@@ -2196,7 +2203,7 @@ function SupabaseVercelMigrationArticle() {
       <section className="mb-8">
         <h2 className="text-2xl font-bold text-surface-900 mb-4">Okta Configuration</h2>
         <div className="space-y-4">
-          <div className="bg-white rounded-lg p-4">
+          <div className="bg-white rounded-lg p-4 dark:bg-surface-900">
             <h4 className="font-semibold text-surface-800 mb-2">Application Settings</h4>
             <ul className="text-surface-600 text-sm space-y-1">
               <li>
@@ -2213,7 +2220,7 @@ function SupabaseVercelMigrationArticle() {
               </li>
             </ul>
           </div>
-          <div className="bg-white rounded-lg p-4">
+          <div className="bg-white rounded-lg p-4 dark:bg-surface-900">
             <h4 className="font-semibold text-surface-800 mb-2">Groups Claim (for roles)</h4>
             <p className="text-surface-600 text-sm mb-2">
               Add a groups claim to include user roles in tokens:
@@ -2258,7 +2265,7 @@ function SupabaseVercelMigrationArticle() {
             </span>
             <span>
               Start Docker services:{' '}
-              <code className="bg-white px-1.5 py-0.5 rounded text-brand-400">
+              <code className="bg-white px-1.5 py-0.5 rounded text-brand-400 dark:bg-surface-900">
                 docker-compose up -d
               </code>
             </span>
@@ -2277,7 +2284,7 @@ function SupabaseVercelMigrationArticle() {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <Link
             to="/help/deployment/cloud-deployment"
-            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors dark:bg-surface-900/50 dark:hover:bg-surface-800"
           >
             <BookOpenIcon className="w-5 h-5 text-surface-600" />
             <span className="text-surface-800">Cloud Deployment Guide</span>
@@ -2285,7 +2292,7 @@ function SupabaseVercelMigrationArticle() {
           </Link>
           <Link
             to="/integrations"
-            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors dark:bg-surface-900/50 dark:hover:bg-surface-800"
           >
             <LinkIcon className="w-5 h-5 text-surface-600" />
             <span className="text-surface-800">Integrations</span>
@@ -2309,7 +2316,7 @@ function MCPQuickStartArticle() {
           AI-powered analysis. This guide walks you through setting up your first MCP server.
         </p>
 
-        <div className="bg-white/50 border border-surface-200 rounded-lg p-4 mt-4">
+        <div className="bg-white/50 border border-surface-200 rounded-lg p-4 mt-4 dark:bg-surface-900/50">
           <h4 className="font-semibold text-surface-800 mb-2">Available MCP Server Types:</h4>
           <ul className="text-surface-600 space-y-1 text-sm list-disc list-inside">
             <li>
@@ -2357,7 +2364,7 @@ function MCPQuickStartArticle() {
         <h2 className="text-2xl font-bold text-surface-900 mb-4">Step 2: Select a Template</h2>
         <p className="text-surface-700 mb-4">Choose the server type that matches your needs:</p>
         <div className="space-y-4">
-          <div className="bg-white/50 border border-surface-200 rounded-lg p-4">
+          <div className="bg-white/50 border border-surface-200 rounded-lg p-4 dark:bg-surface-900/50">
             <h4 className="font-semibold text-surface-800 mb-2">GRC Evidence Collection Server</h4>
             <p className="text-surface-600 text-sm mb-2">
               Best for automated evidence gathering from cloud providers and identity systems.
@@ -2366,7 +2373,7 @@ function MCPQuickStartArticle() {
               Integrations: AWS, Azure, GitHub, Okta, Google Workspace, Jamf
             </p>
           </div>
-          <div className="bg-white/50 border border-surface-200 rounded-lg p-4">
+          <div className="bg-white/50 border border-surface-200 rounded-lg p-4 dark:bg-surface-900/50">
             <h4 className="font-semibold text-surface-800 mb-2">
               GRC Compliance Automation Server
             </h4>
@@ -2377,7 +2384,7 @@ function MCPQuickStartArticle() {
               Capabilities: Control testing, gap analysis, policy validation
             </p>
           </div>
-          <div className="bg-white/50 border border-surface-200 rounded-lg p-4">
+          <div className="bg-white/50 border border-surface-200 rounded-lg p-4 dark:bg-surface-900/50">
             <h4 className="font-semibold text-surface-800 mb-2">GRC AI Assistant Server</h4>
             <p className="text-surface-600 text-sm mb-2">
               Best for AI-powered analysis and recommendations.
@@ -2393,7 +2400,7 @@ function MCPQuickStartArticle() {
           After selecting a template, configure the integrations you want to use. Expand each
           section and enter your API credentials:
         </p>
-        <div className="bg-white rounded-lg overflow-hidden mb-4">
+        <div className="bg-white rounded-lg overflow-hidden mb-4 dark:bg-surface-900">
           <table className="w-full text-sm">
             <thead className="bg-surface-200">
               <tr>
@@ -2537,7 +2544,7 @@ function MCPQuickStartArticle() {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <Link
             to="/help/mcp/credential-security"
-            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors dark:bg-surface-900/50 dark:hover:bg-surface-800"
           >
             <ShieldCheckIcon className="w-5 h-5 text-surface-600" />
             <span className="text-surface-800">MCP Credential Security</span>
@@ -2545,7 +2552,7 @@ function MCPQuickStartArticle() {
           </Link>
           <Link
             to="/settings/mcp"
-            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors dark:bg-surface-900/50 dark:hover:bg-surface-800"
           >
             <Cog6ToothIcon className="w-5 h-5 text-surface-600" />
             <span className="text-surface-800">MCP Settings</span>
@@ -2582,7 +2589,7 @@ function MCPCredentialSecurityArticle() {
 
       <section className="mb-8">
         <h2 className="text-2xl font-bold text-surface-900 mb-4">Encryption Details</h2>
-        <div className="bg-white rounded-lg overflow-hidden mb-4">
+        <div className="bg-white rounded-lg overflow-hidden mb-4 dark:bg-surface-900">
           <table className="w-full text-sm">
             <thead className="bg-surface-200">
               <tr>
@@ -2621,12 +2628,12 @@ function MCPCredentialSecurityArticle() {
       <section className="mb-8">
         <h2 className="text-2xl font-bold text-surface-900 mb-4">Configuration</h2>
         <p className="text-surface-700 mb-4">Set the encryption key via environment variable:</p>
-        <div className="bg-white rounded-lg p-4 font-mono text-sm text-green-600 mb-4">
+        <div className="bg-white rounded-lg p-4 font-mono text-sm text-green-600 mb-4 dark:bg-surface-900">
           MCP_ENCRYPTION_KEY=your-64-character-random-string
         </div>
-        <div className="bg-white/50 border border-surface-200 rounded-lg p-4">
+        <div className="bg-white/50 border border-surface-200 rounded-lg p-4 dark:bg-surface-900/50">
           <h4 className="font-semibold text-surface-800 mb-2">Generate a Secure Key:</h4>
-          <div className="bg-white rounded-lg p-3 font-mono text-sm text-surface-700 mt-2">
+          <div className="bg-white rounded-lg p-3 font-mono text-sm text-surface-700 mt-2 dark:bg-surface-900">
             openssl rand -hex 32
           </div>
         </div>
@@ -2681,7 +2688,7 @@ function MCPCredentialSecurityArticle() {
       <section className="mb-8">
         <h2 className="text-2xl font-bold text-surface-900 mb-4">Audit Trail</h2>
         <p className="text-surface-700 mb-4">Every MCP server configuration records:</p>
-        <div className="bg-white rounded-lg overflow-hidden mb-4">
+        <div className="bg-white rounded-lg overflow-hidden mb-4 dark:bg-surface-900">
           <table className="w-full text-sm">
             <thead className="bg-surface-200">
               <tr>
@@ -2747,7 +2754,7 @@ function MCPCredentialSecurityArticle() {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <Link
             to="/help/mcp/quick-start"
-            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors dark:bg-surface-900/50 dark:hover:bg-surface-800"
           >
             <BookOpenIcon className="w-5 h-5 text-surface-600" />
             <span className="text-surface-800">MCP Quick Start Guide</span>
@@ -2755,7 +2762,7 @@ function MCPCredentialSecurityArticle() {
           </Link>
           <Link
             to="/settings/mcp"
-            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors dark:bg-surface-900/50 dark:hover:bg-surface-800"
           >
             <Cog6ToothIcon className="w-5 h-5 text-surface-600" />
             <span className="text-surface-800">MCP Settings</span>

--- a/frontend/src/pages/HelpCenter.tsx
+++ b/frontend/src/pages/HelpCenter.tsx
@@ -178,7 +178,7 @@ export default function HelpCenter() {
             placeholder="Search help articles..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full pl-12 pr-4 py-3 bg-white border border-surface-200 rounded-xl text-surface-900 placeholder-surface-500 focus:outline-none focus:border-brand-500 focus:ring-1 focus:ring-brand-500"
+            className="w-full pl-12 pr-4 py-3 bg-white border border-surface-200 rounded-xl text-surface-900 placeholder-surface-500 focus:outline-none focus:border-brand-500 focus:ring-1 focus:ring-brand-500 dark:bg-surface-900"
           />
         </div>
       </div>
@@ -194,7 +194,7 @@ export default function HelpCenter() {
               className={`flex flex-col items-center gap-2 p-4 rounded-lg border transition-colors ${
                 isSelected
                   ? 'bg-brand-600/20 border-brand-500 text-brand-400'
-                  : 'bg-white/50 border-surface-200 text-surface-600 hover:bg-white hover:text-surface-800'
+                  : 'bg-white/50 border-surface-200 text-surface-600 hover:bg-white hover:text-surface-800 dark:bg-surface-900/50 dark:hover:bg-surface-800'
               }`}
             >
               <Icon className={`w-6 h-6 ${isSelected ? 'text-brand-400' : category.color}`} />
@@ -243,7 +243,7 @@ export default function HelpCenter() {
         </h2>
 
         {filteredArticles.length === 0 ? (
-          <div className="text-center py-12 bg-white/30 rounded-lg border border-surface-200">
+          <div className="text-center py-12 bg-white/30 rounded-lg border border-surface-200 dark:bg-surface-900/30">
             <BookOpenIcon className="w-12 h-12 text-surface-600 mx-auto mb-3" />
             <p className="text-surface-600">No articles found matching your search</p>
             <button
@@ -262,7 +262,7 @@ export default function HelpCenter() {
               <Link
                 key={article.id}
                 to={article.href}
-                className="group bg-white/50 border border-surface-200 rounded-lg p-5 hover:bg-white hover:border-surface-300 transition-colors"
+                className="group bg-white/50 border border-surface-200 rounded-lg p-5 hover:bg-white hover:border-surface-300 transition-colors dark:bg-surface-900/50 dark:hover:bg-surface-800"
               >
                 <div className="flex items-start justify-between mb-2">
                   <span className="px-2 py-0.5 text-xs bg-surface-200 text-surface-600 rounded">
@@ -287,7 +287,7 @@ export default function HelpCenter() {
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <Link
             to="/docs?section=api"
-            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors dark:bg-surface-900/50 dark:hover:bg-surface-800"
           >
             <BookOpenIcon className="w-5 h-5 text-surface-600" />
             <span className="text-surface-800">API Documentation</span>
@@ -295,7 +295,7 @@ export default function HelpCenter() {
           </Link>
           <Link
             to="/docs?section=architecture"
-            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors dark:bg-surface-900/50 dark:hover:bg-surface-800"
           >
             <BookOpenIcon className="w-5 h-5 text-surface-600" />
             <span className="text-surface-800">Architecture Guide</span>
@@ -303,7 +303,7 @@ export default function HelpCenter() {
           </Link>
           <Link
             to="/docs?section=configuration"
-            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors"
+            className="flex items-center gap-3 p-4 bg-white/50 border border-surface-200 rounded-lg hover:bg-white transition-colors dark:bg-surface-900/50 dark:hover:bg-surface-800"
           >
             <BookOpenIcon className="w-5 h-5 text-surface-600" />
             <span className="text-surface-800">Configuration Guide</span>
@@ -312,7 +312,7 @@ export default function HelpCenter() {
         </div>
       </div>
       {/* Contact Support */}
-      <div className="bg-white/30 border border-surface-200 rounded-xl p-6 text-center">
+      <div className="bg-white/30 border border-surface-200 rounded-xl p-6 text-center dark:bg-surface-900/30">
         <h3 className="text-lg font-semibold text-surface-900 mb-2">Still need help?</h3>
         <p className="text-surface-600 mb-4">
           Can't find what you're looking for? Our support team is here to help.

--- a/frontend/src/pages/Integrations.tsx
+++ b/frontend/src/pages/Integrations.tsx
@@ -263,7 +263,9 @@ export default function Integrations() {
           onClick={() => setStatusFilter(statusFilter === 'all' ? 'all' : 'all')}
           className={clsx(
             'card p-4 text-left transition-all',
-            statusFilter === 'all' ? 'ring-2 ring-surface-500' : 'hover:bg-white/50'
+            statusFilter === 'all'
+              ? 'ring-2 ring-surface-500'
+              : 'hover:bg-white/50 dark:bg-surface-900/50 dark:hover:bg-surface-800/50'
           )}
         >
           <p className="text-sm text-surface-600">Available Integrations</p>
@@ -277,7 +279,7 @@ export default function Integrations() {
             'card p-4 text-left transition-all',
             statusFilter === 'configured'
               ? 'ring-2 ring-green-500'
-              : 'hover:bg-white/50 cursor-pointer'
+              : 'hover:bg-white/50 cursor-pointer dark:bg-surface-900/50 dark:hover:bg-surface-800/50'
           )}
         >
           <p className="text-sm text-surface-600">Configured</p>
@@ -290,7 +292,9 @@ export default function Integrations() {
           onClick={() => setStatusFilter(statusFilter === 'active' ? 'all' : 'active')}
           className={clsx(
             'card p-4 text-left transition-all',
-            statusFilter === 'active' ? 'ring-2 ring-brand-500' : 'hover:bg-white/50 cursor-pointer'
+            statusFilter === 'active'
+              ? 'ring-2 ring-brand-500'
+              : 'hover:bg-white/50 cursor-pointer dark:bg-surface-900/50 dark:hover:bg-surface-800/50'
           )}
         >
           <p className="text-sm text-surface-600">Active</p>
@@ -307,7 +311,7 @@ export default function Integrations() {
             'card p-4 text-left transition-all',
             statusFilter === 'with_evidence'
               ? 'ring-2 ring-purple-500'
-              : 'hover:bg-white/50 cursor-pointer'
+              : 'hover:bg-white/50 cursor-pointer dark:bg-surface-900/50 dark:hover:bg-surface-800/50'
           )}
         >
           <p className="text-sm text-surface-600">Evidence Collected</p>
@@ -384,7 +388,7 @@ export default function Integrations() {
                       >
                         <div className="flex items-start justify-between mb-4">
                           <div className="flex items-center gap-3">
-                            <div className="p-2 bg-white rounded-lg flex items-center justify-center">
+                            <div className="p-2 bg-white rounded-lg flex items-center justify-center dark:bg-surface-900">
                               <IntegrationIcon
                                 iconSlug={meta.iconSlug || type}
                                 integrationName={meta.name}
@@ -457,7 +461,7 @@ export default function Integrations() {
                                   testMutation.mutate(integration.id);
                                 }}
                                 disabled={testMutation.isPending}
-                                className="p-1.5 text-surface-600 hover:text-surface-900 hover:bg-white rounded transition-colors"
+                                className="p-1.5 text-surface-600 hover:text-surface-900 hover:bg-white rounded transition-colors dark:bg-surface-900 dark:hover:bg-surface-800"
                                 title="Test Connection"
                               >
                                 <ArrowPathIcon
@@ -474,7 +478,7 @@ export default function Integrations() {
                                     syncMutation.mutate(integration.id);
                                   }}
                                   disabled={syncMutation.isPending}
-                                  className="p-1.5 text-surface-600 hover:text-green-600 hover:bg-white rounded transition-colors"
+                                  className="p-1.5 text-surface-600 hover:text-green-600 hover:bg-white rounded transition-colors dark:bg-surface-900 dark:hover:bg-surface-800"
                                   title="Trigger Sync"
                                 >
                                   <PlayIcon className="w-4 h-4" />
@@ -490,7 +494,7 @@ export default function Integrations() {
                                   }
                                 }}
                                 disabled={deleteMutation.isPending}
-                                className="p-1.5 text-surface-600 hover:text-red-600 hover:bg-white rounded transition-colors"
+                                className="p-1.5 text-surface-600 hover:text-red-600 hover:bg-white rounded transition-colors dark:bg-surface-900 dark:hover:bg-surface-800"
                                 title="Delete"
                               >
                                 <TrashIcon className="w-4 h-4" />

--- a/frontend/src/pages/KnowledgeBase.tsx
+++ b/frontend/src/pages/KnowledgeBase.tsx
@@ -199,13 +199,13 @@ privacy,GDPR Compliance,Are you GDPR compliant?,"We are fully GDPR compliant and
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder="Search knowledge base..."
-            className="w-full pl-10 pr-4 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+            className="w-full pl-10 pr-4 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
           />
         </div>
         <SelectNative
           value={category}
           onChange={(e) => setCategory(e.target.value)}
-          className="px-4 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+          className="px-4 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
         >
           {categories.map((cat) => (
             <option key={cat} value={cat}>
@@ -236,7 +236,7 @@ privacy,GDPR Compliance,Are you GDPR compliant?,"We are fully GDPR compliant and
             <div
               key={entry.id}
               onClick={() => navigate(`/knowledge-base/${entry.id}`)}
-              className="bg-white border border-surface-200 rounded-lg p-6 hover:bg-white cursor-pointer transition-colors"
+              className="bg-white border border-surface-200 rounded-lg p-6 hover:bg-white cursor-pointer transition-colors dark:bg-surface-900 dark:hover:bg-surface-800"
             >
               <div className="flex items-start justify-between mb-3">
                 <h3 className="text-lg font-semibold text-surface-900 flex-1">{entry.title}</h3>
@@ -315,7 +315,7 @@ privacy,GDPR Compliance,Are you GDPR compliant?,"We are fully GDPR compliant and
           </div>
         </div>
 
-        <div className="mb-4 bg-white rounded-lg p-4">
+        <div className="mb-4 bg-white rounded-lg p-4 dark:bg-surface-900">
           <h3 className="text-sm font-medium text-surface-700 mb-2">Example CSV Format:</h3>
           <pre className="text-xs text-surface-600 font-mono overflow-x-auto">
             {`category,title,question,answer,tags,framework,status,isPublic

--- a/frontend/src/pages/KnowledgeBaseDetail.tsx
+++ b/frontend/src/pages/KnowledgeBaseDetail.tsx
@@ -162,7 +162,7 @@ export default function KnowledgeBaseDetail() {
         <div className="flex items-center gap-4">
           <button
             onClick={() => navigate('/knowledge-base')}
-            className="p-2 text-surface-600 hover:text-surface-900 hover:bg-white rounded-lg transition-colors"
+            className="p-2 text-surface-600 hover:text-surface-900 hover:bg-white rounded-lg transition-colors dark:bg-surface-900 dark:hover:bg-surface-800"
           >
             <ArrowLeftIcon className="w-5 h-5" />
           </button>
@@ -194,7 +194,7 @@ export default function KnowledgeBaseDetail() {
         )}
       </div>
       {editing ? (
-        <div className="bg-white border border-surface-200 rounded-lg p-6 space-y-6">
+        <div className="bg-white border border-surface-200 rounded-lg p-6 space-y-6 dark:bg-surface-900">
           <div>
             <label className="block text-sm font-medium text-surface-600 mb-1">
               Title <span className="text-red-600">*</span>
@@ -203,7 +203,7 @@ export default function KnowledgeBaseDetail() {
               type="text"
               value={formData.title}
               onChange={(e) => setFormData((prev) => ({ ...prev, title: e.target.value }))}
-              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               placeholder="e.g., Data Encryption at Rest"
             />
           </div>
@@ -215,7 +215,7 @@ export default function KnowledgeBaseDetail() {
               <SelectNative
                 value={formData.category}
                 onChange={(e) => setFormData((prev) => ({ ...prev, category: e.target.value }))}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               >
                 {CATEGORIES.map((cat) => (
                   <option key={cat} value={cat}>
@@ -230,7 +230,7 @@ export default function KnowledgeBaseDetail() {
                 type="text"
                 value={formData.framework || ''}
                 onChange={(e) => setFormData((prev) => ({ ...prev, framework: e.target.value }))}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
                 placeholder="e.g., SOC2, ISO 27001"
               />
             </div>
@@ -241,7 +241,7 @@ export default function KnowledgeBaseDetail() {
               type="text"
               value={formData.question || ''}
               onChange={(e) => setFormData((prev) => ({ ...prev, question: e.target.value }))}
-              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               placeholder="e.g., Does your platform encrypt data at rest?"
             />
           </div>
@@ -253,7 +253,7 @@ export default function KnowledgeBaseDetail() {
               value={formData.answer}
               onChange={(e) => setFormData((prev) => ({ ...prev, answer: e.target.value }))}
               rows={6}
-              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               placeholder="Provide a detailed answer..."
             />
           </div>
@@ -270,7 +270,7 @@ export default function KnowledgeBaseDetail() {
                     handleAddTag();
                   }
                 }}
-                className="flex-1 px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="flex-1 px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
                 placeholder="Add a tag and press Enter"
               />
               <button
@@ -307,7 +307,7 @@ export default function KnowledgeBaseDetail() {
               <SelectNative
                 value={formData.status}
                 onChange={(e) => setFormData((prev) => ({ ...prev, status: e.target.value }))}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               >
                 {STATUSES.map((status) => (
                   <option key={status} value={status}>
@@ -322,7 +322,7 @@ export default function KnowledgeBaseDetail() {
                   type="checkbox"
                   checked={formData.isPublic}
                   onChange={(e) => setFormData((prev) => ({ ...prev, isPublic: e.target.checked }))}
-                  className="w-4 h-4 rounded border-surface-200 bg-white text-brand-600 focus:ring-brand-500"
+                  className="w-4 h-4 rounded border-surface-200 bg-white text-brand-600 focus:ring-brand-500 dark:bg-surface-900"
                 />
                 <span className="text-sm text-surface-700">Make publicly visible</span>
               </label>
@@ -352,7 +352,7 @@ export default function KnowledgeBaseDetail() {
           </div>
         </div>
       ) : entry ? (
-        <div className="bg-white border border-surface-200 rounded-lg p-6 space-y-6">
+        <div className="bg-white border border-surface-200 rounded-lg p-6 space-y-6 dark:bg-surface-900">
           <div className="flex items-center gap-2">
             <span className="px-2 py-1 text-xs bg-surface-200 text-surface-700 rounded capitalize">
               {entry.category}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -91,7 +91,9 @@ export default function Login() {
                   <div className="w-full border-t border-surface-200"></div>
                 </div>
                 <div className="relative flex justify-center text-sm">
-                  <span className="px-2 bg-white text-surface-500">Development Only</span>
+                  <span className="px-2 bg-white text-surface-500 dark:bg-surface-900">
+                    Development Only
+                  </span>
                 </div>
               </div>
               <button

--- a/frontend/src/pages/MCPSettings.tsx
+++ b/frontend/src/pages/MCPSettings.tsx
@@ -125,7 +125,7 @@ export default function MCPSettings() {
       case 'connecting':
         return <ArrowPathIcon className="w-5 h-5 text-yellow-500 animate-spin" />;
       default:
-        return <ClockIcon className="w-5 h-5 text-gray-500" />;
+        return <ClockIcon className="w-5 h-5 text-gray-500 dark:text-surface-400" />;
     }
   };
 
@@ -227,12 +227,12 @@ export default function MCPSettings() {
 
         {loadingServers ? (
           <div className="p-8 text-center">
-            <ArrowPathIcon className="w-8 h-8 animate-spin mx-auto text-gray-400" />
+            <ArrowPathIcon className="w-8 h-8 animate-spin mx-auto text-gray-400 dark:text-surface-500" />
             <p className="mt-2 text-gray-600 dark:text-gray-400">Loading servers...</p>
           </div>
         ) : servers.length === 0 ? (
           <div className="p-8 text-center">
-            <CpuChipIcon className="w-12 h-12 mx-auto text-gray-400" />
+            <CpuChipIcon className="w-12 h-12 mx-auto text-gray-400 dark:text-surface-500" />
             <p className="mt-2 text-gray-600 dark:text-gray-400">No servers configured</p>
             <Button onClick={() => setShowAddModal(true)} className="mt-4" variant="secondary">
               Add your first server
@@ -243,7 +243,7 @@ export default function MCPSettings() {
             {servers.map((server) => (
               <div
                 key={server.id}
-                className="p-4 hover:bg-gray-50 dark:hover:bg-surface-200/50 cursor-pointer"
+                className="p-4 hover:bg-gray-50 dark:hover:bg-surface-200/50 cursor-pointer dark:bg-surface-900"
                 onClick={() => setSelectedServer(server)}
               >
                 <div className="flex items-center justify-between">
@@ -265,7 +265,7 @@ export default function MCPSettings() {
                             e.stopPropagation();
                             disconnectMutation.mutate(server.id);
                           }}
-                          className="p-2 text-gray-500 hover:text-red-600 dark:hover:text-red-600"
+                          className="p-2 text-gray-500 hover:text-red-600 dark:hover:text-red-600 dark:text-surface-400"
                           title="Disconnect"
                         >
                           <StopIcon className="w-5 h-5" />
@@ -276,7 +276,7 @@ export default function MCPSettings() {
                             e.stopPropagation();
                             connectMutation.mutate(server.id);
                           }}
-                          className="p-2 text-gray-500 hover:text-green-600 dark:hover:text-green-600"
+                          className="p-2 text-gray-500 hover:text-green-600 dark:hover:text-green-600 dark:text-surface-400"
                           title="Connect"
                         >
                           <PlayIcon className="w-5 h-5" />
@@ -289,7 +289,7 @@ export default function MCPSettings() {
                             deleteMutation.mutate(server.id);
                           }
                         }}
-                        className="p-2 text-gray-500 hover:text-red-600 dark:hover:text-red-600"
+                        className="p-2 text-gray-500 hover:text-red-600 dark:hover:text-red-600 dark:text-surface-400"
                         title="Delete"
                       >
                         <TrashIcon className="w-5 h-5" />
@@ -317,7 +317,7 @@ export default function MCPSettings() {
               setSelectedTemplate(null);
               setEnvVars({});
             }}
-            className="text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
+            className="text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 dark:text-surface-400"
           >
             ×
           </button>
@@ -521,7 +521,7 @@ export default function MCPSettings() {
             </div>
             <button
               onClick={() => setSelectedServer(null)}
-              className="text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
+              className="text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 dark:text-surface-400"
             >
               ×
             </button>

--- a/frontend/src/pages/MappingGaps.tsx
+++ b/frontend/src/pages/MappingGaps.tsx
@@ -301,7 +301,7 @@ export default function MappingGaps() {
           {gapsQuery.isLoading ? (
             <div className="space-y-2" role="status" aria-label="Loading gaps">
               {Array.from({ length: 5 }).map((_, i) => (
-                <div key={i} className="h-10 bg-white rounded animate-pulse" />
+                <div key={i} className="h-10 bg-white rounded animate-pulse dark:bg-surface-900" />
               ))}
             </div>
           ) : gapsQuery.isError ? (
@@ -341,7 +341,10 @@ export default function MappingGaps() {
                         ? `/controls/${row.control.id}`
                         : '#';
                     return (
-                      <tr key={row.id} className="border-b border-surface-200 hover:bg-white/50">
+                      <tr
+                        key={row.id}
+                        className="border-b border-surface-200 hover:bg-white/50 dark:bg-surface-900/50 dark:hover:bg-surface-800/50"
+                      >
                         {showTypeColumn && (
                           <td className="py-2 px-3 text-surface-700">{TYPE_LABEL[row.type]}</td>
                         )}

--- a/frontend/src/pages/NotificationSettings.tsx
+++ b/frontend/src/pages/NotificationSettings.tsx
@@ -63,9 +63,9 @@ function EmailConfigurationNotice() {
 
   if (isLoading) {
     return (
-      <div className="bg-gray-800 border border-gray-700 rounded-xl p-4 animate-pulse">
-        <div className="h-4 bg-gray-700 rounded w-1/4 mb-2"></div>
-        <div className="h-3 bg-gray-700 rounded w-3/4"></div>
+      <div className="bg-gray-800 border border-gray-700 rounded-xl p-4 animate-pulse dark:bg-surface-200 dark:border-surface-300">
+        <div className="h-4 bg-gray-700 rounded w-1/4 mb-2 dark:bg-surface-300"></div>
+        <div className="h-3 bg-gray-700 rounded w-3/4 dark:bg-surface-300"></div>
       </div>
     );
   }
@@ -79,7 +79,7 @@ function EmailConfigurationNotice() {
           <CheckCircleIcon className="h-6 w-6 text-green-600 flex-shrink-0 mt-0.5" />
           <div>
             <h4 className="text-green-600 font-medium">Email Notifications Active</h4>
-            <p className="text-gray-300 text-sm mt-1">
+            <p className="text-gray-300 text-sm mt-1 dark:text-surface-700">
               Email delivery is configured using {emailStatus?.provider?.toUpperCase() || 'SMTP'}.
               Notifications will be sent to recipient email addresses.
             </p>
@@ -95,11 +95,11 @@ function EmailConfigurationNotice() {
         <EnvelopeIcon className="h-6 w-6 text-amber-600 flex-shrink-0 mt-0.5" />
         <div>
           <h4 className="text-amber-600 font-medium">Email Notifications (Demo Mode)</h4>
-          <p className="text-gray-300 text-sm mt-1">
+          <p className="text-gray-300 text-sm mt-1 dark:text-surface-700">
             {emailStatus?.consoleReason ||
               'Email provider not configured. Configure SMTP, SendGrid, or AWS SES in environment variables to enable email delivery.'}
           </p>
-          <p className="text-gray-400 text-xs mt-2">
+          <p className="text-gray-400 text-xs mt-2 dark:text-surface-500">
             In demo mode, emails are logged to the console instead of being sent.
           </p>
         </div>
@@ -232,7 +232,7 @@ export default function NotificationSettings() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold text-white">Notifications</h1>
-          <p className="text-gray-400 mt-1">
+          <p className="text-gray-400 mt-1 dark:text-surface-500">
             Manage your notification preferences and view history
           </p>
         </div>
@@ -241,7 +241,7 @@ export default function NotificationSettings() {
             <>
               <button
                 onClick={() => refetch()}
-                className="p-2 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-colors"
+                className="p-2 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-colors dark:bg-surface-300 dark:hover:bg-surface-300 dark:text-surface-500"
                 title="Refresh"
               >
                 <ArrowPathIcon className="h-5 w-5" />
@@ -249,7 +249,7 @@ export default function NotificationSettings() {
               {unreadCount > 0 && (
                 <button
                   onClick={() => markAllReadMutation.mutate()}
-                  className="px-3 py-2 text-sm text-indigo-600 hover:text-indigo-700 hover:bg-gray-700 rounded-lg transition-colors flex items-center space-x-1"
+                  className="px-3 py-2 text-sm text-indigo-600 hover:text-indigo-700 hover:bg-gray-700 rounded-lg transition-colors flex items-center space-x-1 dark:bg-surface-300 dark:hover:bg-surface-300"
                 >
                   <CheckIcon className="h-4 w-4" />
                   <span>Mark all read</span>
@@ -262,7 +262,7 @@ export default function NotificationSettings() {
                       deleteAllMutation.mutate();
                     }
                   }}
-                  className="px-3 py-2 text-sm text-red-600 hover:text-red-700 hover:bg-gray-700 rounded-lg transition-colors flex items-center space-x-1"
+                  className="px-3 py-2 text-sm text-red-600 hover:text-red-700 hover:bg-gray-700 rounded-lg transition-colors flex items-center space-x-1 dark:bg-surface-300 dark:hover:bg-surface-300"
                 >
                   <TrashIcon className="h-4 w-4" />
                   <span>Clear all</span>
@@ -284,14 +284,14 @@ export default function NotificationSettings() {
       </div>
 
       {/* Tabs */}
-      <div className="border-b border-gray-700">
+      <div className="border-b border-gray-700 dark:border-surface-300">
         <nav className="flex space-x-8">
           <button
             onClick={() => setActiveTab('all')}
             className={`py-4 px-1 border-b-2 font-medium text-sm transition-colors ${
               activeTab === 'all'
                 ? 'border-indigo-500 text-indigo-600'
-                : 'border-transparent text-gray-400 hover:text-gray-300 hover:border-gray-500'
+                : 'border-transparent text-gray-400 hover:text-gray-300 hover:border-gray-500 dark:text-surface-500 dark:border-surface-500'
             }`}
           >
             All Notifications
@@ -301,7 +301,7 @@ export default function NotificationSettings() {
             className={`py-4 px-1 border-b-2 font-medium text-sm transition-colors flex items-center space-x-2 ${
               activeTab === 'unread'
                 ? 'border-indigo-500 text-indigo-600'
-                : 'border-transparent text-gray-400 hover:text-gray-300 hover:border-gray-500'
+                : 'border-transparent text-gray-400 hover:text-gray-300 hover:border-gray-500 dark:text-surface-500 dark:border-surface-500'
             }`}
           >
             <span>Unread</span>
@@ -316,7 +316,7 @@ export default function NotificationSettings() {
             className={`py-4 px-1 border-b-2 font-medium text-sm transition-colors ${
               activeTab === 'settings'
                 ? 'border-indigo-500 text-indigo-600'
-                : 'border-transparent text-gray-400 hover:text-gray-300 hover:border-gray-500'
+                : 'border-transparent text-gray-400 hover:text-gray-300 hover:border-gray-500 dark:text-surface-500 dark:border-surface-500'
             }`}
           >
             Settings
@@ -329,11 +329,11 @@ export default function NotificationSettings() {
         /* Preferences Settings */
         <div className="space-y-6">
           {/* Quick Toggles */}
-          <div className="bg-gray-800 rounded-xl p-4 border border-gray-700">
+          <div className="bg-gray-800 rounded-xl p-4 border border-gray-700 dark:bg-surface-200 dark:border-surface-300">
             <h3 className="text-lg font-medium text-white mb-4">Quick Settings</h3>
             <div className="flex items-center space-x-6">
               <div className="flex items-center space-x-4">
-                <span className="text-gray-300 flex items-center space-x-2">
+                <span className="text-gray-300 flex items-center space-x-2 dark:text-surface-700">
                   <BellIcon className="h-5 w-5" />
                   <span>In-App</span>
                 </span>
@@ -345,13 +345,13 @@ export default function NotificationSettings() {
                 </button>
                 <button
                   onClick={() => handleToggleAll('inApp', false)}
-                  className="px-2 py-1 text-xs bg-gray-600 text-white rounded hover:bg-gray-500"
+                  className="px-2 py-1 text-xs bg-gray-600 text-white rounded hover:bg-gray-500 dark:bg-surface-400 dark:hover:bg-surface-500"
                 >
                   All Off
                 </button>
               </div>
               <div className="flex items-center space-x-4">
-                <span className="text-gray-300 flex items-center space-x-2">
+                <span className="text-gray-300 flex items-center space-x-2 dark:text-surface-700">
                   <EnvelopeIcon className="h-5 w-5" />
                   <span>Email</span>
                 </span>
@@ -363,7 +363,7 @@ export default function NotificationSettings() {
                 </button>
                 <button
                   onClick={() => handleToggleAll('email', false)}
-                  className="px-2 py-1 text-xs bg-gray-600 text-white rounded hover:bg-gray-500"
+                  className="px-2 py-1 text-xs bg-gray-600 text-white rounded hover:bg-gray-500 dark:bg-surface-400 dark:hover:bg-surface-500"
                 >
                   All Off
                 </button>
@@ -375,15 +375,15 @@ export default function NotificationSettings() {
           {preferencesLoading ? (
             <div className="text-center py-12">
               <div className="animate-spin h-8 w-8 border-2 border-indigo-500 border-t-transparent rounded-full mx-auto"></div>
-              <p className="mt-4 text-gray-400">Loading preferences...</p>
+              <p className="mt-4 text-gray-400 dark:text-surface-500">Loading preferences...</p>
             </div>
           ) : (
             Object.entries(preferencesByCategory).map(([category, prefs]) => (
               <div
                 key={category}
-                className="bg-gray-800 rounded-xl border border-gray-700 overflow-hidden"
+                className="bg-gray-800 rounded-xl border border-gray-700 overflow-hidden dark:bg-surface-200 dark:border-surface-300"
               >
-                <div className="px-4 py-3 bg-gray-900 border-b border-gray-700">
+                <div className="px-4 py-3 bg-gray-900 border-b border-gray-700 dark:bg-surface-100 dark:border-surface-300">
                   <h3 className="text-lg font-medium text-white flex items-center space-x-2">
                     <span>{categoryIcons[category] || '📌'}</span>
                     <span>{category}</span>
@@ -397,13 +397,19 @@ export default function NotificationSettings() {
                     >
                       <div className="flex-1">
                         <p className="text-white font-medium">{pref.typeName}</p>
-                        <p className="text-sm text-gray-400">{pref.description}</p>
+                        <p className="text-sm text-gray-400 dark:text-surface-500">
+                          {pref.description}
+                        </p>
                       </div>
                       <div className="flex items-center space-x-6">
                         {/* In-App Toggle */}
                         <label className="flex items-center space-x-2 cursor-pointer">
                           <BellIcon
-                            className={`h-5 w-5 ${pref.inApp ? 'text-indigo-600' : 'text-gray-500'}`}
+                            className={`h-5 w-5 ${
+                              pref.inApp
+                                ? 'text-indigo-600 dark:text-indigo-300'
+                                : 'text-surface-500 dark:text-surface-400'
+                            }`}
                           />
                           <input
                             type="checkbox"
@@ -418,17 +424,25 @@ export default function NotificationSettings() {
                             className="sr-only"
                           />
                           <div
-                            className={`relative w-10 h-6 rounded-full transition-colors ${pref.inApp ? 'bg-indigo-600' : 'bg-gray-600'}`}
+                            className={`relative w-10 h-6 rounded-full transition-colors ${
+                              pref.inApp
+                                ? 'bg-indigo-600 dark:bg-indigo-400'
+                                : 'bg-surface-600 dark:bg-surface-400'
+                            }`}
                           >
                             <div
-                              className={`absolute top-1 left-1 w-4 h-4 bg-white rounded-full transition-transform ${pref.inApp ? 'translate-x-4' : 'translate-x-0'}`}
+                              className={`absolute top-1 left-1 w-4 h-4 bg-white rounded-full transition-transform ${pref.inApp ? 'translate-x-4' : 'translate-x-0'} dark:bg-surface-900`}
                             ></div>
                           </div>
                         </label>
                         {/* Email Toggle */}
                         <label className="flex items-center space-x-2 cursor-pointer">
                           <EnvelopeIcon
-                            className={`h-5 w-5 ${pref.email ? 'text-indigo-600' : 'text-gray-500'}`}
+                            className={`h-5 w-5 ${
+                              pref.email
+                                ? 'text-indigo-600 dark:text-indigo-300'
+                                : 'text-surface-500 dark:text-surface-400'
+                            }`}
                           />
                           <input
                             type="checkbox"
@@ -443,10 +457,14 @@ export default function NotificationSettings() {
                             className="sr-only"
                           />
                           <div
-                            className={`relative w-10 h-6 rounded-full transition-colors ${pref.email ? 'bg-indigo-600' : 'bg-gray-600'}`}
+                            className={`relative w-10 h-6 rounded-full transition-colors ${
+                              pref.email
+                                ? 'bg-indigo-600 dark:bg-indigo-400'
+                                : 'bg-surface-600 dark:bg-surface-400'
+                            }`}
                           >
                             <div
-                              className={`absolute top-1 left-1 w-4 h-4 bg-white rounded-full transition-transform ${pref.email ? 'translate-x-4' : 'translate-x-0'}`}
+                              className={`absolute top-1 left-1 w-4 h-4 bg-white rounded-full transition-transform ${pref.email ? 'translate-x-4' : 'translate-x-0'} dark:bg-surface-900`}
                             ></div>
                           </div>
                         </label>
@@ -467,24 +485,26 @@ export default function NotificationSettings() {
           {notificationsLoading ? (
             <div className="text-center py-12">
               <div className="animate-spin h-8 w-8 border-2 border-indigo-500 border-t-transparent rounded-full mx-auto"></div>
-              <p className="mt-4 text-gray-400">Loading notifications...</p>
+              <p className="mt-4 text-gray-400 dark:text-surface-500">Loading notifications...</p>
             </div>
           ) : notifications.length === 0 ? (
-            <div className="text-center py-12 bg-gray-800 rounded-xl border border-gray-700">
-              <BellIcon className="h-16 w-16 mx-auto text-gray-600 mb-4" />
+            <div className="text-center py-12 bg-gray-800 rounded-xl border border-gray-700 dark:bg-surface-200 dark:border-surface-300">
+              <BellIcon className="h-16 w-16 mx-auto text-gray-600 mb-4 dark:text-surface-300" />
               <h3 className="text-lg font-medium text-white">No notifications</h3>
-              <p className="text-gray-400 mt-1">
+              <p className="text-gray-400 mt-1 dark:text-surface-500">
                 {activeTab === 'unread'
                   ? "You're all caught up!"
                   : "You haven't received any notifications yet."}
               </p>
             </div>
           ) : (
-            <div className="bg-gray-800 rounded-xl border border-gray-700 divide-y divide-gray-700 overflow-hidden">
+            <div className="bg-gray-800 rounded-xl border border-gray-700 divide-y divide-gray-700 overflow-hidden dark:bg-surface-200 dark:border-surface-300">
               {notifications.map((notification) => (
                 <div
                   key={notification.id}
-                  className={`p-4 hover:bg-gray-700/50 transition-colors ${!notification.isRead ? 'bg-gray-700/30' : ''}`}
+                  className={`p-4 hover:bg-surface-200 dark:hover:bg-surface-700/50 transition-colors ${
+                    !notification.isRead ? 'bg-surface-100 dark:bg-surface-800/30' : ''
+                  }`}
                 >
                   <div className="flex items-start justify-between">
                     <div className="flex items-start space-x-4 flex-1">
@@ -498,7 +518,11 @@ export default function NotificationSettings() {
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center space-x-2">
                           <h4
-                            className={`text-sm font-medium ${notification.isRead ? 'text-gray-300' : 'text-white'}`}
+                            className={`text-sm font-medium ${
+                              notification.isRead
+                                ? 'text-surface-600 dark:text-surface-400'
+                                : 'text-surface-900 dark:text-surface-100'
+                            }`}
                           >
                             {notification.title}
                           </h4>
@@ -506,15 +530,17 @@ export default function NotificationSettings() {
                             <span className="h-2 w-2 bg-indigo-500 rounded-full"></span>
                           )}
                         </div>
-                        <p className="text-sm text-gray-400 mt-1">{notification.message}</p>
+                        <p className="text-sm text-gray-400 mt-1 dark:text-surface-500">
+                          {notification.message}
+                        </p>
                         <div className="flex items-center space-x-3 mt-2">
-                          <span className="text-xs text-gray-500">
+                          <span className="text-xs text-gray-500 dark:text-surface-400">
                             {formatDistanceToNow(new Date(notification.createdAt), {
                               addSuffix: true,
                             })}
                           </span>
                           {notification.entityType && (
-                            <span className="text-xs text-gray-500 bg-gray-700 px-2 py-0.5 rounded">
+                            <span className="text-xs text-gray-500 bg-gray-700 px-2 py-0.5 rounded dark:bg-surface-300 dark:text-surface-400">
                               {notification.entityType}
                             </span>
                           )}
@@ -527,7 +553,7 @@ export default function NotificationSettings() {
                       {!notification.isRead && (
                         <button
                           onClick={() => markReadMutation.mutate(notification.id)}
-                          className="p-2 text-gray-400 hover:text-green-600 hover:bg-gray-700 rounded-lg transition-colors"
+                          className="p-2 text-gray-400 hover:text-green-600 hover:bg-gray-700 rounded-lg transition-colors dark:bg-surface-300 dark:hover:bg-surface-300 dark:text-surface-500"
                           title="Mark as read"
                         >
                           <CheckIcon className="h-4 w-4" />
@@ -535,7 +561,7 @@ export default function NotificationSettings() {
                       )}
                       <button
                         onClick={() => deleteMutation.mutate(notification.id)}
-                        className="p-2 text-gray-400 hover:text-red-600 hover:bg-gray-700 rounded-lg transition-colors"
+                        className="p-2 text-gray-400 hover:text-red-600 hover:bg-gray-700 rounded-lg transition-colors dark:bg-surface-300 dark:hover:bg-surface-300 dark:text-surface-500"
                         title="Delete"
                       >
                         <TrashIcon className="h-4 w-4" />

--- a/frontend/src/pages/PermissionGroups.tsx
+++ b/frontend/src/pages/PermissionGroups.tsx
@@ -117,7 +117,10 @@ export default function PermissionGroups() {
       ) : (
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
           {groups?.map((group: PermissionGroup) => (
-            <div key={group.id} className="bg-white rounded-lg border border-surface-200 p-5">
+            <div
+              key={group.id}
+              className="bg-white rounded-lg border border-surface-200 p-5 dark:bg-surface-900"
+            >
               <div className="flex items-start justify-between mb-4">
                 <div>
                   <div className="flex items-center gap-2">
@@ -305,7 +308,7 @@ function PermissionGroupModal({
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              className="w-full bg-white border border-surface-300 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+              className="w-full bg-white border border-surface-300 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-brand-500 dark:bg-surface-900"
               placeholder="e.g., Compliance Manager"
             />
           </div>
@@ -315,7 +318,7 @@ function PermissionGroupModal({
               type="text"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
-              className="w-full bg-white border border-surface-300 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+              className="w-full bg-white border border-surface-300 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-brand-500 dark:bg-surface-900"
               placeholder="Brief description of this role"
             />
           </div>
@@ -324,10 +327,10 @@ function PermissionGroupModal({
         {/* Permission Matrix */}
         <div>
           <label className="block text-sm text-surface-600 mb-3">Permission Matrix</label>
-          <div className="bg-white rounded-lg border border-surface-200 overflow-hidden">
+          <div className="bg-white rounded-lg border border-surface-200 overflow-hidden dark:bg-surface-900">
             <table className="w-full">
               <thead>
-                <tr className="bg-white">
+                <tr className="bg-white dark:bg-surface-900">
                   <th className="text-left text-surface-600 font-medium px-4 py-3 w-48">
                     Resource
                   </th>
@@ -349,7 +352,10 @@ function PermissionGroupModal({
                   const currentActions = permissions[resource.id] || [];
                   const allSelected = currentActions.length === ACTIONS.length;
                   return (
-                    <tr key={resource.id} className="hover:bg-white/50">
+                    <tr
+                      key={resource.id}
+                      className="hover:bg-white/50 dark:bg-surface-900/50 dark:hover:bg-surface-800/50"
+                    >
                       <td className="px-4 py-3">
                         <div className="text-white text-sm font-medium">{resource.label}</div>
                         <div className="text-surface-500 text-xs">{resource.description}</div>

--- a/frontend/src/pages/Policies.tsx
+++ b/frontend/src/pages/Policies.tsx
@@ -150,7 +150,7 @@ export default function Policies() {
                           to={`/policies/${policy.id}`}
                           className="flex items-center gap-3 hover:text-brand-400"
                         >
-                          <div className="p-2 bg-white rounded-lg">
+                          <div className="p-2 bg-white rounded-lg dark:bg-surface-900">
                             <DocumentTextIcon className="w-5 h-5 text-surface-600" />
                           </div>
                           <span className="font-medium text-surface-900">{policy.title}</span>

--- a/frontend/src/pages/PolicyDetail.tsx
+++ b/frontend/src/pages/PolicyDetail.tsx
@@ -170,7 +170,7 @@ export default function PolicyDetail() {
         </Link>
         <div className="flex items-start justify-between">
           <div className="flex items-start gap-4">
-            <div className="p-3 bg-white rounded-xl">
+            <div className="p-3 bg-white rounded-xl dark:bg-surface-900">
               <DocumentTextIcon className="w-8 h-8 text-brand-400" />
             </div>
             <div>
@@ -273,7 +273,9 @@ export default function PolicyDetail() {
                     key={version.id}
                     className={clsx(
                       'flex items-center justify-between p-3 rounded-lg',
-                      index === 0 ? 'bg-brand-500/10 border border-brand-500/30' : 'bg-white'
+                      index === 0
+                        ? 'bg-brand-500/10 border border-brand-500/30'
+                        : 'bg-white dark:bg-surface-900'
                     )}
                   >
                     <div>
@@ -431,7 +433,7 @@ export default function PolicyDetail() {
                 {policy?.controlLinks?.map((link: any) => (
                   <div
                     key={link.id}
-                    className="flex items-center justify-between p-3 bg-white rounded-lg group"
+                    className="flex items-center justify-between p-3 bg-white rounded-lg group dark:bg-surface-900"
                   >
                     <Link
                       to={`/controls/${link.control?.id}`}
@@ -872,7 +874,7 @@ function LinkControlModal({
                 'flex items-center gap-3 p-3 rounded-lg cursor-pointer transition-colors',
                 selectedControlIds.includes(control.id)
                   ? 'bg-brand-500/20 border border-brand-500/50'
-                  : 'bg-white hover:bg-surface-200'
+                  : 'bg-white hover:bg-surface-200 dark:bg-surface-900'
               )}
             >
               <input

--- a/frontend/src/pages/QuestionnaireDetail.tsx
+++ b/frontend/src/pages/QuestionnaireDetail.tsx
@@ -280,7 +280,7 @@ export default function QuestionnaireDetail() {
         <div className="flex items-center gap-4">
           <button
             onClick={() => navigate('/questionnaires')}
-            className="p-2 text-surface-600 hover:text-surface-900 hover:bg-white rounded-lg transition-colors"
+            className="p-2 text-surface-600 hover:text-surface-900 hover:bg-white rounded-lg transition-colors dark:bg-surface-900 dark:hover:bg-surface-800"
           >
             <ArrowLeftIcon className="w-5 h-5" />
           </button>
@@ -319,7 +319,7 @@ export default function QuestionnaireDetail() {
       </div>
       {id === 'new' ? (
         <form onSubmit={handleSubmitNewQuestionnaire} className="space-y-6">
-          <div className="bg-white border border-surface-200 rounded-lg p-6 space-y-4">
+          <div className="bg-white border border-surface-200 rounded-lg p-6 space-y-4 dark:bg-surface-900">
             <h2 className="text-xl font-semibold text-surface-900">Customer Information</h2>
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -332,7 +332,7 @@ export default function QuestionnaireDetail() {
                   required
                   value={formData.requesterName}
                   onChange={(e) => setFormData({ ...formData, requesterName: e.target.value })}
-                  className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                  className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
                   placeholder="John Doe"
                 />
               </div>
@@ -346,7 +346,7 @@ export default function QuestionnaireDetail() {
                   required
                   value={formData.requesterEmail}
                   onChange={(e) => setFormData({ ...formData, requesterEmail: e.target.value })}
-                  className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                  className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
                   placeholder="john@company.com"
                 />
               </div>
@@ -357,7 +357,7 @@ export default function QuestionnaireDetail() {
                   type="text"
                   value={formData.company}
                   onChange={(e) => setFormData({ ...formData, company: e.target.value })}
-                  className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                  className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
                   placeholder="Acme Corp"
                 />
               </div>
@@ -371,7 +371,7 @@ export default function QuestionnaireDetail() {
                   required
                   value={formData.title}
                   onChange={(e) => setFormData({ ...formData, title: e.target.value })}
-                  className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                  className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
                   placeholder="Security Assessment 2025"
                 />
               </div>
@@ -381,7 +381,7 @@ export default function QuestionnaireDetail() {
                 <SelectNative
                   value={formData.priority}
                   onChange={(e) => setFormData({ ...formData, priority: e.target.value })}
-                  className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                  className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
                 >
                   <option value="low">Low</option>
                   <option value="medium">Medium</option>
@@ -396,7 +396,7 @@ export default function QuestionnaireDetail() {
                   type="date"
                   value={formData.dueDate}
                   onChange={(e) => setFormData({ ...formData, dueDate: e.target.value })}
-                  className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                  className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
                 />
               </div>
             </div>
@@ -407,13 +407,13 @@ export default function QuestionnaireDetail() {
                 value={formData.description}
                 onChange={(e) => setFormData({ ...formData, description: e.target.value })}
                 rows={2}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
                 placeholder="Additional context about this questionnaire..."
               />
             </div>
           </div>
 
-          <div className="bg-white border border-surface-200 rounded-lg p-6 space-y-4">
+          <div className="bg-white border border-surface-200 rounded-lg p-6 space-y-4 dark:bg-surface-900">
             <h2 className="text-xl font-semibold text-surface-900">
               Upload Questionnaire <span className="text-red-600">*</span>
             </h2>
@@ -449,7 +449,7 @@ export default function QuestionnaireDetail() {
               </div>
             ) : (
               <div className="space-y-3">
-                <div className="flex items-center justify-between p-4 bg-white rounded-lg border border-surface-200">
+                <div className="flex items-center justify-between p-4 bg-white rounded-lg border border-surface-200 dark:bg-surface-900">
                   <div className="flex items-center gap-3">
                     <DocumentArrowUpIcon className="w-6 h-6 text-green-600" />
                     <div>
@@ -532,7 +532,7 @@ export default function QuestionnaireDetail() {
               type="text"
               value={editForm.title}
               onChange={(e) => setEditForm({ ...editForm, title: e.target.value })}
-              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
             />
           </div>
           <div className="grid grid-cols-2 gap-4">
@@ -544,7 +544,7 @@ export default function QuestionnaireDetail() {
                 type="text"
                 value={editForm.requesterName}
                 onChange={(e) => setEditForm({ ...editForm, requesterName: e.target.value })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               />
             </div>
             <div>
@@ -555,7 +555,7 @@ export default function QuestionnaireDetail() {
                 type="email"
                 value={editForm.requesterEmail}
                 onChange={(e) => setEditForm({ ...editForm, requesterEmail: e.target.value })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               />
             </div>
           </div>
@@ -566,7 +566,7 @@ export default function QuestionnaireDetail() {
                 type="text"
                 value={editForm.company}
                 onChange={(e) => setEditForm({ ...editForm, company: e.target.value })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               />
             </div>
             <div>
@@ -574,7 +574,7 @@ export default function QuestionnaireDetail() {
               <SelectNative
                 value={editForm.priority}
                 onChange={(e) => setEditForm({ ...editForm, priority: e.target.value })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               >
                 <option value="low">Low</option>
                 <option value="medium">Medium</option>
@@ -588,7 +588,7 @@ export default function QuestionnaireDetail() {
               type="date"
               value={editForm.dueDate}
               onChange={(e) => setEditForm({ ...editForm, dueDate: e.target.value })}
-              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
             />
           </div>
           <div>
@@ -597,7 +597,7 @@ export default function QuestionnaireDetail() {
               value={editForm.description}
               onChange={(e) => setEditForm({ ...editForm, description: e.target.value })}
               rows={3}
-              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
             />
           </div>
         </div>
@@ -717,7 +717,7 @@ function QuestionnaireWorkspace({
   return (
     <div className="space-y-4">
       {/* Progress Header */}
-      <div className="bg-white border border-surface-200 rounded-lg p-4">
+      <div className="bg-white border border-surface-200 rounded-lg p-4 dark:bg-surface-900">
         <div className="flex items-center justify-between mb-3">
           <div className="flex items-center gap-4">
             <div>
@@ -885,7 +885,7 @@ function QuestionAnswerCard({
   return (
     <div
       className={clsx(
-        'bg-white border rounded-lg transition-all cursor-pointer',
+        'bg-white border rounded-lg transition-all cursor-pointer dark:bg-surface-900',
         isActive
           ? 'border-brand-500 ring-2 ring-brand-500/20'
           : 'border-surface-200 hover:border-surface-300'
@@ -940,7 +940,7 @@ function QuestionAnswerCard({
               value={currentAnswer}
               onChange={(e) => onAnswerChange(e.target.value)}
               rows={5}
-              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 resize-y"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 resize-y dark:bg-surface-900"
               placeholder="Enter your answer here, or use the Knowledge Base panel to find a pre-approved answer..."
             />
 

--- a/frontend/src/pages/Questionnaires.tsx
+++ b/frontend/src/pages/Questionnaires.tsx
@@ -77,7 +77,7 @@ export default function Questionnaires() {
             className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
               filter === status
                 ? 'bg-brand-600 text-white'
-                : 'bg-white text-surface-700 hover:bg-surface-200'
+                : 'bg-white text-surface-700 hover:bg-surface-200 dark:bg-surface-900'
             }`}
           >
             {status === 'all'
@@ -100,9 +100,9 @@ export default function Questionnaires() {
           }}
         />
       ) : (
-        <div className="bg-white border border-surface-200 rounded-lg overflow-hidden">
+        <div className="bg-white border border-surface-200 rounded-lg overflow-hidden dark:bg-surface-900">
           <table className="w-full">
-            <thead className="bg-white border-b border-surface-200">
+            <thead className="bg-white border-b border-surface-200 dark:bg-surface-900">
               <tr>
                 <th className="px-6 py-3 text-left text-xs font-medium text-surface-600 uppercase tracking-wider">
                   Customer Request
@@ -131,7 +131,7 @@ export default function Questionnaires() {
                   <tr
                     key={questionnaire.id}
                     onClick={() => navigate(`/questionnaires/${questionnaire.id}`)}
-                    className="hover:bg-white cursor-pointer transition-colors"
+                    className="hover:bg-white cursor-pointer transition-colors dark:bg-surface-900 dark:hover:bg-surface-800"
                   >
                     <td className="px-6 py-4">
                       <div>

--- a/frontend/src/pages/ReportBuilder.tsx
+++ b/frontend/src/pages/ReportBuilder.tsx
@@ -168,7 +168,7 @@ export default function ReportBuilderPage() {
         <div className="flex items-center gap-2">
           <button
             onClick={() => setShowTemplates(true)}
-            className="flex items-center gap-2 px-4 py-2 bg-white hover:bg-surface-200 text-white rounded-lg transition-colors"
+            className="flex items-center gap-2 px-4 py-2 bg-white hover:bg-surface-200 text-white rounded-lg transition-colors dark:bg-surface-900"
           >
             <FolderIcon className="w-4 h-4" />
             Templates
@@ -187,11 +187,11 @@ export default function ReportBuilderPage() {
       {isLoading ? (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           {[1, 2, 3].map((i) => (
-            <div key={i} className="h-40 bg-white rounded-xl animate-pulse" />
+            <div key={i} className="h-40 bg-white rounded-xl animate-pulse dark:bg-surface-900" />
           ))}
         </div>
       ) : reports.length === 0 ? (
-        <div className="text-center py-16 bg-white/50 rounded-xl border border-surface-200">
+        <div className="text-center py-16 bg-white/50 rounded-xl border border-surface-200 dark:bg-surface-900/50">
           <DocumentTextIcon className="w-12 h-12 text-surface-600 mx-auto mb-4" />
           <h3 className="text-lg font-medium text-white mb-2">No Custom Reports Yet</h3>
           <p className="text-surface-600 mb-4">
@@ -217,7 +217,7 @@ export default function ReportBuilderPage() {
           {reports.map((report) => (
             <div
               key={report.id}
-              className="p-5 bg-white rounded-xl border border-surface-200 hover:border-surface-300 transition-colors group"
+              className="p-5 bg-white rounded-xl border border-surface-200 hover:border-surface-300 transition-colors group dark:bg-surface-900"
             >
               <div className="flex items-start justify-between mb-3">
                 <div className="p-2 bg-brand-500/20 rounded-lg">
@@ -280,7 +280,7 @@ export default function ReportBuilderPage() {
               <button
                 key={i}
                 onClick={() => createFromTemplate(template)}
-                className="p-4 text-left bg-white hover:bg-surface-200 rounded-lg border border-surface-200 hover:border-surface-300 transition-colors"
+                className="p-4 text-left bg-white hover:bg-surface-200 rounded-lg border border-surface-200 hover:border-surface-300 transition-colors dark:bg-surface-900"
               >
                 <h4 className="font-medium text-white mb-1">{template.name}</h4>
                 <p className="text-sm text-surface-600">{template.description}</p>

--- a/frontend/src/pages/RiskConfiguration.tsx
+++ b/frontend/src/pages/RiskConfiguration.tsx
@@ -530,7 +530,9 @@ function ScoringMethodology({
 
           {/* Formula */}
           <div className="mb-6 p-4 bg-gray-900 dark:bg-white rounded-lg">
-            <p className="text-xs text-gray-400 mb-2 uppercase tracking-wider">Formula</p>
+            <p className="text-xs text-gray-400 mb-2 uppercase tracking-wider dark:text-surface-500">
+              Formula
+            </p>
             <pre className="text-emerald-600 font-mono text-sm whitespace-pre-wrap">
               {currentMethodology.formula}
             </pre>
@@ -664,11 +666,11 @@ function ScoringMethodology({
             calculation.
           </p>
           <div className="grid grid-cols-2 gap-4 text-sm">
-            <div className="p-3 bg-white/50 rounded-lg">
+            <div className="p-3 bg-white/50 rounded-lg dark:bg-surface-900/50">
               <p className="text-gray-500 dark:text-surface-600">Currency</p>
               <p className="text-gray-900 dark:text-white font-medium">USD ($)</p>
             </div>
-            <div className="p-3 bg-white/50 rounded-lg">
+            <div className="p-3 bg-white/50 rounded-lg dark:bg-surface-900/50">
               <p className="text-gray-500 dark:text-surface-600">Analysis Period</p>
               <p className="text-gray-900 dark:text-white font-medium">Annual (12 months)</p>
             </div>

--- a/frontend/src/pages/RiskDetail.tsx
+++ b/frontend/src/pages/RiskDetail.tsx
@@ -233,7 +233,7 @@ export default function RiskDetail() {
 
   const getRiskLevelColor = (level: string) => {
     const levelConfig = RISK_LEVELS.find((l) => l.value === level);
-    return levelConfig?.color || 'bg-gray-500';
+    return levelConfig?.color || 'bg-gray-500 dark:bg-surface-500';
   };
 
   const getStatusColor = (status: string) => {
@@ -344,7 +344,7 @@ export default function RiskDetail() {
       {/* Risk Overview */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Main Info */}
-        <div className="lg:col-span-2 bg-white rounded-xl border border-surface-200 p-6 space-y-6">
+        <div className="lg:col-span-2 bg-white rounded-xl border border-surface-200 p-6 space-y-6 dark:bg-surface-900">
           <div>
             <h3 className="text-sm font-medium text-surface-600 mb-2">Description</h3>
             <p className="text-surface-800">{risk.description}</p>
@@ -415,7 +415,7 @@ export default function RiskDetail() {
         {/* Risk Scoring */}
         <div className="space-y-4">
           {/* Qualitative */}
-          <div className="bg-white rounded-xl border border-surface-200 p-6">
+          <div className="bg-white rounded-xl border border-surface-200 p-6 dark:bg-surface-900">
             <h3 className="text-lg font-medium text-white mb-4">Risk Assessment</h3>
 
             <div className="space-y-4">
@@ -454,7 +454,7 @@ export default function RiskDetail() {
 
           {/* Quantitative */}
           {(risk.likelihoodPct !== undefined || risk.impactValue !== undefined) && (
-            <div className="bg-white rounded-xl border border-surface-200 p-6">
+            <div className="bg-white rounded-xl border border-surface-200 p-6 dark:bg-surface-900">
               <h3 className="text-lg font-medium text-white mb-4">Quantitative Analysis</h3>
               <div className="space-y-4">
                 {risk.likelihoodPct !== undefined && (
@@ -491,7 +491,7 @@ export default function RiskDetail() {
           )}
 
           {/* Quick Stats */}
-          <div className="bg-white rounded-xl border border-surface-200 p-6">
+          <div className="bg-white rounded-xl border border-surface-200 p-6 dark:bg-surface-900">
             <h3 className="text-lg font-medium text-white mb-4">Linked Items</h3>
             <div className="space-y-3">
               <div className="flex justify-between items-center">
@@ -521,7 +521,7 @@ export default function RiskDetail() {
       </div>
 
       {/* Tabs */}
-      <div className="bg-white rounded-xl border border-surface-200">
+      <div className="bg-white rounded-xl border border-surface-200 dark:bg-surface-900">
         {/* Tab Headers */}
         <div className="flex border-b border-surface-200">
           {[

--- a/frontend/src/pages/RiskHeatmap.tsx
+++ b/frontend/src/pages/RiskHeatmap.tsx
@@ -260,7 +260,7 @@ export default function RiskHeatmap() {
           </button>
 
           {showExportMenu && !isExporting && (
-            <div className="absolute right-0 mt-2 w-48 bg-white border border-surface-200 rounded-lg shadow-xl z-10">
+            <div className="absolute right-0 mt-2 w-48 bg-white border border-surface-200 rounded-lg shadow-xl z-10 dark:bg-surface-900">
               <button
                 onClick={exportToPNG}
                 className="w-full flex items-center gap-3 px-4 py-3 text-left text-surface-700 hover:bg-surface-200 transition-colors"
@@ -288,7 +288,7 @@ export default function RiskHeatmap() {
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Heatmap Grid */}
-        <div className="lg:col-span-2 bg-white rounded-xl border border-surface-200 p-6">
+        <div className="lg:col-span-2 bg-white rounded-xl border border-surface-200 p-6 dark:bg-surface-900">
           {isLoading ? (
             <div className="flex items-center justify-center h-96">
               <div className="text-surface-600">Loading heatmap...</div>
@@ -385,7 +385,7 @@ export default function RiskHeatmap() {
         {/* Sidebar */}
         <div className="space-y-6">
           {/* Selected Cell Details */}
-          <div className="bg-white rounded-xl border border-surface-200 p-6">
+          <div className="bg-white rounded-xl border border-surface-200 p-6 dark:bg-surface-900">
             <h3 className="text-lg font-medium text-white mb-4">
               {selectedCell ? 'Selected Risks' : 'Click a Cell'}
             </h3>
@@ -428,7 +428,7 @@ export default function RiskHeatmap() {
 
           {/* Stats */}
           {dashboard && (
-            <div className="bg-white rounded-xl border border-surface-200 p-6">
+            <div className="bg-white rounded-xl border border-surface-200 p-6 dark:bg-surface-900">
               <h3 className="text-lg font-medium text-white mb-4">Risk Distribution</h3>
               <div className="space-y-3">
                 {dashboard.byRiskLevel?.map((level: any) => {
@@ -465,7 +465,7 @@ export default function RiskHeatmap() {
 
           {/* Category Distribution */}
           {dashboard && (
-            <div className="bg-white rounded-xl border border-surface-200 p-6">
+            <div className="bg-white rounded-xl border border-surface-200 p-6 dark:bg-surface-900">
               <h3 className="text-lg font-medium text-white mb-4">By Category</h3>
               <div className="space-y-2">
                 {dashboard.byCategory?.map((cat: any) => (

--- a/frontend/src/pages/RiskQueue.tsx
+++ b/frontend/src/pages/RiskQueue.tsx
@@ -220,7 +220,7 @@ export default function RiskQueue() {
             className={`p-4 rounded-xl border transition-colors text-left ${
               activeTab === tab.key
                 ? 'bg-brand-500/20 border-brand-500'
-                : 'bg-white border-surface-200 hover:border-surface-300'
+                : 'bg-white border-surface-200 hover:border-surface-300 dark:bg-surface-900'
             }`}
           >
             <div className="flex items-center gap-3">
@@ -239,7 +239,7 @@ export default function RiskQueue() {
       </div>
 
       {/* Queue List */}
-      <div className="bg-white rounded-xl border border-surface-200">
+      <div className="bg-white rounded-xl border border-surface-200 dark:bg-surface-900">
         <div className="p-4 border-b border-surface-200">
           <h2 className="text-lg font-medium text-white">
             {tabs.find((t) => t.key === activeTab)?.label}
@@ -308,7 +308,7 @@ export default function RiskQueue() {
                                     ? 'bg-orange-500/20 text-orange-600'
                                     : task.priority === 'medium'
                                       ? 'bg-amber-500/20 text-amber-600'
-                                      : 'bg-gray-500/20 text-gray-400'
+                                      : 'bg-gray-500/20 text-gray-400 dark:bg-surface-500/20 dark:text-surface-500'
                               }`}
                             >
                               {task.priority}
@@ -434,7 +434,7 @@ export default function RiskQueue() {
       </div>
 
       {/* Tips Section */}
-      <div className="bg-white rounded-xl border border-surface-200 p-6">
+      <div className="bg-white rounded-xl border border-surface-200 p-6 dark:bg-surface-900">
         <h3 className="text-lg font-medium text-white mb-3">Queue Tips</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
           <div className="flex gap-3">

--- a/frontend/src/pages/RiskScenarios.tsx
+++ b/frontend/src/pages/RiskScenarios.tsx
@@ -606,7 +606,7 @@ export default function RiskScenarios() {
             </div>
 
             {simulationResult && (
-              <div className="bg-white rounded-lg p-6 border border-surface-200">
+              <div className="bg-white rounded-lg p-6 border border-surface-200 dark:bg-surface-900">
                 <h4 className="font-semibold text-foreground mb-4">Simulation Results</h4>
                 <div className="grid grid-cols-2 gap-6">
                   <div>

--- a/frontend/src/pages/Risks.tsx
+++ b/frontend/src/pages/Risks.tsx
@@ -354,7 +354,7 @@ export default function Risks() {
 
   const getRiskLevelColor = (level: string) => {
     const levelConfig = RISK_LEVELS.find((l) => l.value === level);
-    return levelConfig?.color || 'bg-gray-500';
+    return levelConfig?.color || 'bg-gray-500 dark:bg-surface-500';
   };
 
   const getStatusColor = (status: string) => {
@@ -461,7 +461,10 @@ export default function Risks() {
       {!dashboard ? (
         <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
           {[1, 2, 3, 4].map((i) => (
-            <SkeletonStatCard key={i} className="bg-white border border-surface-200" />
+            <SkeletonStatCard
+              key={i}
+              className="bg-white border border-surface-200 dark:bg-surface-900"
+            />
           ))}
         </div>
       ) : (
@@ -469,7 +472,7 @@ export default function Risks() {
           <button
             onClick={() => setStatFilter(statFilter === 'all' ? 'all' : 'all')}
             className={clsx(
-              'bg-white rounded-xl border p-4 text-left transition-all',
+              'bg-white rounded-xl border p-4 text-left transition-all dark:bg-surface-900',
               statFilter === 'all'
                 ? 'border-brand-500 ring-2 ring-brand-500'
                 : 'border-surface-200 hover:bg-surface-200/50 cursor-pointer'
@@ -491,7 +494,7 @@ export default function Risks() {
           <button
             onClick={() => setStatFilter(statFilter === 'open' ? 'all' : 'open')}
             className={clsx(
-              'bg-white rounded-xl border p-4 text-left transition-all',
+              'bg-white rounded-xl border p-4 text-left transition-all dark:bg-surface-900',
               statFilter === 'open'
                 ? 'border-red-500 ring-2 ring-red-500'
                 : 'border-surface-200 hover:bg-surface-200/50 cursor-pointer'
@@ -513,7 +516,7 @@ export default function Risks() {
           <button
             onClick={() => setStatFilter(statFilter === 'reviews_due' ? 'all' : 'reviews_due')}
             className={clsx(
-              'bg-white rounded-xl border p-4 text-left transition-all',
+              'bg-white rounded-xl border p-4 text-left transition-all dark:bg-surface-900',
               statFilter === 'reviews_due'
                 ? 'border-amber-500 ring-2 ring-amber-500'
                 : 'border-surface-200 hover:bg-surface-200/50 cursor-pointer'
@@ -537,7 +540,7 @@ export default function Risks() {
           <button
             onClick={() => setStatFilter(statFilter === 'mitigated' ? 'all' : 'mitigated')}
             className={clsx(
-              'bg-white rounded-xl border p-4 text-left transition-all',
+              'bg-white rounded-xl border p-4 text-left transition-all dark:bg-surface-900',
               statFilter === 'mitigated'
                 ? 'border-emerald-500 ring-2 ring-emerald-500'
                 : 'border-surface-200 hover:bg-surface-200/50 cursor-pointer'
@@ -586,7 +589,7 @@ export default function Risks() {
         </div>
       )}
       {/* Search and Filters */}
-      <div className="bg-white rounded-xl border border-surface-200 p-4">
+      <div className="bg-white rounded-xl border border-surface-200 p-4 dark:bg-surface-900">
         <div className="flex flex-col lg:flex-row gap-4">
           {/* Search */}
           <div className="flex-1 relative">
@@ -652,7 +655,7 @@ export default function Risks() {
         </div>
       </div>
       {/* Risks Table */}
-      <div className="bg-white rounded-xl border border-surface-200 overflow-hidden">
+      <div className="bg-white rounded-xl border border-surface-200 overflow-hidden dark:bg-surface-900">
         {isLoading ? (
           <SkeletonTable rows={8} columns={8} className="border-none shadow-none" />
         ) : data?.risks.length === 0 ? (

--- a/frontend/src/pages/RunbookDetail.tsx
+++ b/frontend/src/pages/RunbookDetail.tsx
@@ -455,7 +455,10 @@ export default function RunbookDetail() {
             {runbook!.steps && runbook!.steps.length > 0 ? (
               <div className="space-y-4">
                 {runbook!.steps.map((step, index) => (
-                  <div key={step.id} className="flex gap-4 p-4 bg-white rounded-lg">
+                  <div
+                    key={step.id}
+                    className="flex gap-4 p-4 bg-white rounded-lg dark:bg-surface-900"
+                  >
                     <div className="flex-shrink-0 w-8 h-8 bg-brand-500/20 text-brand-400 rounded-full flex items-center justify-center font-semibold">
                       {index + 1}
                     </div>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -391,7 +391,7 @@ function OrganizationSettings() {
             <div className="mt-2 flex items-start gap-4">
               {/* Current Logo Preview */}
               <div className="flex-shrink-0">
-                <div className="w-20 h-20 rounded-lg border border-surface-200 bg-white flex items-center justify-center overflow-hidden">
+                <div className="w-20 h-20 rounded-lg border border-surface-200 bg-white flex items-center justify-center overflow-hidden dark:bg-surface-900">
                   {logoUrl ? (
                     <img
                       src={safeLogoUrl()}
@@ -562,7 +562,7 @@ function OrganizationSettings() {
           />
         </div>
 
-        <div className="bg-white/60 rounded-lg p-4 space-y-2 text-sm text-surface-600">
+        <div className="bg-white/60 rounded-lg p-4 space-y-2 text-sm text-surface-600 dark:bg-surface-900/60">
           <p className="font-medium text-surface-800">What&apos;s included</p>
           <ul className="list-disc list-inside space-y-1">
             <li>Risk register data (using the full export endpoint)</li>
@@ -671,7 +671,7 @@ function MultiWorkspaceSettings() {
             } ${isToggling || isLoading ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
           >
             <span
-              className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+              className={`inline-block h-4 w-4 transform rounded-full bg-white dark:bg-surface-100 transition-transform ${
                 isMultiWorkspaceEnabled ? 'translate-x-6' : 'translate-x-1'
               }`}
             />
@@ -701,7 +701,7 @@ function MultiWorkspaceSettings() {
         )}
 
         {!isMultiWorkspaceEnabled && (
-          <div className="bg-white rounded-lg p-4 text-sm text-surface-600">
+          <div className="bg-white rounded-lg p-4 text-sm text-surface-600 dark:bg-surface-900">
             <p className="mb-2">Multi-workspace mode allows you to:</p>
             <ul className="list-disc list-inside space-y-1">
               <li>Track compliance progress separately for each product</li>
@@ -938,7 +938,7 @@ function CommunicationsSettings() {
             </div>
 
             {emailProvider === 'smtp' && (
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4 p-4 bg-white/50 rounded-lg">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4 p-4 bg-white/50 rounded-lg dark:bg-surface-900/50">
                 <div>
                   <label className="label">SMTP Host</label>
                   <Input
@@ -983,7 +983,7 @@ function CommunicationsSettings() {
             )}
 
             {emailProvider === 'sendgrid' && (
-              <div className="p-4 bg-white/50 rounded-lg">
+              <div className="p-4 bg-white/50 rounded-lg dark:bg-surface-900/50">
                 <label className="label">SendGrid API Key</label>
                 <Input
                   type="password"
@@ -996,7 +996,7 @@ function CommunicationsSettings() {
             )}
 
             {emailProvider === 'ses' && (
-              <div className="grid grid-cols-1 md:grid-cols-3 gap-4 p-4 bg-white/50 rounded-lg">
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4 p-4 bg-white/50 rounded-lg dark:bg-surface-900/50">
                 <div>
                   <label className="label">AWS Region</label>
                   <SelectNative
@@ -1081,7 +1081,7 @@ function CommunicationsSettings() {
               onChange={(e) => setSlackForm((f) => ({ ...f, enabled: e.target.checked }))}
               className="sr-only peer"
             />
-            <div className="w-11 h-6 bg-surface-200 peer-focus:ring-2 peer-focus:ring-brand-500 rounded-full peer peer-checked:after:translate-x-full after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-brand-600"></div>
+            <div className="w-11 h-6 bg-surface-200 peer-focus:ring-2 peer-focus:ring-brand-500 rounded-full peer peer-checked:after:translate-x-full after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-brand-600 dark:bg-surface-900"></div>
           </label>
         </div>
 
@@ -1266,7 +1266,7 @@ function ApiSettings() {
           {keys.map((key: ApiKey) => (
             <div
               key={key.id}
-              className="flex items-center justify-between p-4 bg-white/50 rounded-lg"
+              className="flex items-center justify-between p-4 bg-white/50 rounded-lg dark:bg-surface-900/50"
             >
               <div>
                 <div className="flex items-center gap-2">
@@ -1407,7 +1407,7 @@ function ApiSettings() {
                         setNewKeyScopes(newKeyScopes.filter((s) => s !== scope));
                       }
                     }}
-                    className="rounded border-surface-300 bg-white text-primary-500"
+                    className="rounded border-surface-300 bg-white text-primary-500 dark:bg-surface-900"
                   />
                   <span className="text-surface-700 text-sm">{scope}</span>
                 </label>
@@ -1440,7 +1440,7 @@ function ApiSettings() {
               Copy this key now. You won't be able to see it again!
             </p>
           </div>
-          <div className="bg-white rounded-lg p-4">
+          <div className="bg-white rounded-lg p-4 dark:bg-surface-900">
             <div className="flex items-center justify-between">
               <code className="text-green-600 text-sm break-all">{newKey.key}</code>
               <Button
@@ -1538,7 +1538,7 @@ function DashboardTemplatesSettings() {
             <div className="animate-spin w-6 h-6 border-2 border-surface-300 rounded-full border-t-brand-500" />
           </div>
         ) : templates?.length === 0 ? (
-          <div className="text-center py-12 bg-white/50 rounded-lg">
+          <div className="text-center py-12 bg-white/50 rounded-lg dark:bg-surface-900/50">
             <Squares2X2Icon className="w-12 h-12 mx-auto text-surface-500 mb-4" />
             <h3 className="text-surface-700 font-medium mb-2">No templates yet</h3>
             <p className="text-surface-500 text-sm mb-4">
@@ -1553,7 +1553,7 @@ function DashboardTemplatesSettings() {
             {templates?.map((template: any) => (
               <div
                 key={template.id}
-                className="flex items-center justify-between p-4 bg-white/50 rounded-lg hover:bg-white transition-colors"
+                className="flex items-center justify-between p-4 bg-white/50 rounded-lg hover:bg-white transition-colors dark:bg-surface-900/50 dark:hover:bg-surface-800"
               >
                 <div className="flex items-center gap-4">
                   <div className="p-2 bg-surface-200 rounded">
@@ -1574,7 +1574,7 @@ function DashboardTemplatesSettings() {
                   <Link
                     to={`/dashboards`}
                     state={{ editTemplate: template.id }}
-                    className="inline-flex items-center rounded-md border border-surface-300 bg-white px-3 h-8 text-small font-medium !text-surface-900 hover:bg-surface-100 transition-colors"
+                    className="inline-flex items-center rounded-md border border-surface-300 bg-white px-3 h-8 text-small font-medium !text-surface-900 hover:bg-surface-100 transition-colors dark:bg-surface-900"
                   >
                     <PencilIcon className="w-4 h-4 mr-1" /> Edit
                   </Link>
@@ -1968,7 +1968,7 @@ function EmployeeComplianceSettings() {
 
         <div className="space-y-4">
           {/* Background Check */}
-          <div className="p-4 bg-white/50 rounded-lg space-y-3">
+          <div className="p-4 bg-white/50 rounded-lg space-y-3 dark:bg-surface-900/50">
             <div className="flex items-center justify-between">
               <label className="text-surface-800 font-medium">Background Check</label>
               <label className="relative inline-flex items-center cursor-pointer">
@@ -1978,7 +1978,7 @@ function EmployeeComplianceSettings() {
                   onChange={(e) => updateRequirement('backgroundCheckRequired', e.target.checked)}
                   className="sr-only peer"
                 />
-                <div className="w-11 h-6 bg-surface-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-brand-500"></div>
+                <div className="w-11 h-6 bg-surface-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-brand-500 dark:bg-surface-900 dark:border-surface-700"></div>
               </label>
             </div>
             {config.requirements.backgroundCheckRequired && (
@@ -2003,7 +2003,7 @@ function EmployeeComplianceSettings() {
           </div>
 
           {/* Training */}
-          <div className="p-4 bg-white/50 rounded-lg space-y-3">
+          <div className="p-4 bg-white/50 rounded-lg space-y-3 dark:bg-surface-900/50">
             <div className="flex items-center justify-between">
               <label className="text-surface-800 font-medium">Training Completion</label>
               <label className="relative inline-flex items-center cursor-pointer">
@@ -2015,7 +2015,7 @@ function EmployeeComplianceSettings() {
                   }
                   className="sr-only peer"
                 />
-                <div className="w-11 h-6 bg-surface-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-brand-500"></div>
+                <div className="w-11 h-6 bg-surface-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-brand-500 dark:bg-surface-900 dark:border-surface-700"></div>
               </label>
             </div>
             {config.requirements.trainingCompletionRequired && (
@@ -2037,7 +2037,7 @@ function EmployeeComplianceSettings() {
           </div>
 
           {/* Attestation */}
-          <div className="p-4 bg-white/50 rounded-lg space-y-3">
+          <div className="p-4 bg-white/50 rounded-lg space-y-3 dark:bg-surface-900/50">
             <div className="flex items-center justify-between">
               <label className="text-surface-800 font-medium">Policy Attestation</label>
               <label className="relative inline-flex items-center cursor-pointer">
@@ -2047,7 +2047,7 @@ function EmployeeComplianceSettings() {
                   onChange={(e) => updateRequirement('attestationRequired', e.target.checked)}
                   className="sr-only peer"
                 />
-                <div className="w-11 h-6 bg-surface-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-brand-500"></div>
+                <div className="w-11 h-6 bg-surface-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-brand-500 dark:bg-surface-900 dark:border-surface-700"></div>
               </label>
             </div>
             {config.requirements.attestationRequired && (
@@ -2069,7 +2069,7 @@ function EmployeeComplianceSettings() {
           </div>
 
           {/* MFA */}
-          <div className="p-4 bg-white/50 rounded-lg">
+          <div className="p-4 bg-white/50 rounded-lg dark:bg-surface-900/50">
             <div className="flex items-center justify-between">
               <div>
                 <label className="text-surface-800 font-medium">MFA Required</label>
@@ -2084,7 +2084,7 @@ function EmployeeComplianceSettings() {
                   onChange={(e) => updateRequirement('mfaRequired', e.target.checked)}
                   className="sr-only peer"
                 />
-                <div className="w-11 h-6 bg-surface-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-brand-500"></div>
+                <div className="w-11 h-6 bg-surface-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-brand-500 dark:bg-surface-900 dark:border-surface-700"></div>
               </label>
             </div>
           </div>
@@ -2103,7 +2103,7 @@ function EmployeeComplianceSettings() {
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
           <Link
             to="/integrations?search=HR%20Tools"
-            className="p-3 bg-white/50 rounded-lg hover:bg-surface-200/50 hover:border-brand-500/50 border border-transparent transition-all cursor-pointer group"
+            className="p-3 bg-white/50 rounded-lg hover:bg-surface-200/50 hover:border-brand-500/50 border border-transparent transition-all cursor-pointer group dark:bg-surface-900/50"
           >
             <p className="text-surface-600 text-xs uppercase tracking-wider mb-1 group-hover:text-brand-400">
               HRIS / Employee List
@@ -2115,7 +2115,7 @@ function EmployeeComplianceSettings() {
           </Link>
           <Link
             to="/integrations?search=Background%20Check"
-            className="p-3 bg-white/50 rounded-lg hover:bg-surface-200/50 hover:border-brand-500/50 border border-transparent transition-all cursor-pointer group"
+            className="p-3 bg-white/50 rounded-lg hover:bg-surface-200/50 hover:border-brand-500/50 border border-transparent transition-all cursor-pointer group dark:bg-surface-900/50"
           >
             <p className="text-surface-600 text-xs uppercase tracking-wider mb-1 group-hover:text-brand-400">
               Background Check
@@ -2127,7 +2127,7 @@ function EmployeeComplianceSettings() {
           </Link>
           <Link
             to="/integrations?search=Security%20Awareness"
-            className="p-3 bg-white/50 rounded-lg hover:bg-surface-200/50 hover:border-brand-500/50 border border-transparent transition-all cursor-pointer group"
+            className="p-3 bg-white/50 rounded-lg hover:bg-surface-200/50 hover:border-brand-500/50 border border-transparent transition-all cursor-pointer group dark:bg-surface-900/50"
           >
             <p className="text-surface-600 text-xs uppercase tracking-wider mb-1 group-hover:text-brand-400">
               Training / LMS
@@ -2139,7 +2139,7 @@ function EmployeeComplianceSettings() {
           </Link>
           <Link
             to="/integrations?search=MDM"
-            className="p-3 bg-white/50 rounded-lg hover:bg-surface-200/50 hover:border-brand-500/50 border border-transparent transition-all cursor-pointer group"
+            className="p-3 bg-white/50 rounded-lg hover:bg-surface-200/50 hover:border-brand-500/50 border border-transparent transition-all cursor-pointer group dark:bg-surface-900/50"
           >
             <p className="text-surface-600 text-xs uppercase tracking-wider mb-1 group-hover:text-brand-400">
               MDM / Device
@@ -2151,7 +2151,7 @@ function EmployeeComplianceSettings() {
           </Link>
           <Link
             to="/integrations?search=Identity%20Provider"
-            className="p-3 bg-white/50 rounded-lg hover:bg-surface-200/50 hover:border-brand-500/50 border border-transparent transition-all cursor-pointer group"
+            className="p-3 bg-white/50 rounded-lg hover:bg-surface-200/50 hover:border-brand-500/50 border border-transparent transition-all cursor-pointer group dark:bg-surface-900/50"
           >
             <p className="text-surface-600 text-xs uppercase tracking-wider mb-1 group-hover:text-brand-400">
               Identity Provider
@@ -2343,7 +2343,7 @@ function AISettings() {
           ].map((feature) => (
             <div
               key={feature.key}
-              className="flex items-center justify-between p-3 bg-white/50 rounded-lg"
+              className="flex items-center justify-between p-3 bg-white/50 rounded-lg dark:bg-surface-900/50"
             >
               <div>
                 <p className="text-surface-800 font-medium">{feature.name}</p>
@@ -2357,7 +2357,7 @@ function AISettings() {
                   disabled={aiProvider === 'disabled'}
                   className="sr-only peer"
                 />
-                <div className="w-11 h-6 bg-surface-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-brand-500 peer-disabled:opacity-50"></div>
+                <div className="w-11 h-6 bg-surface-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-brand-500 peer-disabled:opacity-50 dark:bg-surface-900 dark:border-surface-700"></div>
               </label>
             </div>
           ))}

--- a/frontend/src/pages/TPRMConfiguration.tsx
+++ b/frontend/src/pages/TPRMConfiguration.tsx
@@ -158,7 +158,7 @@ export default function TPRMConfiguration() {
       </div>
 
       {/* Tab Content */}
-      <div className="bg-white rounded-xl border border-surface-200 p-6">
+      <div className="bg-white rounded-xl border border-surface-200 p-6 dark:bg-surface-900">
         {activeTab === 'tiers' && config && referenceData && (
           <TierFrequencyTab
             config={config}
@@ -416,7 +416,10 @@ function TierFrequencyTab({
             const freq = tierMapping[tier.key as keyof typeof tierMapping];
             const months = parseFrequencyToMonths(freq);
             return (
-              <div key={tier.key} className="text-center p-3 bg-white rounded-lg">
+              <div
+                key={tier.key}
+                className="text-center p-3 bg-white rounded-lg dark:bg-surface-900"
+              >
                 <p className="text-surface-600 text-xs mb-1">{tier.label}</p>
                 <p className="text-white font-medium">{formatFrequencyLabel(freq)}</p>
                 <p className="text-surface-500 text-xs mt-1">
@@ -880,7 +883,7 @@ function FeatureSettingsTab({
                   onChange={(e) => handleChange(feature.key, e.target.checked)}
                   className="sr-only peer"
                 />
-                <div className="w-11 h-6 bg-surface-600 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-brand-500 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-brand-500"></div>
+                <div className="w-11 h-6 bg-surface-600 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-brand-500 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-brand-500 dark:bg-surface-900 dark:border-surface-700"></div>
               </label>
             </div>
           </div>

--- a/frontend/src/pages/TestProcedures.tsx
+++ b/frontend/src/pages/TestProcedures.tsx
@@ -183,21 +183,21 @@ export default function TestProcedures() {
       {/* Stats */}
       {stats && (
         <div className="grid grid-cols-4 gap-4">
-          <div className="bg-white rounded-lg p-4 border border-surface-200">
+          <div className="bg-white rounded-lg p-4 border border-surface-200 dark:bg-surface-900">
             <p className="text-surface-600 text-sm">Total Procedures</p>
             <p className="text-3xl font-bold text-white">{stats.total}</p>
           </div>
-          <div className="bg-white rounded-lg p-4 border border-surface-200">
+          <div className="bg-white rounded-lg p-4 border border-surface-200 dark:bg-surface-900">
             <p className="text-surface-600 text-sm">Effectiveness Rate</p>
             <p className="text-3xl font-bold text-green-600">{stats.effectivenessRate}%</p>
           </div>
-          <div className="bg-white rounded-lg p-4 border border-surface-200">
+          <div className="bg-white rounded-lg p-4 border border-surface-200 dark:bg-surface-900">
             <p className="text-surface-600 text-sm">Completed</p>
             <p className="text-3xl font-bold text-white">
               {stats.byStatus.find((s) => s.status === 'completed')?.count || 0}
             </p>
           </div>
-          <div className="bg-white rounded-lg p-4 border border-surface-200">
+          <div className="bg-white rounded-lg p-4 border border-surface-200 dark:bg-surface-900">
             <p className="text-surface-600 text-sm">Pending</p>
             <p className="text-3xl font-bold text-yellow-600">
               {stats.byStatus.find((s) => s.status === 'pending')?.count || 0}
@@ -209,7 +209,7 @@ export default function TestProcedures() {
       {isLoading ? (
         <div className="animate-pulse space-y-4">
           {[1, 2, 3].map((i) => (
-            <div key={i} className="bg-white rounded-lg h-24" />
+            <div key={i} className="bg-white rounded-lg h-24 dark:bg-surface-900" />
           ))}
         </div>
       ) : (
@@ -219,7 +219,10 @@ export default function TestProcedures() {
             const isRecording = recordingId === proc.id;
 
             return (
-              <div key={proc.id} className="bg-white rounded-lg border border-surface-200 p-4">
+              <div
+                key={proc.id}
+                className="bg-white rounded-lg border border-surface-200 p-4 dark:bg-surface-900"
+              >
                 <div className="flex items-start justify-between">
                   <div className="flex items-start gap-4">
                     <div className="p-2 bg-brand-500/10 rounded-lg">
@@ -270,7 +273,7 @@ export default function TestProcedures() {
                           onChange={(e) =>
                             setResultForm({ ...resultForm, actualResult: e.target.value })
                           }
-                          className="w-full bg-white border border-surface-300 rounded-lg px-3 py-2 text-white"
+                          className="w-full bg-white border border-surface-300 rounded-lg px-3 py-2 text-white dark:bg-surface-900"
                           rows={3}
                         />
                       </div>
@@ -283,7 +286,7 @@ export default function TestProcedures() {
                           onChange={(e) =>
                             setResultForm({ ...resultForm, deviationsNoted: e.target.value })
                           }
-                          className="w-full bg-white border border-surface-300 rounded-lg px-3 py-2 text-white"
+                          className="w-full bg-white border border-surface-300 rounded-lg px-3 py-2 text-white dark:bg-surface-900"
                           rows={3}
                         />
                       </div>
@@ -298,7 +301,7 @@ export default function TestProcedures() {
                           onChange={(e) =>
                             setResultForm({ ...resultForm, conclusion: e.target.value })
                           }
-                          className="w-full bg-white border border-surface-300 rounded-lg px-3 py-2 text-white"
+                          className="w-full bg-white border border-surface-300 rounded-lg px-3 py-2 text-white dark:bg-surface-900"
                         >
                           <option value="effective">Effective</option>
                           <option value="partially_effective">Partially Effective</option>
@@ -316,7 +319,7 @@ export default function TestProcedures() {
                           onChange={(e) =>
                             setResultForm({ ...resultForm, conclusionRationale: e.target.value })
                           }
-                          className="w-full bg-white border border-surface-300 rounded-lg px-3 py-2 text-white"
+                          className="w-full bg-white border border-surface-300 rounded-lg px-3 py-2 text-white dark:bg-surface-900"
                         />
                       </div>
                     </div>
@@ -333,7 +336,7 @@ export default function TestProcedures() {
           })}
 
           {procedures.length === 0 && (
-            <div className="text-center py-12 bg-white rounded-lg border border-surface-200">
+            <div className="text-center py-12 bg-white rounded-lg border border-surface-200 dark:bg-surface-900">
               <BeakerIcon className="h-12 w-12 text-surface-500 mx-auto mb-4" />
               <h3 className="text-lg font-medium text-white">No test procedures yet</h3>
               <p className="text-surface-600 mt-2">

--- a/frontend/src/pages/TrainingAdmin.tsx
+++ b/frontend/src/pages/TrainingAdmin.tsx
@@ -493,7 +493,7 @@ function CampaignsTab({
                       className={`px-2 py-0.5 rounded text-xs font-medium ${
                         campaign.isActive
                           ? 'bg-emerald-500/10 text-emerald-500'
-                          : 'bg-gray-500/10 text-gray-500'
+                          : 'bg-gray-500/10 text-gray-500 dark:bg-surface-500/10 dark:text-surface-400'
                       }`}
                     >
                       {campaign.isActive ? 'Active' : 'Inactive'}
@@ -674,7 +674,7 @@ function ModulesTab({
                       className={`px-2 py-0.5 rounded text-xs font-medium ${
                         module.isActive
                           ? 'bg-emerald-500/10 text-emerald-500'
-                          : 'bg-gray-500/10 text-gray-500'
+                          : 'bg-gray-500/10 text-gray-500 dark:bg-surface-500/10 dark:text-surface-400'
                       }`}
                     >
                       {module.isActive ? 'Active' : 'Inactive'}
@@ -798,8 +798,8 @@ function StatsTab({ orgStats }: { orgStats: any }) {
   if (!orgStats) {
     return (
       <div className="text-center py-12">
-        <ChartBarIcon className="w-12 h-12 mx-auto text-gray-400" />
-        <p className="mt-4 text-gray-500">Loading statistics...</p>
+        <ChartBarIcon className="w-12 h-12 mx-auto text-gray-400 dark:text-surface-500" />
+        <p className="mt-4 text-gray-500 dark:text-surface-400">Loading statistics...</p>
       </div>
     );
   }
@@ -998,11 +998,11 @@ function CampaignModal({
                   type="checkbox"
                   checked={formData.moduleIds.includes(module.id)}
                   onChange={() => toggleModule(module.id)}
-                  className="rounded border-gray-300 text-brand-500 focus:ring-brand-500"
+                  className="rounded border-gray-300 text-brand-500 focus:ring-brand-500 dark:border-surface-700"
                 />
                 <span className="text-sm text-gray-900 dark:text-white">{module.name}</span>
                 {'isBuiltIn' in module && module.isBuiltIn && (
-                  <span className="text-xs text-gray-400">(Built-in)</span>
+                  <span className="text-xs text-gray-400 dark:text-surface-500">(Built-in)</span>
                 )}
               </label>
             ))}
@@ -1020,7 +1020,7 @@ function CampaignModal({
                 type="checkbox"
                 checked={formData.targetGroups.includes('all')}
                 onChange={() => toggleRole('all')}
-                className="rounded border-gray-300 text-brand-500 focus:ring-brand-500"
+                className="rounded border-gray-300 text-brand-500 focus:ring-brand-500 dark:border-surface-700"
               />
               <span className="text-sm text-gray-900 dark:text-white">All Users</span>
             </label>
@@ -1034,7 +1034,7 @@ function CampaignModal({
                   checked={formData.targetGroups.includes(role.id)}
                   onChange={() => toggleRole(role.id)}
                   disabled={formData.targetGroups.includes('all')}
-                  className="rounded border-gray-300 text-brand-500 focus:ring-brand-500"
+                  className="rounded border-gray-300 text-brand-500 focus:ring-brand-500 dark:border-surface-700"
                 />
                 <span className="text-sm text-gray-900 dark:text-white">{role.label}</span>
               </label>
@@ -1075,7 +1075,7 @@ function CampaignModal({
             type="checkbox"
             checked={formData.isActive}
             onChange={(e) => setFormData({ ...formData, isActive: e.target.checked })}
-            className="rounded border-gray-300 text-brand-500 focus:ring-brand-500"
+            className="rounded border-gray-300 text-brand-500 focus:ring-brand-500 dark:border-surface-700"
           />
           <span className="text-sm text-gray-900 dark:text-white">Campaign is active</span>
         </label>
@@ -1239,7 +1239,7 @@ function ModuleModal({ module, onClose }: { module: CustomModule | null; onClose
             type="checkbox"
             checked={formData.isActive}
             onChange={(e) => setFormData({ ...formData, isActive: e.target.checked })}
-            className="rounded border-gray-300 text-brand-500 focus:ring-brand-500"
+            className="rounded border-gray-300 text-brand-500 focus:ring-brand-500 dark:border-surface-700"
           />
           <span className="text-sm text-gray-900 dark:text-white">Module is active</span>
         </label>
@@ -1351,7 +1351,10 @@ function UploadScormModal({ moduleId, onClose }: { moduleId: string; onClose: ()
                 {(file.size / 1024 / 1024).toFixed(2)} MB
               </p>
             </div>
-            <button onClick={() => setFile(null)} className="text-gray-400 hover:text-gray-600">
+            <button
+              onClick={() => setFile(null)}
+              className="text-gray-400 hover:text-gray-600 dark:text-surface-500"
+            >
               <XMarkIcon className="w-5 h-5" />
             </button>
           </div>
@@ -1716,7 +1719,7 @@ function UploadNewScormModal({ onClose }: { onClose: () => void }) {
               type="checkbox"
               checked={formData.isActive}
               onChange={(e) => setFormData({ ...formData, isActive: e.target.checked })}
-              className="rounded border-gray-300 text-brand-500 focus:ring-brand-500"
+              className="rounded border-gray-300 text-brand-500 focus:ring-brand-500 dark:border-surface-700"
             />
             <span className="text-sm text-gray-900 dark:text-white">
               Module is active and available for campaigns

--- a/frontend/src/pages/TrustAnalytics.tsx
+++ b/frontend/src/pages/TrustAnalytics.tsx
@@ -51,12 +51,12 @@ export default function TrustAnalytics() {
         <div className="h-8 bg-surface-200 rounded w-48 animate-pulse" />
         <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
           {[1, 2, 3, 4].map((i) => (
-            <div key={i} className="h-32 bg-white rounded-xl animate-pulse" />
+            <div key={i} className="h-32 bg-white rounded-xl animate-pulse dark:bg-surface-900" />
           ))}
         </div>
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-          <div className="h-80 bg-white rounded-xl animate-pulse" />
-          <div className="h-80 bg-white rounded-xl animate-pulse" />
+          <div className="h-80 bg-white rounded-xl animate-pulse dark:bg-surface-900" />
+          <div className="h-80 bg-white rounded-xl animate-pulse dark:bg-surface-900" />
         </div>
       </div>
     );
@@ -131,7 +131,7 @@ export default function TrustAnalytics() {
       {/* Charts Row */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Questions by Status */}
-        <div className="bg-white border border-surface-200 rounded-xl p-6">
+        <div className="bg-white border border-surface-200 rounded-xl p-6 dark:bg-surface-900">
           <h3 className="text-lg font-semibold text-surface-900 mb-4">Questions by Status</h3>
           <LazyRechartsWrapper height={250}>
             {(Recharts) =>
@@ -185,7 +185,7 @@ export default function TrustAnalytics() {
         </div>
 
         {/* Questionnaires by Priority */}
-        <div className="bg-white border border-surface-200 rounded-xl p-6">
+        <div className="bg-white border border-surface-200 rounded-xl p-6 dark:bg-surface-900">
           <h3 className="text-lg font-semibold text-surface-900 mb-4">
             Questionnaires by Priority
           </h3>
@@ -231,7 +231,7 @@ export default function TrustAnalytics() {
       {/* Response Time & Completion Trend */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Average Response Time by Priority */}
-        <div className="bg-white border border-surface-200 rounded-xl p-6">
+        <div className="bg-white border border-surface-200 rounded-xl p-6 dark:bg-surface-900">
           <div className="flex items-center gap-2 mb-4">
             <ClockIcon className="w-5 h-5 text-surface-600" />
             <h3 className="text-lg font-semibold text-surface-900">Average Response Time</h3>
@@ -258,7 +258,7 @@ export default function TrustAnalytics() {
         </div>
 
         {/* Completion Trend */}
-        <div className="bg-white border border-surface-200 rounded-xl p-6">
+        <div className="bg-white border border-surface-200 rounded-xl p-6 dark:bg-surface-900">
           <div className="flex items-center gap-2 mb-4">
             <ArrowTrendingUpIcon className="w-5 h-5 text-surface-600" />
             <h3 className="text-lg font-semibold text-surface-900">Completion Trend</h3>
@@ -313,7 +313,7 @@ export default function TrustAnalytics() {
       </div>
 
       {/* Top Knowledge Base Entries */}
-      <div className="bg-white border border-surface-200 rounded-xl p-6">
+      <div className="bg-white border border-surface-200 rounded-xl p-6 dark:bg-surface-900">
         <div className="flex items-center gap-2 mb-4">
           <BookOpenIcon className="w-5 h-5 text-surface-600" />
           <h3 className="text-lg font-semibold text-surface-900">
@@ -379,7 +379,7 @@ function StatCard({
   };
 
   return (
-    <div className="bg-white border border-surface-200 rounded-xl p-5">
+    <div className="bg-white border border-surface-200 rounded-xl p-5 dark:bg-surface-900">
       <div className="flex items-center gap-3 mb-3">
         <div className={clsx('p-2 rounded-lg', colorClasses[color])}>
           <Icon className="w-5 h-5" />

--- a/frontend/src/pages/TrustCenter.tsx
+++ b/frontend/src/pages/TrustCenter.tsx
@@ -275,7 +275,7 @@ export default function TrustCenter() {
                   className={`flex items-center gap-2 px-5 py-4 text-sm font-medium border-b-2 transition-colors whitespace-nowrap ${
                     activeSection === section.id
                       ? 'border-brand-500 text-brand-400 bg-white dark:bg-white/50'
-                      : 'border-transparent text-gray-500 dark:text-surface-600 hover:text-gray-600 dark:text-surface-700 hover:bg-white dark:bg-white/30'
+                      : 'border-transparent text-gray-500 dark:text-surface-600 hover:text-gray-600 dark:text-surface-700 hover:bg-white dark:bg-white/30 dark:hover:bg-surface-800'
                   }`}
                 >
                   <Icon className="w-5 h-5" />
@@ -546,7 +546,7 @@ function PreviewModal({ config, contents, onClose }: PreviewModalProps) {
       {/* Close Button */}
       <button
         onClick={onClose}
-        className="sticky top-4 right-4 float-right z-10 p-2 bg-gray-800 text-gray-900 dark:text-white rounded-full hover:bg-gray-700 transition-colors m-4"
+        className="sticky top-4 right-4 float-right z-10 p-2 bg-gray-800 text-gray-900 dark:text-white rounded-full hover:bg-gray-700 transition-colors m-4 dark:bg-surface-200 dark:hover:bg-surface-300"
       >
         <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path
@@ -577,7 +577,9 @@ function PreviewModal({ config, contents, onClose }: PreviewModalProps) {
             {config.companyName} Trust Center
           </h1>
           {config.description && (
-            <p className="text-lg text-gray-600 max-w-2xl mx-auto">{config.description}</p>
+            <p className="text-lg text-gray-600 max-w-2xl mx-auto dark:text-surface-300">
+              {config.description}
+            </p>
           )}
         </div>
 
@@ -606,9 +608,9 @@ function PreviewModal({ config, contents, onClose }: PreviewModalProps) {
                 </h2>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   {sectionContents.map((content) => (
-                    <div key={content.id} className="bg-gray-50 p-5 rounded-lg">
+                    <div key={content.id} className="bg-gray-50 p-5 rounded-lg dark:bg-surface-900">
                       <h3 className="text-lg font-semibold mb-2">{content.title}</h3>
-                      <p className="text-gray-600">{content.content}</p>
+                      <p className="text-gray-600 dark:text-surface-300">{content.content}</p>
                     </div>
                   ))}
                 </div>
@@ -620,15 +622,19 @@ function PreviewModal({ config, contents, onClose }: PreviewModalProps) {
         {/* Empty State */}
         {publishedContents.length === 0 && (
           <div className="text-center py-16">
-            <GlobeAltIcon className="w-16 h-16 text-gray-300 mx-auto mb-4" />
-            <h3 className="text-xl font-semibold text-gray-500 mb-2">No Published Content</h3>
-            <p className="text-gray-400">Add and publish content to see it here</p>
+            <GlobeAltIcon className="w-16 h-16 text-gray-300 mx-auto mb-4 dark:text-surface-700" />
+            <h3 className="text-xl font-semibold text-gray-500 mb-2 dark:text-surface-400">
+              No Published Content
+            </h3>
+            <p className="text-gray-400 dark:text-surface-500">
+              Add and publish content to see it here
+            </p>
           </div>
         )}
 
         {/* Footer */}
-        <footer className="text-center pt-8 mt-12 border-t border-gray-200">
-          <p className="text-gray-400 text-sm">
+        <footer className="text-center pt-8 mt-12 border-t border-gray-200 dark:border-surface-800">
+          <p className="text-gray-400 text-sm dark:text-surface-500">
             © {new Date().getFullYear()} {config.companyName}. All rights reserved.
           </p>
         </footer>

--- a/frontend/src/pages/TrustCenterSettings.tsx
+++ b/frontend/src/pages/TrustCenterSettings.tsx
@@ -122,13 +122,13 @@ export default function TrustCenterSettings() {
               onChange={(e) => updateConfig({ isEnabled: e.target.checked })}
               className="sr-only peer"
             />
-            <div className="w-14 h-7 bg-surface-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-6 after:w-6 after:transition-all peer-checked:bg-green-600"></div>
+            <div className="w-14 h-7 bg-surface-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-6 after:w-6 after:transition-all peer-checked:bg-green-600 dark:bg-surface-900"></div>
           </label>
         </div>
       </div>
 
       {/* Tabs */}
-      <div className="bg-white border border-surface-200 rounded-lg overflow-hidden">
+      <div className="bg-white border border-surface-200 rounded-lg overflow-hidden dark:bg-surface-900">
         <div className="border-b border-surface-200">
           <nav className="flex">
             {tabs.map((tab) => {
@@ -139,8 +139,8 @@ export default function TrustCenterSettings() {
                   onClick={() => setActiveTab(tab.id)}
                   className={`flex items-center gap-2 px-6 py-4 text-sm font-medium border-b-2 transition-colors ${
                     activeTab === tab.id
-                      ? 'border-brand-500 text-brand-400 bg-white/50'
-                      : 'border-transparent text-surface-600 hover:text-surface-700 hover:bg-white/30'
+                      ? 'border-brand-500 text-brand-400 bg-white/50 dark:bg-surface-900/50'
+                      : 'border-transparent text-surface-600 hover:text-surface-700 hover:bg-white/30 dark:bg-surface-900/30 dark:hover:bg-surface-800/30'
                   }`}
                 >
                   <Icon className="w-5 h-5" />
@@ -161,7 +161,7 @@ export default function TrustCenterSettings() {
 
       {/* Save indicator */}
       {saving && (
-        <div className="fixed bottom-4 right-4 bg-white text-surface-800 px-4 py-2 rounded-lg shadow-lg">
+        <div className="fixed bottom-4 right-4 bg-white text-surface-800 px-4 py-2 rounded-lg shadow-lg dark:bg-surface-900">
           Saving...
         </div>
       )}
@@ -190,7 +190,7 @@ function GeneralSettings({
               type="email"
               value={config.securityEmail || ''}
               onChange={(e) => onUpdate({ securityEmail: e.target.value })}
-              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               placeholder="security@company.com"
             />
             <p className="text-xs text-surface-500 mt-1">Public email for security inquiries</p>
@@ -201,7 +201,7 @@ function GeneralSettings({
               type="url"
               value={config.supportUrl || ''}
               onChange={(e) => onUpdate({ supportUrl: e.target.value })}
-              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               placeholder="https://support.company.com"
             />
             <p className="text-xs text-surface-500 mt-1">Link to your support portal</p>
@@ -235,13 +235,13 @@ function GeneralSettings({
           ].map((section) => (
             <label
               key={section.key}
-              className="flex items-start gap-3 p-3 bg-white/50 rounded-lg cursor-pointer hover:bg-white transition-colors"
+              className="flex items-start gap-3 p-3 bg-white/50 rounded-lg cursor-pointer hover:bg-white transition-colors dark:bg-surface-900/50 dark:hover:bg-surface-800"
             >
               <input
                 type="checkbox"
                 checked={config[section.key as keyof TrustCenterConfig] as boolean}
                 onChange={(e) => onUpdate({ [section.key]: e.target.checked })}
-                className="mt-1 w-4 h-4 bg-white border-surface-200 rounded text-brand-600 focus:ring-brand-500"
+                className="mt-1 w-4 h-4 bg-white border-surface-200 rounded text-brand-600 focus:ring-brand-500 dark:bg-surface-900"
               />
               <div>
                 <span className="text-sm font-medium text-surface-800">{section.label}</span>
@@ -294,7 +294,7 @@ function BrandingSettings({
               type="text"
               value={config.companyName}
               onChange={(e) => onUpdate({ companyName: e.target.value })}
-              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               placeholder="Your Company Name"
             />
           </div>
@@ -306,7 +306,7 @@ function BrandingSettings({
               value={config.description || ''}
               onChange={(e) => onUpdate({ description: e.target.value })}
               rows={3}
-              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               placeholder="Describe your security posture and commitment to security..."
             />
             <p className="text-xs text-surface-500 mt-1">
@@ -324,7 +324,7 @@ function BrandingSettings({
               type="url"
               value={config.logoUrl || ''}
               onChange={(e) => onUpdate({ logoUrl: e.target.value })}
-              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               placeholder="https://example.com/logo.png"
             />
             <p className="text-xs text-surface-500 mt-1">Recommended: 200x50px, PNG or SVG</p>
@@ -336,13 +336,13 @@ function BrandingSettings({
                 type="color"
                 value={config.primaryColor || '#6366f1'}
                 onChange={(e) => onUpdate({ primaryColor: e.target.value })}
-                className="w-12 h-10 bg-white border border-surface-200 rounded-lg cursor-pointer"
+                className="w-12 h-10 bg-white border border-surface-200 rounded-lg cursor-pointer dark:bg-surface-900"
               />
               <Input
                 type="text"
                 value={config.primaryColor || '#6366f1'}
                 onChange={(e) => onUpdate({ primaryColor: e.target.value })}
-                className="flex-1 px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="flex-1 px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
                 placeholder="#6366f1"
               />
             </div>
@@ -353,7 +353,7 @@ function BrandingSettings({
       {/* Preview */}
       <div className="pt-6 border-t border-surface-200">
         <h3 className="text-lg font-medium text-surface-900 mb-4">Preview</h3>
-        <div className="bg-white rounded-lg p-8 text-center">
+        <div className="bg-white rounded-lg p-8 text-center dark:bg-surface-900">
           {config.logoUrl && (
             <img src={config.logoUrl} alt={config.companyName} className="h-12 mx-auto mb-4" />
           )}
@@ -364,7 +364,9 @@ function BrandingSettings({
             {config.companyName} Trust Center
           </h2>
           {config.description && (
-            <p className="text-gray-600 max-w-xl mx-auto">{config.description}</p>
+            <p className="text-gray-600 max-w-xl mx-auto dark:text-surface-300">
+              {config.description}
+            </p>
           )}
         </div>
       </div>
@@ -404,7 +406,7 @@ function DomainSettings({
                 type="text"
                 value={domainInput}
                 onChange={(e) => setDomainInput(e.target.value)}
-                className="flex-1 px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="flex-1 px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
                 placeholder="trust.yourcompany.com"
               />
               <button
@@ -421,7 +423,7 @@ function DomainSettings({
         </div>
       </div>
       {config.customDomain && (
-        <div className="bg-white/50 rounded-lg p-6 border border-surface-200">
+        <div className="bg-white/50 rounded-lg p-6 border border-surface-200 dark:bg-surface-900/50">
           <h4 className="text-md font-medium text-surface-800 mb-4 flex items-center gap-2">
             <LinkIcon className="w-5 h-5 text-brand-400" />
             DNS Configuration Required
@@ -445,7 +447,7 @@ function DomainSettings({
               </span>
               <div>
                 <p className="text-surface-800">Add a CNAME record with these values:</p>
-                <div className="mt-2 bg-white rounded-lg p-4 space-y-2">
+                <div className="mt-2 bg-white rounded-lg p-4 space-y-2 dark:bg-surface-900">
                   <div className="flex justify-between">
                     <span className="text-surface-600">Type:</span>
                     <code className="text-brand-400">CNAME</code>
@@ -506,7 +508,7 @@ function DomainSettings({
         </div>
       )}
       {!config.customDomain && (
-        <div className="bg-white/30 rounded-lg p-6 border border-dashed border-surface-200 text-center">
+        <div className="bg-white/30 rounded-lg p-6 border border-dashed border-surface-200 text-center dark:bg-surface-900/30">
           <LinkIcon className="w-12 h-12 text-surface-600 mx-auto mb-3" />
           <p className="text-surface-600">Enter a custom domain above to see setup instructions</p>
         </div>
@@ -562,7 +564,7 @@ function EmbedSettings({ config }: { config: TrustCenterConfig }) {
           Embed your complete Trust Center on any webpage
         </p>
         <div className="relative">
-          <pre className="p-4 bg-white rounded-lg text-sm text-surface-700 overflow-x-auto">
+          <pre className="p-4 bg-white rounded-lg text-sm text-surface-700 overflow-x-auto dark:bg-surface-900">
             {iframeCode}
           </pre>
           <button
@@ -584,7 +586,7 @@ function EmbedSettings({ config }: { config: TrustCenterConfig }) {
           Add a branded button that links to your Trust Center
         </p>
         <div className="relative">
-          <pre className="p-4 bg-white rounded-lg text-sm text-surface-700 overflow-x-auto">
+          <pre className="p-4 bg-white rounded-lg text-sm text-surface-700 overflow-x-auto dark:bg-surface-900">
             {buttonCode}
           </pre>
           <button
@@ -597,7 +599,7 @@ function EmbedSettings({ config }: { config: TrustCenterConfig }) {
         </div>
 
         {/* Button Preview */}
-        <div className="mt-4 p-4 bg-white/50 rounded-lg">
+        <div className="mt-4 p-4 bg-white/50 rounded-lg dark:bg-surface-900/50">
           <p className="text-xs text-surface-500 mb-3">Preview:</p>
           <a
             href={trustCenterUrl}
@@ -643,7 +645,7 @@ function EmbedSettings({ config }: { config: TrustCenterConfig }) {
             type="text"
             readOnly
             value={trustCenterUrl}
-            className="flex-1 px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-700 text-sm"
+            className="flex-1 px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-700 text-sm dark:bg-surface-900"
           />
           <button
             onClick={() => copyToClipboard(trustCenterUrl, 'URL')}

--- a/frontend/src/pages/TrustConfiguration.tsx
+++ b/frontend/src/pages/TrustConfiguration.tsx
@@ -89,7 +89,7 @@ export default function TrustConfiguration() {
       <div className="space-y-6">
         <div className="animate-pulse">
           <div className="h-8 bg-surface-200 rounded w-48 mb-4" />
-          <div className="h-64 bg-white rounded" />
+          <div className="h-64 bg-white rounded dark:bg-surface-900" />
         </div>
       </div>
     );
@@ -139,7 +139,7 @@ export default function TrustConfiguration() {
       </div>
 
       {/* Tab Content */}
-      <div className="bg-white border border-surface-200 rounded-xl p-6">
+      <div className="bg-white border border-surface-200 rounded-xl p-6 dark:bg-surface-900">
         {activeTab === 'sla' && config && (
           <SlaSettingsTab
             config={config}
@@ -233,7 +233,7 @@ function SlaSettingsTab({
       </div>
       <div className="space-y-4">
         {priorities.map((priority) => (
-          <div key={priority} className="bg-white rounded-lg p-4">
+          <div key={priority} className="bg-white rounded-lg p-4 dark:bg-surface-900">
             <div className="flex items-center gap-3 mb-4">
               <span
                 className={clsx(
@@ -267,7 +267,7 @@ function SlaSettingsTab({
                   onChange={(e) =>
                     handleChange(priority, 'targetHours', parseInt(e.target.value) || 1)
                   }
-                  className="w-full px-3 py-2 bg-white border border-surface-300 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                  className="w-full px-3 py-2 bg-white border border-surface-300 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
                 />
               </div>
               <div>
@@ -282,7 +282,7 @@ function SlaSettingsTab({
                   onChange={(e) =>
                     handleChange(priority, 'warningHours', parseInt(e.target.value) || 1)
                   }
-                  className="w-full px-3 py-2 bg-white border border-surface-300 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                  className="w-full px-3 py-2 bg-white border border-surface-300 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
                 />
               </div>
             </div>
@@ -363,7 +363,7 @@ function AssignmentSettingsTab({
       </div>
 
       <div className="space-y-4">
-        <label className="flex items-center gap-3 p-4 bg-white rounded-lg cursor-pointer">
+        <label className="flex items-center gap-3 p-4 bg-white rounded-lg cursor-pointer dark:bg-surface-900">
           <input
             type="checkbox"
             checked={settings.enableAutoAssignment}
@@ -416,7 +416,7 @@ function KbSettingsTab({
       </div>
 
       <div className="space-y-4">
-        <label className="flex items-center gap-3 p-4 bg-white rounded-lg cursor-pointer">
+        <label className="flex items-center gap-3 p-4 bg-white rounded-lg cursor-pointer dark:bg-surface-900">
           <input
             type="checkbox"
             checked={settings.requireApprovalForNewEntries}
@@ -433,7 +433,7 @@ function KbSettingsTab({
           </div>
         </label>
 
-        <label className="flex items-center gap-3 p-4 bg-white rounded-lg cursor-pointer">
+        <label className="flex items-center gap-3 p-4 bg-white rounded-lg cursor-pointer dark:bg-surface-900">
           <input
             type="checkbox"
             checked={settings.autoSuggestFromKB}
@@ -450,7 +450,7 @@ function KbSettingsTab({
           </div>
         </label>
 
-        <label className="flex items-center gap-3 p-4 bg-white rounded-lg cursor-pointer">
+        <label className="flex items-center gap-3 p-4 bg-white rounded-lg cursor-pointer dark:bg-surface-900">
           <input
             type="checkbox"
             checked={settings.trackUsageMetrics}
@@ -502,7 +502,7 @@ function TrustCenterSettingsTab({
         </p>
       </div>
       <div className="space-y-4">
-        <label className="flex items-center gap-3 p-4 bg-white rounded-lg cursor-pointer">
+        <label className="flex items-center gap-3 p-4 bg-white rounded-lg cursor-pointer dark:bg-surface-900">
           <input
             type="checkbox"
             checked={settings.enabled}
@@ -515,7 +515,7 @@ function TrustCenterSettingsTab({
           </div>
         </label>
 
-        <label className="flex items-center gap-3 p-4 bg-white rounded-lg cursor-pointer">
+        <label className="flex items-center gap-3 p-4 bg-white rounded-lg cursor-pointer dark:bg-surface-900">
           <input
             type="checkbox"
             checked={settings.allowAnonymousAccess}
@@ -532,7 +532,7 @@ function TrustCenterSettingsTab({
           </div>
         </label>
 
-        <div className="p-4 bg-white rounded-lg">
+        <div className="p-4 bg-white rounded-lg dark:bg-surface-900">
           <label className="block text-sm font-medium text-surface-600 mb-2">
             Custom Domain (optional)
           </label>
@@ -543,7 +543,7 @@ function TrustCenterSettingsTab({
               setSettings((prev) => ({ ...prev, customDomain: e.target.value || null }))
             }
             placeholder="trust.yourcompany.com"
-            className="w-full px-3 py-2 bg-white border border-surface-300 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+            className="w-full px-3 py-2 bg-white border border-surface-300 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
           />
           <p className="text-xs text-surface-500 mt-1">
             Point a CNAME record to your trust center URL
@@ -598,7 +598,7 @@ function AiSettingsTab({
       )}
 
       <div className="space-y-4">
-        <label className="flex items-center gap-3 p-4 bg-white rounded-lg cursor-pointer">
+        <label className="flex items-center gap-3 p-4 bg-white rounded-lg cursor-pointer dark:bg-surface-900">
           <input
             type="checkbox"
             checked={settings.enabled}
@@ -615,7 +615,7 @@ function AiSettingsTab({
 
         {settings.enabled && (
           <>
-            <label className="flex items-center gap-3 p-4 bg-white rounded-lg cursor-pointer">
+            <label className="flex items-center gap-3 p-4 bg-white rounded-lg cursor-pointer dark:bg-surface-900">
               <input
                 type="checkbox"
                 checked={settings.autoCategorizationEnabled}
@@ -632,7 +632,7 @@ function AiSettingsTab({
               </div>
             </label>
 
-            <label className="flex items-center gap-3 p-4 bg-white rounded-lg cursor-pointer">
+            <label className="flex items-center gap-3 p-4 bg-white rounded-lg cursor-pointer dark:bg-surface-900">
               <input
                 type="checkbox"
                 checked={settings.answerSuggestionsEnabled}

--- a/frontend/src/pages/UserManagement.tsx
+++ b/frontend/src/pages/UserManagement.tsx
@@ -147,25 +147,25 @@ export default function UserManagement() {
       </div>
       {/* Stats Cards */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-        <div className="bg-white rounded-lg p-4 border border-surface-200">
+        <div className="bg-white rounded-lg p-4 border border-surface-200 dark:bg-surface-900">
           <div className="text-surface-600 text-sm">Total Users</div>
           <div className="text-2xl font-bold text-white mt-1">{statsData?.total || 0}</div>
         </div>
-        <div className="bg-white rounded-lg p-4 border border-surface-200">
+        <div className="bg-white rounded-lg p-4 border border-surface-200 dark:bg-surface-900">
           <div className="text-surface-600 text-sm">Active Users</div>
           <div className="text-2xl font-bold text-emerald-600 mt-1">{statsData?.active || 0}</div>
         </div>
-        <div className="bg-white rounded-lg p-4 border border-surface-200">
+        <div className="bg-white rounded-lg p-4 border border-surface-200 dark:bg-surface-900">
           <div className="text-surface-600 text-sm">Inactive Users</div>
           <div className="text-2xl font-bold text-red-600 mt-1">{statsData?.inactive || 0}</div>
         </div>
-        <div className="bg-white rounded-lg p-4 border border-surface-200">
+        <div className="bg-white rounded-lg p-4 border border-surface-200 dark:bg-surface-900">
           <div className="text-surface-600 text-sm">Permission Groups</div>
           <div className="text-2xl font-bold text-brand-400 mt-1">{groups.length}</div>
         </div>
       </div>
       {/* Filters */}
-      <div className="bg-white rounded-lg p-4 border border-surface-200">
+      <div className="bg-white rounded-lg p-4 border border-surface-200 dark:bg-surface-900">
         <div className="flex flex-wrap gap-4">
           <div className="flex-1 min-w-64">
             <div className="relative">
@@ -175,14 +175,14 @@ export default function UserManagement() {
                 placeholder="Search users by name or email..."
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
-                className="w-full bg-white border border-surface-300 rounded-lg pl-10 pr-4 py-2 text-white placeholder:text-surface-500 focus:outline-none focus:ring-2 focus:ring-brand-500"
+                className="w-full bg-white border border-surface-300 rounded-lg pl-10 pr-4 py-2 text-white placeholder:text-surface-500 focus:outline-none focus:ring-2 focus:ring-brand-500 dark:bg-surface-900"
               />
             </div>
           </div>
           <SelectNative
             value={statusFilter}
             onChange={(e) => setStatusFilter(e.target.value)}
-            className="bg-white border border-surface-300 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+            className="bg-white border border-surface-300 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-brand-500 dark:bg-surface-900"
           >
             <option value="">All Statuses</option>
             <option value="active">Active</option>
@@ -191,7 +191,7 @@ export default function UserManagement() {
           <SelectNative
             value={roleFilter}
             onChange={(e) => setRoleFilter(e.target.value)}
-            className="bg-white border border-surface-300 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+            className="bg-white border border-surface-300 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-brand-500 dark:bg-surface-900"
           >
             <option value="">All Roles</option>
             <option value="admin">Admin</option>
@@ -202,9 +202,9 @@ export default function UserManagement() {
         </div>
       </div>
       {/* Users Table */}
-      <div className="bg-white rounded-lg border border-surface-200 overflow-hidden">
+      <div className="bg-white rounded-lg border border-surface-200 overflow-hidden dark:bg-surface-900">
         <table className="w-full">
-          <thead className="bg-white">
+          <thead className="bg-white dark:bg-surface-900">
             <tr>
               <th className="text-left text-surface-600 font-medium px-4 py-3">User</th>
               <th className="text-left text-surface-600 font-medium px-4 py-3">Role</th>

--- a/frontend/src/pages/VendorDetail.tsx
+++ b/frontend/src/pages/VendorDetail.tsx
@@ -155,7 +155,7 @@ export default function VendorDetail() {
         <div className="flex items-center gap-4">
           <button
             onClick={() => navigate('/vendors')}
-            className="p-2 text-surface-600 hover:text-surface-900 hover:bg-white rounded-lg transition-colors"
+            className="p-2 text-surface-600 hover:text-surface-900 hover:bg-white rounded-lg transition-colors dark:bg-surface-900 dark:hover:bg-surface-800"
           >
             <ArrowLeftIcon className="w-5 h-5" />
           </button>
@@ -280,7 +280,7 @@ function VendorForm({
 
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
-      <div className="bg-white border border-surface-200 rounded-lg p-6 space-y-6">
+      <div className="bg-white border border-surface-200 rounded-lg p-6 space-y-6 dark:bg-surface-900">
         {/* Basic Information */}
         <div>
           <h3 className="text-lg font-medium text-surface-900 mb-4">Basic Information</h3>
@@ -294,7 +294,7 @@ function VendorForm({
                 required
                 value={formData.name}
                 onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               />
             </div>
 
@@ -304,7 +304,7 @@ function VendorForm({
                 type="text"
                 value={formData.legalName}
                 onChange={(e) => setFormData({ ...formData, legalName: e.target.value })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               />
             </div>
 
@@ -314,7 +314,7 @@ function VendorForm({
                 required
                 value={formData.category}
                 onChange={(e) => setFormData({ ...formData, category: e.target.value })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               >
                 <option value="software_vendor">Software Vendor</option>
                 <option value="cloud_provider">Cloud Provider</option>
@@ -330,7 +330,7 @@ function VendorForm({
                 required
                 value={formData.tier}
                 onChange={(e) => setFormData({ ...formData, tier: e.target.value })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               >
                 <option value="tier_1">Tier 1 (Critical)</option>
                 <option value="tier_2">Tier 2 (High)</option>
@@ -345,7 +345,7 @@ function VendorForm({
                 required
                 value={formData.status}
                 onChange={(e) => setFormData({ ...formData, status: e.target.value })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               >
                 <option value="active">Active</option>
                 <option value="inactive">Inactive</option>
@@ -361,7 +361,7 @@ function VendorForm({
                 type="url"
                 value={formData.website}
                 onChange={(e) => setFormData({ ...formData, website: e.target.value })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               />
             </div>
           </div>
@@ -379,7 +379,7 @@ function VendorForm({
                 type="text"
                 value={formData.primaryContact}
                 onChange={(e) => setFormData({ ...formData, primaryContact: e.target.value })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               />
             </div>
 
@@ -389,7 +389,7 @@ function VendorForm({
                 type="email"
                 value={formData.primaryContactEmail}
                 onChange={(e) => setFormData({ ...formData, primaryContactEmail: e.target.value })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               />
             </div>
 
@@ -399,7 +399,7 @@ function VendorForm({
                 type="tel"
                 value={formData.primaryContactPhone}
                 onChange={(e) => setFormData({ ...formData, primaryContactPhone: e.target.value })}
-                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+                className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
               />
             </div>
           </div>
@@ -413,7 +413,7 @@ function VendorForm({
               value={formData.description}
               onChange={(e) => setFormData({ ...formData, description: e.target.value })}
               rows={3}
-              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
             />
           </div>
 
@@ -423,7 +423,7 @@ function VendorForm({
               value={formData.notes}
               onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
               rows={3}
-              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500"
+              className="w-full px-3 py-2 bg-white border border-surface-200 rounded-lg text-surface-900 focus:outline-none focus:border-brand-500 dark:bg-surface-900"
             />
           </div>
         </div>
@@ -488,7 +488,7 @@ function VendorView({
               ? 'bg-red-500/10 border-red-500/30'
               : daysUntilReview !== null && daysUntilReview <= 30
                 ? 'bg-yellow-500/10 border-yellow-500/30'
-                : 'bg-white border-surface-200'
+                : 'bg-white border-surface-200 dark:bg-surface-900'
           )}
         >
           <div className="flex items-center gap-3">
@@ -553,7 +553,7 @@ function VendorView({
       )}
 
       {/* Basic Information */}
-      <div className="bg-white border border-surface-200 rounded-lg p-6">
+      <div className="bg-white border border-surface-200 rounded-lg p-6 dark:bg-surface-900">
         <h3 className="text-lg font-medium text-surface-900 mb-4">Basic Information</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <InfoField label="Vendor Name" value={vendor.name} />
@@ -572,7 +572,7 @@ function VendorView({
 
       {/* Contact Information */}
       {(vendor.primaryContact || vendor.primaryContactEmail || vendor.primaryContactPhone) && (
-        <div className="bg-white border border-surface-200 rounded-lg p-6">
+        <div className="bg-white border border-surface-200 rounded-lg p-6 dark:bg-surface-900">
           <h3 className="text-lg font-medium text-surface-900 mb-4">Primary Contact</h3>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             <InfoField label="Name" value={vendor.primaryContact} />
@@ -583,7 +583,7 @@ function VendorView({
       )}
 
       {/* Documents Section with AI Analysis */}
-      <div className="bg-white border border-surface-200 rounded-lg p-6">
+      <div className="bg-white border border-surface-200 rounded-lg p-6 dark:bg-surface-900">
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center gap-2">
             <DocumentTextIcon className="w-5 h-5 text-surface-600" />
@@ -596,7 +596,7 @@ function VendorView({
             {extendedVendor.documents.map((doc) => (
               <div
                 key={doc.id}
-                className="flex items-center justify-between p-3 bg-white/50 rounded-lg"
+                className="flex items-center justify-between p-3 bg-white/50 rounded-lg dark:bg-surface-900/50"
               >
                 <div className="flex items-center gap-3">
                   <DocumentTextIcon className="w-5 h-5 text-surface-600" />
@@ -692,7 +692,7 @@ function VendorView({
 
       {/* Description */}
       {vendor.description && (
-        <div className="bg-white border border-surface-200 rounded-lg p-6">
+        <div className="bg-white border border-surface-200 rounded-lg p-6 dark:bg-surface-900">
           <h3 className="text-lg font-medium text-surface-900 mb-4">Description</h3>
           <p className="text-surface-700">{vendor.description}</p>
         </div>
@@ -700,7 +700,7 @@ function VendorView({
 
       {/* Notes */}
       {vendor.notes && (
-        <div className="bg-white border border-surface-200 rounded-lg p-6">
+        <div className="bg-white border border-surface-200 rounded-lg p-6 dark:bg-surface-900">
           <h3 className="text-lg font-medium text-surface-900 mb-4">Notes</h3>
           <p className="text-surface-700 whitespace-pre-wrap">{vendor.notes}</p>
         </div>

--- a/frontend/src/pages/Vendors.tsx
+++ b/frontend/src/pages/Vendors.tsx
@@ -96,7 +96,7 @@ export default function Vendors() {
       </div>
       {/* Vendors List */}
       {vendors.length === 0 ? (
-        <div className="bg-white border border-surface-200 rounded-lg p-12 text-center">
+        <div className="bg-white border border-surface-200 rounded-lg p-12 text-center dark:bg-surface-900">
           <BuildingOfficeIcon className="w-12 h-12 text-surface-600 mx-auto mb-4" />
           <h3 className="text-lg font-medium text-surface-700 mb-2">No vendors yet</h3>
           <p className="text-surface-500 mb-6">Get started by adding your first vendor</p>
@@ -108,9 +108,9 @@ export default function Vendors() {
           </Button>
         </div>
       ) : (
-        <div className="bg-white border border-surface-200 rounded-lg overflow-hidden">
+        <div className="bg-white border border-surface-200 rounded-lg overflow-hidden dark:bg-surface-900">
           <table className="w-full">
-            <thead className="bg-white border-b border-surface-200">
+            <thead className="bg-white border-b border-surface-200 dark:bg-surface-900">
               <tr>
                 <th className="px-6 py-3 text-left text-xs font-medium text-surface-600 uppercase tracking-wider">
                   Vendor
@@ -134,7 +134,7 @@ export default function Vendors() {
                 <tr
                   key={vendor.id}
                   onClick={() => navigate(`/vendors/${vendor.id}`)}
-                  className="hover:bg-white cursor-pointer transition-colors"
+                  className="hover:bg-white cursor-pointer transition-colors dark:bg-surface-900 dark:hover:bg-surface-800"
                 >
                   <td className="px-6 py-4">
                     <div>

--- a/frontend/src/pages/WorkspaceList.tsx
+++ b/frontend/src/pages/WorkspaceList.tsx
@@ -181,7 +181,7 @@ export default function WorkspaceList() {
             compliance tracking, while sharing a common control library across your organization.
           </p>
 
-          <div className="bg-white rounded-lg p-6 text-left mb-8">
+          <div className="bg-white rounded-lg p-6 text-left mb-8 dark:bg-surface-900">
             <h3 className="font-semibold text-foreground mb-4">What you get with workspaces:</h3>
             <ul className="space-y-3 text-sm text-muted-foreground">
               <li className="flex items-start gap-3">
@@ -238,25 +238,25 @@ export default function WorkspaceList() {
       {/* Org-level Stats */}
       {orgDashboard && (
         <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
-          <div className="bg-white rounded-lg p-4 border border-surface-200">
+          <div className="bg-white rounded-lg p-4 border border-surface-200 dark:bg-surface-900">
             <p className="text-sm text-muted-foreground">Total Workspaces</p>
             <p className="text-2xl font-bold text-foreground mt-1">
               {orgDashboard.workspaces?.length || 0}
             </p>
           </div>
-          <div className="bg-white rounded-lg p-4 border border-surface-200">
+          <div className="bg-white rounded-lg p-4 border border-surface-200 dark:bg-surface-900">
             <p className="text-sm text-muted-foreground">Avg Compliance Score</p>
             <p className="text-2xl font-bold text-brand-400 mt-1">
               {orgDashboard.avgComplianceScore || 0}%
             </p>
           </div>
-          <div className="bg-white rounded-lg p-4 border border-surface-200">
+          <div className="bg-white rounded-lg p-4 border border-surface-200 dark:bg-surface-900">
             <p className="text-sm text-muted-foreground">Total Controls</p>
             <p className="text-2xl font-bold text-foreground mt-1">
               {orgDashboard.totals?.controls || 0}
             </p>
           </div>
-          <div className="bg-white rounded-lg p-4 border border-surface-200">
+          <div className="bg-white rounded-lg p-4 border border-surface-200 dark:bg-surface-900">
             <p className="text-sm text-muted-foreground">Total Risks</p>
             <p className="text-2xl font-bold text-foreground mt-1">
               {orgDashboard.totals?.risks || 0}
@@ -272,7 +272,7 @@ export default function WorkspaceList() {
           placeholder="Search workspaces..."
           value={search}
           onChange={(e) => setSearch(e.target.value)}
-          className="w-full pl-10 pr-4 py-2 bg-white border border-surface-200 rounded-lg text-foreground placeholder-muted-foreground focus:outline-none focus:ring-2 focus:ring-brand-500"
+          className="w-full pl-10 pr-4 py-2 bg-white border border-surface-200 rounded-lg text-foreground placeholder-muted-foreground focus:outline-none focus:ring-2 focus:ring-brand-500 dark:bg-surface-900"
         />
       </div>
       {/* Workspaces Grid */}
@@ -282,10 +282,10 @@ export default function WorkspaceList() {
           return (
             <div
               key={workspace.id}
-              className={`bg-white rounded-lg p-5 border transition-all cursor-pointer hover:border-brand-500/50 ${
+              className={`bg-white dark:bg-surface-900 rounded-lg p-5 border transition-all cursor-pointer hover:border-brand-500/50 ${
                 currentWorkspace?.id === workspace.id
                   ? 'border-brand-500 ring-1 ring-brand-500/30'
-                  : 'border-surface-200'
+                  : 'border-surface-200 dark:border-surface-800'
               }`}
               onClick={() => {
                 setCurrentWorkspace(workspace);

--- a/frontend/src/pages/WorkspaceSettings.tsx
+++ b/frontend/src/pages/WorkspaceSettings.tsx
@@ -250,7 +250,7 @@ export default function WorkspaceSettings() {
       <div className="flex items-center gap-4 mb-6">
         <button
           onClick={() => navigate('/settings/workspaces')}
-          className="p-2 text-muted-foreground hover:text-foreground hover:bg-white rounded-lg"
+          className="p-2 text-muted-foreground hover:text-foreground hover:bg-white rounded-lg dark:bg-surface-900 dark:hover:bg-surface-800"
         >
           <ArrowLeftIcon className="w-5 h-5" />
         </button>
@@ -260,7 +260,7 @@ export default function WorkspaceSettings() {
         </div>
       </div>
       {/* Basic Information */}
-      <section className="bg-white rounded-lg p-6 border border-surface-200 mb-6">
+      <section className="bg-white rounded-lg p-6 border border-surface-200 mb-6 dark:bg-surface-900">
         <h2 className="text-lg font-semibold text-foreground mb-4 flex items-center gap-2">
           <BuildingOfficeIcon className="w-5 h-5" />
           Basic Information
@@ -310,7 +310,7 @@ export default function WorkspaceSettings() {
         </div>
       </section>
       {/* Members */}
-      <section className="bg-white rounded-lg p-6 border border-surface-200 mb-6">
+      <section className="bg-white rounded-lg p-6 border border-surface-200 mb-6 dark:bg-surface-900">
         <div className="flex items-center justify-between mb-4">
           <h2 className="text-lg font-semibold text-foreground">Members</h2>
           <button


### PR DESCRIPTION
## Summary
Closes the dark-mode coverage gaps left after PR #321 shipped ThemeContext + primitive-level dark variants. Until now, ~893 lines across 178 files used `bg-white`, `bg-gray-*`, `text-gray-*`, or `border-gray-*` without any `dark:` sibling — they looked broken when a user flipped to dark mode.

- Codemod swept ~1000+ usages across **166 files**, picking dark surface tokens at the elevation step the light token implies:
  - `bg-white` → `+ dark:bg-surface-900` (card surface)
  - `bg-white/X` → `+ dark:bg-surface-900/X` (preserve opacity)
  - `bg-gray-{50…900}` → `dark:bg-surface-{900…100}` (inverted)
  - `text-gray-{500…900}` → `dark:text-surface-{400…50}` (light text on dark bg)
  - `border-gray-{200…700}` → `dark:border-surface-{800…300}`
- Ternary branches that compose `className` via `${cond ? 'a' : 'b'}` each carry their own `dark:` sibling now — no more "dark belongs outside the ternary" patterns that left bare gray tokens stranded.
- 4 new ESLint rules (#11–#14) lock the gains in at **`error`**: bare `bg-white`, `bg-gray-*`, `text-gray-*`, and `border-gray-*` literals must carry a matching `dark:*` sibling on the same className string. Modifier-prefixed forms (`hover:bg-white`, `focus:text-gray-500`) are exempt — only the bare class is regulated.

## Test plan
- [x] `npm --workspace frontend run lint` — 0 errors, 0 warnings
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 397 / 397 pass
- [ ] Visual sweep in dark mode: dashboard, controls, risks, policies, evidence, vendors, settings, command palette, notification panel
- [ ] Visual sweep in light mode for regression: same pages
- [ ] Toggle theme via /settings and verify all surfaces transition cleanly