### PR TITLE
chore(deps): remove unused frameworks schematics dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24514,7 +24514,6 @@
       },
       "devDependencies": {
         "@nestjs/cli": "^11.0.19",
-        "@nestjs/schematics": "^11.0.10",
         "@nestjs/testing": "^11.1.19",
         "@types/express": "^4.17.21",
         "@types/jest": "^29.5.11",

--- a/services/frameworks/package.json
+++ b/services/frameworks/package.json
@@ -35,7 +35,6 @@
   },
   "devDependencies": {
     "@nestjs/cli": "^11.0.19",
-    "@nestjs/schematics": "^11.0.10",
     "@nestjs/testing": "^11.1.19",
     "@types/express": "^4.17.21",
     "@types/jest": "^29.5.11",


### PR DESCRIPTION
## Summary
- remove `@nestjs/schematics` from `services/frameworks` `devDependencies`
- keep `nest-cli.json` unchanged (`collection: @nestjs/schematics`) because `@nestjs/cli` already provides the schematics package transitively
- refresh `package-lock.json` to keep the workspace lockfile in sync

## Test plan
- [x] `npx -y npm@10.8.2 --workspace services/shared run build`
- [x] `npx -y npm@10.8.2 --workspace services/frameworks run build`
- [x] `npx -y npm@10.8.2 --workspace services/controls run build`
- [x] `npx -y npm@10.8.2 --workspace services/audit run build`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci -- --no-cache`
- [x] `npx -y npm@10.8.2 --workspace services/audit run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/audit run test:ci -- --no-cache`
- [ ] `npx -y npm@10.8.2 --workspace services/frameworks run test -- --runInBand` *(currently fails on existing shared ESM/CJS Jest boundary: `SyntaxError: Unexpected token 'export'` in `services/shared/dist/*`)*