### PR TITLE
chore(deps): remove unused controls tsconfig-paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24336,7 +24336,6 @@
         "jest": "^29.7.0",
         "prisma": "^5.22.0",
         "ts-jest": "^29.4.9",
-        "tsconfig-paths": "^4.2.0",
         "typescript": "^5.3.3"
       }
     },

--- a/services/controls/package.json
+++ b/services/controls/package.json
@@ -68,7 +68,6 @@
     "jest": "^29.7.0",
     "prisma": "^5.22.0",
     "ts-jest": "^29.4.9",
-    "tsconfig-paths": "^4.2.0",
     "typescript": "^5.3.3"
   },
   "overrides": {


### PR DESCRIPTION
## Summary
- remove unused `tsconfig-paths` from `services/controls` devDependencies
- keep workspace lockfile metadata synchronized

## Test plan
- [x] `npx -y npm@10.8.2 install`
- [x] `npx -y npm@10.8.2 --workspace services/shared run build`
- [x] `npx -y npm@10.8.2 --workspace services/controls run build`
- [x] `npx -y npm@10.8.2 --workspace services/audit run build`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci -- --no-cache`
- [x] `npx -y npm@10.8.2 --workspace services/audit run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/audit run test:ci -- --no-cache`