### PR TITLE
chore(deps): remove unused controls schematics dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24358,7 +24358,6 @@
       },
       "devDependencies": {
         "@nestjs/cli": "^11.0.19",
-        "@nestjs/schematics": "^11.0.10",
         "@nestjs/testing": "^11.1.19",
         "@types/compression": "^1.7.5",
         "@types/express": "^4.17.21",

--- a/services/controls/package.json
+++ b/services/controls/package.json
@@ -57,7 +57,6 @@
   },
   "devDependencies": {
     "@nestjs/cli": "^11.0.19",
-    "@nestjs/schematics": "^11.0.10",
     "@nestjs/testing": "^11.1.19",
     "@types/compression": "^1.7.5",
     "@types/express": "^4.17.21",


### PR DESCRIPTION
## Summary
- remove direct `@nestjs/schematics` from `services/controls` devDependencies
- keep tooling behavior intact because `@nestjs/cli` still provides `@nestjs/schematics` transitively
- keep Tier 2 pruning scoped to one dependency for easy rollback and clearer validation

## Test plan
- [x] `npx -y npm@10.8.2 --workspace services/controls run build`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci` (fails with pre-existing baseline issues reproduced previously on `main`: `validator/lib/isLatLong` resolution and Jest `uuid` ESM parsing)
- [x] `npx -y npm@10.8.2 ls @nestjs/schematics --workspace services/controls --all` confirms transitive availability via `@nestjs/cli`