### PR TITLE
fix(policies): send category instead of type on policy create (#329)

### DIFF
--- a/frontend/src/lib/apiTypes.ts
+++ b/frontend/src/lib/apiTypes.ts
@@ -707,7 +707,9 @@ export interface Policy {
 export interface UploadPolicyData {
   title: string;
   description?: string;
-  type?: PolicyType;
+  // Backend CreatePolicy/UploadPolicy DTO whitelists `category` (PolicyCategory
+  // enum), not `type`. Sending `type` is rejected by forbidNonWhitelisted.
+  category?: string;
   version?: string;
   ownerId?: string;
   effectiveDate?: string;

--- a/frontend/src/pages/Policies.tsx
+++ b/frontend/src/pages/Policies.tsx
@@ -223,7 +223,7 @@ function UploadPolicyModal({ onClose, onSuccess }: { onClose: () => void; onSucc
       return policiesApi.upload(file, {
         title,
         description,
-        type: category as any,
+        category,
         version,
       });
     },


### PR DESCRIPTION
Fixes #329.

## Problem
`POST /api/policies` returned **400 Bad Request** from the Upload Policy form:
> property type should not exist, category must be one of the following values: …

The backend `UploadPolicyDto` (services/policies) uses `whitelist: true` + `forbidNonWhitelisted: true` and expects a **`category`** field (the `PolicyCategory` enum). The frontend form collected the correct category value but sent it under a **`type`** key — masked by an `as any` cast — so validation rejected it.

## Fix
- **`frontend/src/pages/Policies.tsx`** — the Upload Policy modal now sends `category` (it already collected the right value via `CATEGORY_OPTIONS`; only the key was wrong).
- **`frontend/src/lib/apiTypes.ts`** — `UploadPolicyData` now declares `category?: string` (matching the backend DTO and the existing `Policy.category` field) instead of the never-accepted `type?: PolicyType`.

No value mapping needed: the frontend `CATEGORY_OPTIONS` values (`information_security`, `acceptable_use`, …) already match the backend `PolicyCategory` enum exactly.

## Notes
- The `status` symptom in the issue was from the reported commit (`ba6b7a8`); on current `main` the upload payload is `{title, description, type→category, version}` and does not send `status` (status is set via the separate `PUT /:id/status` endpoint), so no status handling is needed here.
- Verified the frontend builds.

## Test plan
- Data → Policies → Create Policy → fill fields, attach a file → Submit → policy is created (no 400).