### PR TITLE
chore(deps): remove unused audit @nestjs/axios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6317,17 +6317,6 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
-    "node_modules/@nestjs/axios": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-4.0.1.tgz",
-      "integrity": "sha512-68pFJgu+/AZbWkGu65Z3r55bTsCPlgyKaV4BSG8yUAD72q1PPuyVRgUwFv6BxdnibTUHlyxm06FmYWNC+bjN7A==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@nestjs/common": "^10.0.0 || ^11.0.0",
-        "axios": "^1.3.1",
-        "rxjs": "^7.0.0"
-      }
-    },
     "node_modules/@nestjs/cli": {
       "version": "11.0.23",
       "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-11.0.23.tgz",
@@ -24249,7 +24238,6 @@
       "hasInstallScript": true,
       "dependencies": {
         "@gigachad-grc/shared": "file:../shared",
-        "@nestjs/axios": "^4.0.0",
         "@nestjs/common": "^11.1.19",
         "@nestjs/config": "^4.0.4",
         "@nestjs/core": "^11.1.19",

--- a/services/audit/package.json
+++ b/services/audit/package.json
@@ -20,7 +20,6 @@
   },
   "dependencies": {
     "@gigachad-grc/shared": "file:../shared",
-    "@nestjs/axios": "^4.0.0",
     "@nestjs/common": "^11.1.19",
     "@nestjs/config": "^4.0.4",
     "@nestjs/core": "^11.1.19",


### PR DESCRIPTION
## Summary
- remove `@nestjs/axios` from `services/audit` dependencies because there are no imports of `@nestjs/axios`, `HttpModule`, or `HttpService` in that workspace
- update `package-lock.json` to keep workspace dependency metadata in sync

## Test plan
- [x] `npx -y npm@10.8.2 install`
- [x] `npx -y npm@10.8.2 --workspace services/shared run build`
- [x] `npx -y npm@10.8.2 --workspace services/controls run build`
- [x] `npx -y npm@10.8.2 --workspace services/audit run build`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci -- --no-cache`
- [x] `npx -y npm@10.8.2 --workspace services/audit run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/audit run test:ci -- --no-cache`