### PR TITLE
chore(deps): remove unused controls @types/multer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24329,7 +24329,6 @@
         "@nestjs/testing": "^11.1.19",
         "@types/compression": "^1.7.5",
         "@types/express": "^4.17.21",
-        "@types/multer": "^2.2.0",
         "@types/node": "^20.19.39",
         "@types/pdfkit": "^0.17.5",
         "jest": "^29.7.0",

--- a/services/controls/package.json
+++ b/services/controls/package.json
@@ -61,7 +61,6 @@
     "@nestjs/testing": "^11.1.19",
     "@types/compression": "^1.7.5",
     "@types/express": "^4.17.21",
-    "@types/multer": "^2.2.0",
     "@types/node": "^20.19.39",
     "@types/pdfkit": "^0.17.5",
     "jest": "^29.7.0",


### PR DESCRIPTION
## Summary
- remove unused `@types/multer` from `services/controls` devDependencies
- keep workspace lockfile metadata synchronized

## Test plan
- [x] `npx -y npm@10.8.2 install`
- [x] `npx -y npm@10.8.2 --workspace services/shared run build`
- [x] `npx -y npm@10.8.2 --workspace services/controls run build`
- [x] `npx -y npm@10.8.2 --workspace services/audit run build`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci -- --no-cache`
- [x] `npx -y npm@10.8.2 --workspace services/audit run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/audit run test:ci -- --no-cache`