### PR TITLE
chore(deps): remove unused trust schematics dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24730,7 +24730,6 @@
       },
       "devDependencies": {
         "@nestjs/cli": "^11.0.19",
-        "@nestjs/schematics": "^11.0.10",
         "@types/express": "^4.17.21",
         "@types/node": "^20.19.39",
         "prisma": "^5.22.0",

--- a/services/trust/package.json
+++ b/services/trust/package.json
@@ -37,7 +37,6 @@
   },
   "devDependencies": {
     "@nestjs/cli": "^11.0.19",
-    "@nestjs/schematics": "^11.0.10",
     "@types/express": "^4.17.21",
     "@types/node": "^20.19.39",
     "prisma": "^5.22.0",


### PR DESCRIPTION
## Summary
- remove unused `@nestjs/schematics` from `services/trust` devDependencies
- keep workspace lockfile metadata synchronized

## Test plan
- [x] `npx -y npm@10.8.2 install`
- [x] `npx -y npm@10.8.2 --workspace services/shared run build`
- [x] `npx -y npm@10.8.2 --workspace services/trust run build`
- [x] `npx -y npm@10.8.2 --workspace services/controls run build`
- [x] `npx -y npm@10.8.2 --workspace services/audit run build`
- [x] `npx -y npm@10.8.2 --workspace services/trust run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/trust run test:ci -- --no-cache`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci -- --no-cache`
- [x] `npx -y npm@10.8.2 --workspace services/audit run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/audit run test:ci -- --no-cache`