### PR TITLE
chore(deps): remove shared uuid direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24645,7 +24645,6 @@
         "jwks-rsa": "^3.1.0",
         "pdfkit": "^0.18.0",
         "sanitize-html": "^2.17.2",
-        "uuid": "^14.0.1",
         "winston": "^3.11.0"
       },
       "devDependencies": {

--- a/services/shared/package.json
+++ b/services/shared/package.json
@@ -24,7 +24,6 @@
     "jwks-rsa": "^3.1.0",
     "pdfkit": "^0.18.0",
     "sanitize-html": "^2.17.2",
-    "uuid": "^14.0.1",
     "winston": "^3.11.0"
   },
   "devDependencies": {
@@ -55,7 +54,7 @@
     "picomatch": ">=2.3.2",
     "brace-expansion": ">=5.0.5",
     "lodash": ">=4.18.0",
-    "uuid": "$uuid",
+    "uuid": ">=11.1.1",
     "js-yaml": "^4.2.0"
   }
 }


### PR DESCRIPTION
## Summary
- remove the direct `uuid` dependency from `services/shared` now that shared utilities no longer import it
- replace the shared override `uuid: \"$uuid\"` with `uuid: \">=11.1.1\"` to keep a secure transitive floor without a direct pin
- update `package-lock.json` to keep workspace manifests and lockfile synchronized

## Test plan
- [x] `npx -y npm@10.8.2 install`
- [x] `npx -y npm@10.8.2 --workspace services/shared run build`
- [x] `npx -y npm@10.8.2 --workspace services/controls run build`
- [x] `npx -y npm@10.8.2 --workspace services/audit run build`
- [x] `npx -y npm@10.8.2 --workspace services/frameworks run build`
- [x] `npx -y npm@10.8.2 --workspace services/policies run build`
- [x] `npx -y npm@10.8.2 --workspace services/tprm run build`
- [x] `npx -y npm@10.8.2 --workspace services/trust run build`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci -- --no-cache`
- [x] `npx -y npm@10.8.2 --workspace services/audit run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/audit run test:ci -- --no-cache`