### PR TITLE
chore(deps): remove shared @prisma/client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24629,7 +24629,6 @@
         "@azure/storage-blob": "^12.17.0",
         "@infisical/sdk": "^4.0.6",
         "@nestjs/throttler": "^6.5.0",
-        "@prisma/client": "^5.22.0",
         "class-transformer": "^0.5.1",
         "ioredis": "^5.10.1",
         "jsonwebtoken": "^9.0.2",

--- a/services/shared/package.json
+++ b/services/shared/package.json
@@ -16,7 +16,6 @@
     "@azure/storage-blob": "^12.17.0",
     "@infisical/sdk": "^4.0.6",
     "@nestjs/throttler": "^6.5.0",
-    "@prisma/client": "^5.22.0",
     "class-transformer": "^0.5.1",
     "ioredis": "^5.10.1",
     "jsonwebtoken": "^9.0.2",


### PR DESCRIPTION
## Summary
- remove `@prisma/client` from `services/shared` dependencies because shared has no direct Prisma imports
- update `package-lock.json` so workspace dependency metadata remains synchronized

## Test plan
- [x] `npx -y npm@10.8.2 install`
- [x] `npx -y npm@10.8.2 --workspace services/shared run build`
- [x] `npx -y npm@10.8.2 --workspace services/controls run build`
- [x] `npx -y npm@10.8.2 --workspace services/audit run build`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci -- --no-cache`
- [x] `npx -y npm@10.8.2 --workspace services/audit run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/audit run test:ci -- --no-cache`