### PR TITLE
chore(deps): remove audit uuid direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24270,8 +24270,7 @@
         "class-validator": "^0.15.1",
         "helmet": "^7.2.0",
         "reflect-metadata": "^0.1.13",
-        "rxjs": "^7.8.1",
-        "uuid": "^14.0.1"
+        "rxjs": "^7.8.1"
       },
       "devDependencies": {
         "@nestjs/cli": "^11.0.19",

--- a/services/audit/package.json
+++ b/services/audit/package.json
@@ -34,8 +34,7 @@
     "class-validator": "^0.15.1",
     "helmet": "^7.2.0",
     "reflect-metadata": "^0.1.13",
-    "rxjs": "^7.8.1",
-    "uuid": "^14.0.1"
+    "rxjs": "^7.8.1"
   },
   "devDependencies": {
     "@nestjs/cli": "^11.0.19",
@@ -55,7 +54,7 @@
     "brace-expansion": ">=5.0.5",
     "lodash": ">=4.18.0",
     "multer": "^2.2.0",
-    "uuid": "$uuid",
+    "uuid": ">=11.1.1",
     "js-yaml": "^4.2.0"
   }
 }


### PR DESCRIPTION
## Summary
- remove the direct `uuid` dependency from `services/audit` now that audit service code no longer imports it
- replace the audit override `uuid: \"$uuid\"` with `uuid: \">=11.1.1\"` so transitive resolution remains pinned to a secure floor without requiring a direct pin
- update `package-lock.json` to keep workspace manifests and lockfile synchronized

## Test plan
- [x] `npx -y npm@10.8.2 install`
- [x] `npx -y npm@10.8.2 --workspace services/audit run build`
- [x] `npx -y npm@10.8.2 --workspace services/audit run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/audit run test:ci -- --no-cache`