### PR TITLE
chore(deps): remove unused frontend and root dependencies

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,7 +1,6 @@
 import eslint from '@eslint/js';
 import tseslint from 'typescript-eslint';
 import reactHooks from 'eslint-plugin-react-hooks';
-import reactRefresh from 'eslint-plugin-react-refresh';
 import eslintConfigPrettier from 'eslint-config-prettier';
 import globals from 'globals';
 
@@ -124,11 +123,9 @@ export default [
     },
     plugins: {
       'react-hooks': reactHooks,
-      'react-refresh': reactRefresh,
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
-      'react-refresh/only-export-components': 'off',
       '@typescript-eslint/no-unused-vars': [
         'error',
         {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,20 +39,16 @@
     "exceljs": "^4.4.0",
     "html2canvas": "^1.4.1",
     "jspdf": "^4.2.1",
-    "jwt-decode": "^4.0.0",
     "keycloak-js": "^25.0.0",
     "lucide-react": "^0.577.0",
     "mammoth": "^1.11.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-dropzone": "^14.4.1",
     "react-grid-layout": "^1.5.3",
     "react-hook-form": "^7.71.2",
     "react-hot-toast": "^2.4.1",
-    "react-icons": "^5.5.0",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^6.21.1",
-    "react-toastify": "^11.1.0",
     "recharts": "^2.10.3",
     "tailwind-merge": "^2.2.0",
     "zod": "^3.22.4"
@@ -76,10 +72,10 @@
     "@types/react-dom": "^18.2.18",
     "@vitejs/plugin-react": "^6.0.3",
     "autoprefixer": "^10.5.2",
+    "esbuild": "^0.28.1",
     "eslint": "^9.39.4",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-react-hooks": "^5.0.0",
-    "eslint-plugin-react-refresh": "^0.5.2",
     "jsdom": "^24.0.0",
     "postcss": "^8.5.16",
     "prettier": "^3.9.4",
@@ -89,7 +85,6 @@
     "typescript": "^5.3.3",
     "typescript-eslint": "^8.62.1",
     "vite": "^8.1.3",
-    "vitest": "^4.1.10",
-    "esbuild": "^0.28.1"
+    "vitest": "^4.1.10"
   }
 }

--- a/frontend/src/pages/Evidence.tsx
+++ b/frontend/src/pages/Evidence.tsx
@@ -1,6 +1,5 @@
-import { useState, useCallback } from 'react';
+import { useRef, useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useDropzone } from 'react-dropzone';
 import { useSearchParams, Link } from 'react-router-dom';
 import { evidenceApi, controlsApi } from '@/lib/api';
 import { useAuth } from '@/contexts/AuthContext';
@@ -350,6 +349,8 @@ function UploadModal({
 }) {
   const queryClient = useQueryClient();
   const [file, setFile] = useState<File | null>(null);
+  const [isDragActive, setIsDragActive] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [title, setTitle] = useState('');
   const [type, setType] = useState('document');
   const [description, setDescription] = useState('');
@@ -386,32 +387,17 @@ function UploadModal({
     },
   });
 
-  const onDrop = useCallback(
-    (acceptedFiles: File[]) => {
-      if (acceptedFiles[0]) {
-        setFile(acceptedFiles[0]);
-        if (!title) {
-          setTitle(acceptedFiles[0].name.replace(/\.[^/.]+$/, ''));
-        }
-      }
-    },
-    [title]
-  );
+  const assignSelectedFile = (nextFile: File | null) => {
+    if (!nextFile) return;
+    setFile(nextFile);
+    if (!title) {
+      setTitle(nextFile.name.replace(/\.[^/.]+$/, ''));
+    }
+  };
 
-  const { getRootProps, getInputProps, isDragActive } = useDropzone({
-    onDrop,
-    maxFiles: 1,
-    accept: {
-      'application/pdf': ['.pdf'],
-      'image/*': ['.png', '.jpg', '.jpeg', '.gif'],
-      'application/msword': ['.doc'],
-      'application/vnd.openxmlformats-officedocument.wordprocessingml.document': ['.docx'],
-      'application/vnd.ms-excel': ['.xls'],
-      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': ['.xlsx'],
-      'text/csv': ['.csv'],
-      'text/plain': ['.txt'],
-    },
-  });
+  const handleFiles = (files: FileList | null) => {
+    assignSelectedFile(files?.[0] ?? null);
+  };
 
   return (
     <div className="fixed inset-0 z-50 overflow-y-auto">
@@ -439,7 +425,6 @@ function UploadModal({
           <div className="space-y-4">
             {/* Dropzone */}
             <div
-              {...getRootProps()}
               className={clsx(
                 'border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-all',
                 isDragActive
@@ -448,8 +433,28 @@ function UploadModal({
                     ? 'border-green-500 bg-green-500/10'
                     : 'border-surface-200 hover:border-surface-300'
               )}
+              onClick={() => fileInputRef.current?.click()}
+              onDragOver={(event) => {
+                event.preventDefault();
+                setIsDragActive(true);
+              }}
+              onDragLeave={(event) => {
+                event.preventDefault();
+                setIsDragActive(false);
+              }}
+              onDrop={(event) => {
+                event.preventDefault();
+                setIsDragActive(false);
+                handleFiles(event.dataTransfer.files);
+              }}
             >
-              <input {...getInputProps()} />
+              <input
+                ref={fileInputRef}
+                type="file"
+                className="hidden"
+                accept=".pdf,.png,.jpg,.jpeg,.gif,.doc,.docx,.xls,.xlsx,.csv,.txt"
+                onChange={(event) => handleFiles(event.target.files)}
+              />
               {file ? (
                 <div className="flex items-center justify-center gap-2 text-green-600">
                   <CheckIcon className="w-6 h-6" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,6 @@
         "services/audit",
         "frontend"
       ],
-      "dependencies": {
-        "@prisma/client": "^5.22.0"
-      },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
         "eslint": "^9.39.4",
@@ -26,7 +23,6 @@
         "husky": "^9.0.0",
         "lint-staged": "^15.0.0",
         "prettier": "^3.9.4",
-        "prisma": "^5.22.0",
         "typescript-eslint": "^8.62.1"
       }
     },
@@ -35,7 +31,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@headlessui/react": "^1.7.18",
-        "@heroicons/react": "^2.1.1",
+        "@heroicons/react": "2.2.0",
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@tanstack/react-query": "^5.99.2",
@@ -49,20 +45,16 @@
         "exceljs": "^4.4.0",
         "html2canvas": "^1.4.1",
         "jspdf": "^4.2.1",
-        "jwt-decode": "^4.0.0",
         "keycloak-js": "^25.0.0",
         "lucide-react": "^0.577.0",
         "mammoth": "^1.11.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-dropzone": "^14.4.1",
         "react-grid-layout": "^1.5.3",
         "react-hook-form": "^7.71.2",
         "react-hot-toast": "^2.4.1",
-        "react-icons": "^5.5.0",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^6.21.1",
-        "react-toastify": "^11.1.0",
         "recharts": "^2.10.3",
         "tailwind-merge": "^2.2.0",
         "zod": "^3.22.4"
@@ -82,7 +74,6 @@
         "eslint": "^9.39.4",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-react-hooks": "^5.0.0",
-        "eslint-plugin-react-refresh": "^0.5.2",
         "jsdom": "^24.0.0",
         "postcss": "^8.5.16",
         "prettier": "^3.9.4",
@@ -7247,9 +7238,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7267,9 +7255,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7287,9 +7272,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7307,9 +7289,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7327,9 +7306,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7347,9 +7323,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10622,15 +10595,6 @@
         "node": ">= 4.5.0"
       }
     },
-    "node_modules/attr-accept": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz",
-      "integrity": "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/autoprefixer": {
       "version": "10.5.2",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.2.tgz",
@@ -13408,16 +13372,6 @@
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
       }
     },
-    "node_modules/eslint-plugin-react-refresh": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.3.tgz",
-      "integrity": "sha512-5EMmLCV98Pi4o/f/3DP/v/tNqLHMIc9I8LKClNDWhZ9JTho89/kQcitCXQBMG7sAfVRK0Ie3T2EDOzp1YXYiVA==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "eslint": "^9 || ^10"
-      }
-    },
     "node_modules/eslint-scope": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
