### PR TITLE
chore(deps): remove shared prisma dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24646,7 +24646,6 @@
         "@types/node": "^20.19.39",
         "@types/pdfkit": "^0.17.5",
         "@types/sanitize-html": "^2.16.1",
-        "prisma": "^5.22.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.2",
         "typescript": "^5.3.2"

--- a/services/shared/package.json
+++ b/services/shared/package.json
@@ -33,7 +33,6 @@
     "@types/node": "^20.19.39",
     "@types/pdfkit": "^0.17.5",
     "@types/sanitize-html": "^2.16.1",
-    "prisma": "^5.22.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
     "typescript": "^5.3.2"


### PR DESCRIPTION
## Summary
- remove `prisma` from `services/shared` devDependencies because shared has no local Prisma imports or Prisma scripts
- update `package-lock.json` to keep workspace metadata synchronized

## Test plan
- [x] `npx -y npm@10.8.2 install`
- [x] `npx -y npm@10.8.2 --workspace services/shared run build`
- [x] `npx -y npm@10.8.2 --workspace services/controls run build`
- [x] `npx -y npm@10.8.2 --workspace services/audit run build`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci -- --no-cache`
- [x] `npx -y npm@10.8.2 --workspace services/audit run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/audit run test:ci -- --no-cache`