### PR TITLE
chore(deps): remove unused controls source-map-support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24335,7 +24335,6 @@
         "@types/pdfkit": "^0.17.5",
         "jest": "^29.7.0",
         "prisma": "^5.22.0",
-        "source-map-support": "^0.5.21",
         "ts-jest": "^29.4.9",
         "ts-node": "^10.9.2",
         "tsconfig-paths": "^4.2.0",

--- a/services/controls/package.json
+++ b/services/controls/package.json
@@ -67,7 +67,6 @@
     "@types/pdfkit": "^0.17.5",
     "jest": "^29.7.0",
     "prisma": "^5.22.0",
-    "source-map-support": "^0.5.21",
     "ts-jest": "^29.4.9",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",


### PR DESCRIPTION
## Summary
- remove unused `source-map-support` from `services/controls` devDependencies
- keep workspace lockfile metadata synchronized

## Test plan
- [x] `npx -y npm@10.8.2 install`
- [x] `npx -y npm@10.8.2 --workspace services/shared run build`
- [x] `npx -y npm@10.8.2 --workspace services/controls run build`
- [x] `npx -y npm@10.8.2 --workspace services/audit run build`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci -- --no-cache`
- [x] `npx -y npm@10.8.2 --workspace services/audit run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/audit run test:ci -- --no-cache`