### PR TITLE
fix: resolve controls test runtime dependency failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17025,6 +17025,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/libphonenumber-js": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.8.tgz",
+      "integrity": "sha512-80xal1m93rADejw2pMp2MSzFhHCPLEspjHxnH2UtqI+DgAmElsbmLMiqk9niwH9NWAfjsRtaJI+qBrOEmRx9nQ==",
+      "license": "MIT"
+    },
     "node_modules/lie": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
@@ -23131,6 +23137,15 @@
         "node": ">=10.12.0"
       }
     },
+    "node_modules/validator": {
+      "version": "13.15.35",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.35.tgz",
+      "integrity": "sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -24324,12 +24339,14 @@
         "exceljs": "^4.4.0",
         "helmet": "^7.1.0",
         "js-yaml": "^4.2.0",
+        "libphonenumber-js": "^1.12.26",
         "nodemailer": "^9.0.1",
         "pdfkit": "^0.18.0",
         "prom-client": "^15.1.3",
         "reflect-metadata": "^0.1.14",
         "rxjs": "^7.8.1",
-        "uuid": "^14.0.1"
+        "uuid": "^14.0.1",
+        "validator": "^13.15.23"
       },
       "devDependencies": {
         "@nestjs/cli": "^11.0.19",

--- a/services/audit/src/fieldguide/fieldguide.service.ts
+++ b/services/audit/src/fieldguide/fieldguide.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger, BadRequestException, NotFoundException } from '@nestjs/common';
 import { safeFetch, SSRFProtectionError } from '@gigachad-grc/shared';
 import { PrismaService } from '../prisma/prisma.service';
-import { createHmac, timingSafeEqual } from 'crypto';
+import { createHmac, randomUUID, timingSafeEqual } from 'crypto';
 import { AuditStatus } from '@prisma/client';
 import {
   FieldGuideConnectDto,
@@ -16,7 +16,6 @@ import {
   LinkAuditDto,
   FieldGuideAudit,
 } from './dto/fieldguide.dto';
-import { v4 as uuidv4 } from 'uuid';
 
 @Injectable()
 export class FieldGuideService {
@@ -143,7 +142,7 @@ export class FieldGuideService {
       throw new BadRequestException('FieldGuide is not connected');
     }
 
-    const syncId = uuidv4();
+    const syncId = randomUUID();
     const startedAt = new Date();
     const direction = dto.direction || SyncDirection.BIDIRECTIONAL;
     const entityTypes = dto.entityTypes || Object.values(SyncEntityType);

--- a/services/controls/package.json
+++ b/services/controls/package.json
@@ -48,11 +48,13 @@
     "exceljs": "^4.4.0",
     "helmet": "^7.1.0",
     "js-yaml": "^4.2.0",
+    "libphonenumber-js": "^1.12.26",
     "nodemailer": "^9.0.1",
     "pdfkit": "^0.18.0",
     "prom-client": "^15.1.3",
     "reflect-metadata": "^0.1.14",
     "rxjs": "^7.8.1",
+    "validator": "^13.15.23",
     "uuid": "^14.0.1"
   },
   "devDependencies": {

--- a/services/controls/src/training/phishing/phishing.service.ts
+++ b/services/controls/src/training/phishing/phishing.service.ts
@@ -2,8 +2,7 @@ import { Injectable, Logger, BadRequestException, NotFoundException } from '@nes
 import { PrismaService } from '../../prisma/prisma.service';
 import { EmailService } from '../../email/email.service';
 import { Prisma } from '@prisma/client';
-import { v4 as uuidv4 } from 'uuid';
-import { createHmac, timingSafeEqual } from 'crypto';
+import { createHmac, randomUUID, timingSafeEqual } from 'crypto';
 import { maskEmail } from '@gigachad-grc/shared';
 import {
   CampaignStatus,
@@ -72,7 +71,7 @@ export class PhishingService {
     organizationId: string,
     dto: CreatePhishingTemplateDto
   ): Promise<PhishingTemplateDto> {
-    const id = uuidv4();
+    const id = randomUUID();
     const now = new Date();
 
     // Store in organization settings (or a dedicated table if you prefer)
@@ -175,7 +174,7 @@ export class PhishingService {
       throw new BadRequestException('Template not found');
     }
 
-    const id = uuidv4();
+    const id = randomUUID();
     const now = new Date();
 
     // Store campaign in organization settings

--- a/services/shared/src/utils/error-handler.ts
+++ b/services/shared/src/utils/error-handler.ts
@@ -1,5 +1,5 @@
 import { Logger, HttpException, InternalServerErrorException } from '@nestjs/common';
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'crypto';
 
 /**
  * Standard error response structure.
@@ -282,7 +282,7 @@ export async function retryAsync<T>(
  */
 export function createApiErrorResponse(error: unknown, correlationId?: string): ApiErrorResponse {
   const errorDetails = toErrorDetails(error);
-  const id = correlationId || uuidv4();
+  const id = correlationId || randomUUID();
 
   return {
     success: false,
@@ -333,7 +333,7 @@ export function CatchErrors(options: CatchErrorsOptions = {}): MethodDecorator {
     const methodName = String(propertyKey);
 
     descriptor.value = async function (...args: unknown[]) {
-      const correlationId = uuidv4();
+      const correlationId = randomUUID();
       const logger = (this as { logger?: Logger }).logger || new Logger(methodName);
       const context = options.context || methodName;
 

--- a/services/shared/src/utils/helpers.ts
+++ b/services/shared/src/utils/helpers.ts
@@ -1,10 +1,10 @@
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'crypto';
 
 /**
  * Generate a UUID
  */
 export function generateId(): string {
-  return uuidv4();
+  return randomUUID();
 }
 
 /**


### PR DESCRIPTION
## Summary
- switch backend UUID generation call sites from `uuid` imports to Node `crypto.randomUUID()` to avoid Jest/CJS parsing failures from `uuid` ESM exports
- add explicit `validator` and `libphonenumber-js` dependencies in `services/controls` so `class-validator` runtime subpath imports resolve consistently in tests
- regenerate `package-lock.json` so workspace dependency resolution matches CI installs

## Test plan
- [x] `npx -y npm@10.8.2 --workspace services/shared run build`
- [x] `npx -y npm@10.8.2 --workspace services/audit run build`
- [x] `npx -y npm@10.8.2 --workspace services/controls run build`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci -- --no-cache`