### PR TITLE
chore(deps): remove unused audit @types/multer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24257,7 +24257,6 @@
         "@nestjs/cli": "^11.0.19",
         "@types/bcrypt": "^5.0.2",
         "@types/express": "^4.17.21",
-        "@types/multer": "^2.2.0",
         "@types/node": "^20.19.39",
         "prisma": "^5.22.0",
         "typescript": "^5.3.3"

--- a/services/audit/package.json
+++ b/services/audit/package.json
@@ -39,7 +39,6 @@
     "@nestjs/cli": "^11.0.19",
     "@types/bcrypt": "^5.0.2",
     "@types/express": "^4.17.21",
-    "@types/multer": "^2.2.0",
     "@types/node": "^20.19.39",
     "prisma": "^5.22.0",
     "typescript": "^5.3.3"


### PR DESCRIPTION
## Summary
- remove unused `@types/multer` from `services/audit` devDependencies
- keep lockfile metadata in sync after dependency removal

## Test plan
- [x] `npx -y npm@10.8.2 install`
- [x] `npx -y npm@10.8.2 --workspace services/shared run build`
- [x] `npx -y npm@10.8.2 --workspace services/controls run build`
- [x] `npx -y npm@10.8.2 --workspace services/audit run build`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci -- --no-cache`
- [x] `npx -y npm@10.8.2 --workspace services/audit run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/audit run test:ci -- --no-cache`