### PR TITLE
chore(deps): remove shared @types/uuid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9535,13 +9535,6 @@
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
     },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
@@ -24654,7 +24647,6 @@
         "@types/node": "^20.19.39",
         "@types/pdfkit": "^0.17.5",
         "@types/sanitize-html": "^2.16.1",
-        "@types/uuid": "^10.0.0",
         "prisma": "^5.22.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.2",

--- a/services/shared/package.json
+++ b/services/shared/package.json
@@ -34,7 +34,6 @@
     "@types/node": "^20.19.39",
     "@types/pdfkit": "^0.17.5",
     "@types/sanitize-html": "^2.16.1",
-    "@types/uuid": "^10.0.0",
     "prisma": "^5.22.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",


### PR DESCRIPTION
## Summary
- remove `@types/uuid` from `services/shared` devDependencies now that shared has no remaining uuid imports
- sync `package-lock.json` to reflect removal of the workspace dev dependency and the now-unused hoisted types package

## Test plan
- [x] `npx -y npm@10.8.2 install`
- [x] `npx -y npm@10.8.2 --workspace services/shared run build`
- [x] `npx -y npm@10.8.2 --workspace services/controls run build`
- [x] `npx -y npm@10.8.2 --workspace services/audit run build`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci -- --no-cache`
- [x] `npx -y npm@10.8.2 --workspace services/audit run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/audit run test:ci -- --no-cache`