### PR TITLE
chore(deps): remove unused policies @types/node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24570,7 +24570,6 @@
         "@nestjs/cli": "^11.0.19",
         "@types/express": "^4.17.21",
         "@types/multer": "^2.2.0",
-        "@types/node": "^20.19.39",
         "prisma": "^5.22.0",
         "typescript": "^5.3.3"
       }

--- a/services/policies/package.json
+++ b/services/policies/package.json
@@ -36,7 +36,6 @@
     "@nestjs/cli": "^11.0.19",
     "@types/express": "^4.17.21",
     "@types/multer": "^2.2.0",
-    "@types/node": "^20.19.39",
     "prisma": "^5.22.0",
     "typescript": "^5.3.3"
   },


### PR DESCRIPTION
## Summary
- remove `@types/node` from `services/policies` `devDependencies`
- rely on existing transitive node type availability from current workspace dependencies
- refresh `package-lock.json` to keep lockfile state aligned

## Test plan
- [x] `npx -y npm@10.8.2 --workspace services/shared run build`
- [x] `npx -y npm@10.8.2 --workspace services/policies run build`
- [x] `npx -y npm@10.8.2 --workspace services/controls run build`
- [x] `npx -y npm@10.8.2 --workspace services/audit run build`
- [x] `npx -y npm@10.8.2 --workspace services/policies run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/policies run test:ci -- --no-cache`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci -- --no-cache`
- [x] `npx -y npm@10.8.2 --workspace services/audit run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/audit run test:ci -- --no-cache`