### PR TITLE
chore(deps): remove unused frameworks multer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24508,7 +24508,6 @@
         "csv-parse": "^5.5.3",
         "exceljs": "^4.4.0",
         "helmet": "^7.2.0",
-        "multer": "^2.2.0",
         "reflect-metadata": "^0.1.14",
         "rxjs": "^7.8.1"
       },

--- a/services/frameworks/package.json
+++ b/services/frameworks/package.json
@@ -29,7 +29,6 @@
     "csv-parse": "^5.5.3",
     "exceljs": "^4.4.0",
     "helmet": "^7.2.0",
-    "multer": "^2.2.0",
     "reflect-metadata": "^0.1.14",
     "rxjs": "^7.8.1"
   },


### PR DESCRIPTION
## Summary
- remove direct `multer` from `services/frameworks` `dependencies`
- rely on transitive runtime provision from `@nestjs/platform-express`
- update `package-lock.json` to keep lockfile aligned

## Test plan
- [x] `npx -y npm@10.8.2 --workspace services/shared run build`
- [x] `npx -y npm@10.8.2 --workspace services/frameworks run build`
- [x] `npx -y npm@10.8.2 --workspace services/controls run build`
- [x] `npx -y npm@10.8.2 --workspace services/audit run build`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/controls run test:ci -- --no-cache`
- [x] `npx -y npm@10.8.2 --workspace services/audit run test:ci`
- [x] `npx -y npm@10.8.2 --workspace services/audit run test:ci -- --no-cache`
- [ ] `npx -y npm@10.8.2 --workspace services/frameworks run test -- --runInBand` *(existing unrelated Jest ESM/CJS parsing failure around `exceljs`/`uuid` in frameworks tests)*