@@ -13921,18 +13875,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/file-selector": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-2.1.2.tgz",
-      "integrity": "sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.7.0"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/file-type": {
       "version": "21.3.4",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
@@ -14217,6 +14159,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -20583,23 +20526,6 @@
         "react-dom": ">= 16.3.0"
       }
     },
-    "node_modules/react-dropzone": {
-      "version": "14.4.1",
-      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.4.1.tgz",
-      "integrity": "sha512-QDuV76v3uKbHiH34SpwifZ+gOLi1+RdsCO1kl5vxMT4wW8R82+sthjvBw4th3NHF/XX6FBsqDYZVNN+pnhaw0g==",
-      "license": "MIT",
-      "dependencies": {
-        "attr-accept": "^2.2.4",
-        "file-selector": "^2.1.0",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">= 10.13"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8 || 18.0.0"
-      }
-    },
     "node_modules/react-grid-layout": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/react-grid-layout/-/react-grid-layout-1.5.3.tgz",
@@ -20672,15 +20598,6 @@
         "react-native": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-icons": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.6.0.tgz",
-      "integrity": "sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "*"
       }
     },
     "node_modules/react-is": {
@@ -20784,19 +20701,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/react-toastify": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.1.0.tgz",
-      "integrity": "sha512-e9h23x3phN0wbFeB6yovmWp7lobzV4CaCH0LO8nVP6H7Y+3GbcLpIzMm9dJhcp1RXbpyfvjgpfXqO80QAmn7sg==",
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.1.1"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19",
-        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/react-transition-group": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@headlessui/react": "^1.7.18",
-        "@heroicons/react": "2.2.0",
+        "@heroicons/react": "^2.1.1",
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@tanstack/react-query": "^5.99.2",
@@ -24776,7 +24776,7 @@
         "csv-parse": "^5.5.3",
         "exceljs": "^4.4.0",
         "helmet": "^7.2.0",
-        "multer": "^2.1.1",
+        "multer": "^2.2.0",
         "reflect-metadata": "^0.1.14",
         "rxjs": "^7.8.1"
       },

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "minimatch": "^10.2.3",
     "rollup": "^4.59.0",
     "@smithy/config-resolver": "^4.4.0",
