### PR TITLE
fix(ui): remove useless conditional in CommandMenu empty state

### DIFF
--- a/frontend/src/components/ui/CommandMenu.tsx
+++ b/frontend/src/components/ui/CommandMenu.tsx
@@ -179,7 +179,7 @@ export function CommandMenu<T>({
                     <Search className="mx-auto h-8 w-8 text-surface-500 dark:text-surface-400" />
                     <p className="mt-4 text-sm text-surface-700 dark:text-surface-200">
                       {emptyTitle}
-                      {query && <> for &ldquo;{query}&rdquo;</>}
+                      <> for &ldquo;{query}&rdquo;</>
                     </p>
                     {emptyDescription && (
                       <p className="mt-2 text-xs text-surface-500 dark:text-surface-400">


### PR DESCRIPTION
Resolves the only open CodeQL code-scanning alert (#320, `js/trivial-conditional`, "Useless conditional") at `frontend/src/components/ui/CommandMenu.tsx:182`.

The inner `query &&` guard is always true — the enclosing block already requires `query && flatCount === 0`, so `query` is guaranteed truthy at that point:

```tsx
{query && flatCount === 0 && (
  ...
  {emptyTitle}
  {query && <> for &ldquo;{query}&rdquo;</>}   // <- redundant guard
```

Dropped the redundant guard. No behavior change. Frontend builds clean.