### PR TITLE
chore(deps): remove unused controls ts-loader dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22573,31 +22573,6 @@
         }
       }
     },
-    "node_modules/ts-loader": {
-      "version": "9.6.2",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.6.2.tgz",
-      "integrity": "sha512-R4iuczmtgxvtuI556s+hTZ6/7Ee03VCAk/l/M8LY1OAsUgB7YydsCxkgq9D9pKRaD7GJqUi2u8fp9zZP/ufjKA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "picomatch": "^4.0.0",
-        "source-map": "^0.7.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "loader-utils": "*",
-        "typescript": "*",
-        "webpack": "^4.0.0 || ^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "loader-utils": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/ts-node": {
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
@@ -24369,7 +24344,6 @@
         "prisma": "^5.22.0",
         "source-map-support": "^0.5.21",
         "ts-jest": "^29.4.9",
-        "ts-loader": "^9.6.2",
         "ts-node": "^10.9.2",
         "tsconfig-paths": "^4.2.0",
         "typescript": "^5.3.3"

--- a/services/controls/package.json
+++ b/services/controls/package.json
@@ -68,7 +68,6 @@
     "prisma": "^5.22.0",
     "source-map-support": "^0.5.21",
     "ts-jest": "^29.4.9",
-    "ts-loader": "^9.6.2",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.3.3"


### PR DESCRIPTION
## Summary
- remove direct `ts-loader` from `services/controls` devDependencies
- keep the Tier 2 dependency-prune sequence scoped to one package for easy rollback
- update `package-lock.json` to remove the direct `ts-loader` entry and keep dependency metadata consistent

## Test plan
- [x] `npx -y npm@10.8.2 --workspace services/controls run build`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci` (still fails with pre-existing baseline issues: `validator/lib/isLatLong` resolution and Jest `uuid` ESM parsing)
- [x] `rg "ts-loader" services/controls` returns no usage references