-    "multer": ">=2.1.0",
+    "multer": "^2.2.0",
     "serialize-javascript": ">=7.0.3",
     "file-type": ">=21.3.4",
     "dompurify": ">=3.4.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "husky": "^9.0.0",
     "lint-staged": "^15.0.0",
     "prettier": "^3.9.4",
-    "prisma": "^5.22.0",
     "typescript-eslint": "^8.62.1"
   },
   "lint-staged": {
@@ -59,9 +58,6 @@
     "*.{json,md,yml,yaml}": [
       "prettier --write"
     ]
-  },
-  "dependencies": {
-    "@prisma/client": "^5.22.0"
   },
   "overrides": {
     "broadcast-channel": {

--- a/services/audit/package.json
+++ b/services/audit/package.json
@@ -54,6 +54,7 @@
     "picomatch": ">=2.3.2",
     "brace-expansion": ">=5.0.5",
     "lodash": ">=4.18.0",
+    "multer": "^2.2.0",
     "uuid": "$uuid",
     "js-yaml": "^4.2.0"
   }

--- a/services/controls/package.json
+++ b/services/controls/package.json
@@ -81,6 +81,7 @@
     "picomatch": ">=2.3.2",
     "brace-expansion": ">=5.0.5",
     "lodash": ">=4.18.0",
+    "multer": "^2.2.0",
     "uuid": "$uuid",
     "js-yaml": "^4.2.0"
   }

--- a/services/frameworks/package.json
+++ b/services/frameworks/package.json
@@ -29,7 +29,7 @@
     "csv-parse": "^5.5.3",
     "exceljs": "^4.4.0",
     "helmet": "^7.2.0",
-    "multer": "^2.1.1",
+    "multer": "^2.2.0",
     "reflect-metadata": "^0.1.14",
     "rxjs": "^7.8.1"
   },
@@ -70,6 +70,7 @@
     "picomatch": ">=2.3.2",
     "brace-expansion": ">=5.0.5",
     "lodash": ">=4.18.0",
+    "multer": "^2.2.0",
     "uuid": ">=11.1.1",
     "js-yaml": "^4.2.0"
   }

--- a/services/policies/package.json
+++ b/services/policies/package.json
@@ -46,6 +46,7 @@
     "picomatch": ">=2.3.2",
     "brace-expansion": ">=5.0.5",
     "lodash": ">=4.18.0",
+    "multer": "^2.2.0",
     "uuid": ">=11.1.1",
     "js-yaml": "^4.2.0"
   }

--- a/services/tprm/package.json
+++ b/services/tprm/package.json
@@ -47,6 +47,7 @@
     "picomatch": ">=2.3.2",
     "brace-expansion": ">=5.0.5",
     "lodash": ">=4.18.0",
+    "multer": "^2.2.0",
     "uuid": ">=11.1.1",
     "js-yaml": "^4.2.0"
   }

--- a/services/trust/package.json
+++ b/services/trust/package.json
@@ -50,6 +50,7 @@
     "picomatch": ">=2.3.2",
     "brace-expansion": ">=5.0.5",
     "lodash": ">=4.18.0",
+    "multer": "^2.2.0",
     "uuid": ">=11.1.1",
     "js-yaml": "^4.2.0"
   }


### PR DESCRIPTION
## Summary
- reduce dependency surface by removing unused frontend packages (`jwt-decode`, `react-icons`, `react-toastify`, `react-dropzone`) and an unused frontend lint plugin (`eslint-plugin-react-refresh`)
- replace `react-dropzone` usage in `Evidence` upload with native drag/drop + file input handling to preserve behavior without external runtime dependency
- remove unused root Prisma dependencies (`prisma`, `@prisma/client`) while keeping workspace Prisma generation flow intact

## Test plan
- [x] `npx -y npm@10.8.2 ci --ignore-scripts`
- [x] `npx -y npm@10.8.2 --workspace frontend run lint`
- [x] `npx -y npm@10.8.2 --workspace frontend run build:typecheck`
- [x] `npx -y npm@10.8.2 --workspace frontend run test`
- [x] `npx -y npm@10.8.2 run db:generate`
- [x] `npm run lint:check` currently fails due pre-existing unrelated issues in `services/controls` (no new lint errors introduced by this change)