### PR TITLE
chore(deps): remove unused audit schematics dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24255,7 +24255,6 @@
       },
       "devDependencies": {
         "@nestjs/cli": "^11.0.19",
-        "@nestjs/schematics": "^11.0.10",
         "@types/bcrypt": "^5.0.2",
         "@types/express": "^4.17.21",
         "@types/multer": "^2.2.0",

--- a/services/audit/package.json
+++ b/services/audit/package.json
@@ -37,7 +37,6 @@
   },
   "devDependencies": {
     "@nestjs/cli": "^11.0.19",
-    "@nestjs/schematics": "^11.0.10",
     "@types/bcrypt": "^5.0.2",
     "@types/express": "^4.17.21",
     "@types/multer": "^2.2.0",


### PR DESCRIPTION
## Summary
- remove direct `@nestjs/schematics` from `services/audit` devDependencies
- keep Nest generation behavior intact via transitive `@nestjs/schematics` provided by `@nestjs/cli`
- sync `package-lock.json` workspace metadata

## Test plan
- [x] `npx -y npm@10.8.2 install`
- [x] `npx -y npm@10.8.2 --workspace services/shared run build`
- [x] `npx -y npm@10.8.2 --workspace services/controls run build`
- [x] `npx -y npm@10.8.2 --workspace services/audit run build`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci -- --no-cache`
- [x] `npx -y npm@10.8.2 --workspace services/audit run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/audit run test:ci -- --no-cache`
- [x] `npx -y npm@10.8.2 ls @nestjs/schematics --workspace services/audit`