### PR TITLE
chore(deps): remove controls uuid direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24345,7 +24345,6 @@
         "prom-client": "^15.1.3",
         "reflect-metadata": "^0.1.14",
         "rxjs": "^7.8.1",
-        "uuid": "^14.0.1",
         "validator": "^13.15.23"
       },
       "devDependencies": {

--- a/services/controls/package.json
+++ b/services/controls/package.json
@@ -54,8 +54,7 @@
     "prom-client": "^15.1.3",
     "reflect-metadata": "^0.1.14",
     "rxjs": "^7.8.1",
-    "validator": "^13.15.23",
-    "uuid": "^14.0.1"
+    "validator": "^13.15.23"
   },
   "devDependencies": {
     "@nestjs/cli": "^11.0.19",
@@ -81,7 +80,7 @@
     "brace-expansion": ">=5.0.5",
     "lodash": ">=4.18.0",
     "multer": "^2.2.0",
-    "uuid": "$uuid",
+    "uuid": ">=11.1.1",
     "js-yaml": "^4.2.0"
   }
 }


### PR DESCRIPTION
## Summary
- remove the direct `uuid` dependency from `services/controls` now that service code no longer imports it
- replace the controls override `uuid: \"$uuid\"` with `uuid: \">=11.1.1\"` so transitive resolution remains pinned to a secure floor without relying on a direct dependency
- update `package-lock.json` to keep workspace manifests and lockfile in sync

## Test plan
- [x] `npx -y npm@10.8.2 install`
- [x] `npx -y npm@10.8.2 --workspace services/controls run build`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci -- --no-cache`