### PR TITLE
chore(deps): remove unused trust @types/node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24731,7 +24731,6 @@
       "devDependencies": {
         "@nestjs/cli": "^11.0.19",
         "@types/express": "^4.17.21",
-        "@types/node": "^20.19.39",
         "prisma": "^5.22.0",
         "typescript": "^5.3.3"
       }

--- a/services/trust/package.json
+++ b/services/trust/package.json
@@ -38,7 +38,6 @@
   "devDependencies": {
     "@nestjs/cli": "^11.0.19",
     "@types/express": "^4.17.21",
-    "@types/node": "^20.19.39",
     "prisma": "^5.22.0",
     "typescript": "^5.3.3"
   },


### PR DESCRIPTION
## Summary
- remove unused `@types/node` from `services/trust` devDependencies
- keep workspace lockfile metadata synchronized

## Test plan
- [x] `npx -y npm@10.8.2 install`
- [x] `npx -y npm@10.8.2 --workspace services/shared run build`
- [x] `npx -y npm@10.8.2 --workspace services/trust run build`
- [x] `npx -y npm@10.8.2 --workspace services/controls run build`
- [x] `npx -y npm@10.8.2 --workspace services/audit run build`
- [x] `npx -y npm@10.8.2 --workspace services/trust run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/trust run test:ci -- --no-cache`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci -- --no-cache`
- [x] `npx -y npm@10.8.2 --workspace services/audit run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/audit run test:ci -- --no-cache`