### PR TITLE
chore(deps): remove audit @types/uuid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24279,7 +24279,6 @@
         "@types/express": "^4.17.21",
         "@types/multer": "^2.2.0",
         "@types/node": "^20.19.39",
-        "@types/uuid": "^10.0.0",
         "prisma": "^5.22.0",
         "typescript": "^5.3.3"
       }

--- a/services/audit/package.json
+++ b/services/audit/package.json
@@ -43,7 +43,6 @@
     "@types/express": "^4.17.21",
     "@types/multer": "^2.2.0",
     "@types/node": "^20.19.39",
-    "@types/uuid": "^10.0.0",
     "prisma": "^5.22.0",
     "typescript": "^5.3.3"
   },


### PR DESCRIPTION
## Summary
- remove `@types/uuid` from `services/audit` devDependencies now that the audit service has no remaining uuid imports
- synchronize `package-lock.json` with the workspace manifest change

## Test plan
- [x] `npx -y npm@10.8.2 install`
- [x] `npx -y npm@10.8.2 --workspace services/audit run build`
- [x] `npx -y npm@10.8.2 --workspace services/audit run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/audit run test:ci -- --no-cache`