### PR TITLE
fix(database): make fresh bootstrap deterministic

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -318,10 +318,12 @@ jobs:
             -H 'x-org-id: 8924f0c1-7bb1-4be8-84ee-ad8725c712bf'
 
       - name: Install Playwright test runner
-        run: npm install --no-save @playwright/test
+        run: npm install --no-save @playwright/test@1.62.1
 
-      - name: Install Playwright + Chromium
-        run: npx playwright install --with-deps chromium
+      - name: Install Playwright Chromium
+        # GitHub's Ubuntu image already includes Chromium's system libraries.
+        # Avoid apt font downloads, which can exhaust the E2E job timeout.
+        run: npx playwright install chromium
 
       - name: Run Playwright tenant + RBAC gate suite
         # Keep the required gate deterministic while UI reconciliation is in
@@ -461,8 +463,14 @@ jobs:
             -H 'x-org-id: 8924f0c1-7bb1-4be8-84ee-ad8725c712bf' \
             --max-time 120 || echo "Seed call returned non-zero (continuing)"
 
+      - name: Install Playwright test runner
+        run: npm install --no-save @playwright/test@1.62.1
+        working-directory: frontend
+
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+        # GitHub's Ubuntu image already includes Chromium's system libraries.
+        # Avoid apt font downloads, which can exhaust the E2E job timeout.
+        run: npx playwright install chromium
         working-directory: frontend
 
       - name: Run accessibility (axe-core) scans (report-only)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -83,7 +83,11 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - postgres_backups:/backups
-      - ./database/init:/docker-entrypoint-initdb.d:ro
+      # Bootstrap only supporting databases/extensions. The controls
+      # entrypoint applies the canonical Prisma application schema.
+      - ./database/init/00-create-keycloak-db.sh:/docker-entrypoint-initdb.d/00-create-keycloak-db.sh:ro
+      - ./database/init/00b-create-infisical-db.sh:/docker-entrypoint-initdb.d/00b-create-infisical-db.sh:ro
+      - ./database/init/01-init.sql:/docker-entrypoint-initdb.d/01-init.sql:ro
     networks:
       - grc-network
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,11 @@ services:
       - '127.0.0.1:5433:5432' # Using 5433 externally to avoid conflicts
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      - ./database/init:/docker-entrypoint-initdb.d
+      # Only bootstrap prerequisites here. Application tables are created by
+      # Prisma in the controls entrypoint after PostgreSQL becomes healthy.
+      - ./database/init/00-create-keycloak-db.sh:/docker-entrypoint-initdb.d/00-create-keycloak-db.sh:ro
+      - ./database/init/00b-create-infisical-db.sh:/docker-entrypoint-initdb.d/00b-create-infisical-db.sh:ro
+      - ./database/init/01-init.sql:/docker-entrypoint-initdb.d/01-init.sql:ro
     networks:
       - grc-network
     restart: unless-stopped
@@ -81,12 +85,7 @@ services:
           memory: 256M
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER:-grc} -d ${POSTGRES_DB:-gigachad_grc}']
-      # First boot runs every script under database/init/ (creates keycloak + infisical DBs,
-      # 26+ SQL files for soft-delete, BCDR, enums, indexes, etc.). On a slow / contended CI
-      # runner this can easily push past 30s. We've seen `docker compose up -d` exit non-zero
-      # with "dependency failed to start: grc-postgres is unhealthy" on PRs #320 and #321
-      # despite the previous 30s budget. Bumped headroom + retry total so the dependency wait
-      # has 60s of init grace + 80s of polling = ~140s total before compose gives up.
+      # Allow first-boot database creation to finish before dependent services start.
       start_period: 60s
       interval: 10s
       timeout: 5s


### PR DESCRIPTION
## Summary
- mount only the Keycloak, Infisical, extension, and schema prerequisite scripts into PostgreSQL first-boot initialization
- leave application table creation to the canonical Prisma schema in the controls entrypoint
- prevent legacy post-schema SQL such as `02-soft-delete-migration.sql` from running before its target tables exist

## Root cause
Fresh E2E volumes restart PostgreSQL because `02-soft-delete-migration.sql` executes before Prisma creates the `controls` table. Health checks can briefly succeed against PostgreSQL's temporary init server, creating a race that made the failure intermittent.

## Test plan
- [x] development Compose configuration renders successfully
- [x] production Compose configuration renders successfully
- [x] Compose files pass Prettier, lint, and whitespace checks
- [ ] GitHub Actions tenant/RBAC E2E starts from a fresh volume
- [ ] GitHub Actions quality E2E starts from a fresh volume