### PR TITLE
chore(deps): remove shared file-type dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24631,7 +24631,6 @@
         "@nestjs/throttler": "^6.5.0",
         "@prisma/client": "^5.22.0",
         "class-transformer": "^0.5.1",
-        "file-type": "^21.3.4",
         "ioredis": "^5.10.1",
         "jsonwebtoken": "^9.0.2",
         "jwks-rsa": "^3.1.0",

--- a/services/shared/package.json
+++ b/services/shared/package.json
@@ -18,7 +18,6 @@
     "@nestjs/throttler": "^6.5.0",
     "@prisma/client": "^5.22.0",
     "class-transformer": "^0.5.1",
-    "file-type": "^21.3.4",
     "ioredis": "^5.10.1",
     "jsonwebtoken": "^9.0.2",
     "jwks-rsa": "^3.1.0",


### PR DESCRIPTION
## Summary
- remove `file-type` from `services/shared` dependencies because there are no `file-type` imports in the monorepo
- update `package-lock.json` to keep workspace lock metadata aligned

## Test plan
- [x] `npx -y npm@10.8.2 install`
- [x] `npx -y npm@10.8.2 --workspace services/shared run build`
- [x] `npx -y npm@10.8.2 --workspace services/controls run build`
- [x] `npx -y npm@10.8.2 --workspace services/audit run build`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci -- --no-cache`
- [x] `npx -y npm@10.8.2 --workspace services/audit run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/audit run test:ci -- --no-cache`